### PR TITLE
[Fix] #8 카드 도메인 패키지 구조를 domain.card로 통일

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -1,4 +1,4 @@
-package com.pokade.card.controller;
+package com.pokade.domain.card.controller;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.pokade.card.dto.CardResponse;
-import com.pokade.card.service.CardService;
+import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.service.CardService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -1,8 +1,8 @@
-package com.pokade.card.dto;
+package com.pokade.domain.card.dto;
 
 import java.util.List;
 
-import com.pokade.card.entity.Card;
+import com.pokade.domain.card.entity.Card;
 
 public record CardResponse(
         Long id,

--- a/Pokade/src/main/java/com/pokade/domain/card/entity/Card.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/entity/Card.java
@@ -1,4 +1,4 @@
-package com.pokade.card.entity;
+package com.pokade.domain.card.entity;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/Pokade/src/main/java/com/pokade/domain/card/entity/CardVariant.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/entity/CardVariant.java
@@ -1,4 +1,4 @@
-package com.pokade.card.entity;
+package com.pokade.domain.card.entity;
 
 import java.time.LocalDateTime;
 

--- a/Pokade/src/main/java/com/pokade/domain/card/entity/Expansion.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/entity/Expansion.java
@@ -1,4 +1,4 @@
-package com.pokade.card.entity;
+package com.pokade.domain.card.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -1,4 +1,4 @@
-package com.pokade.card.repository;
+package com.pokade.domain.card.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.pokade.card.entity.Card;
+import com.pokade.domain.card.entity.Card;
 
 public interface CardRepository extends JpaRepository<Card, Long> {
 

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -1,12 +1,12 @@
-package com.pokade.card.service;
+package com.pokade.domain.card.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.pokade.card.dto.CardResponse;
-import com.pokade.card.repository.CardRepository;
+import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.repository.CardRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -1,4 +1,4 @@
-package com.pokade.card.controller;
+package com.pokade.domain.card.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,8 +19,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
-import com.pokade.card.dto.CardResponse;
-import com.pokade.card.service.CardService;
+import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.service.CardService;
 
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.pokade.card.repository;
+package com.pokade.domain.card.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,8 +13,8 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
-import com.pokade.card.entity.Card;
-import com.pokade.card.entity.Expansion;
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.Expansion;
 import com.pokade.support.AbstractIntegrationTest;
 
 import jakarta.persistence.EntityManager;

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -1,4 +1,4 @@
-package com.pokade.card.service;
+package com.pokade.domain.card.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -16,9 +16,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import com.pokade.card.dto.CardResponse;
-import com.pokade.card.entity.Card;
-import com.pokade.card.repository.CardRepository;
+import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 
 @ExtendWith(MockitoExtension.class)
 class CardServiceTest {


### PR DESCRIPTION
## 📌 관련 이슈
- #8 (카드 검색 API, 이미 머지된 PR #14의 후속 수정)

## ✨ 작업 내용
- 카드 도메인 패키지를 `com.pokade.card.*` → `com.pokade.domain.card.*`로 이동
  - develop에 먼저 병합된 매물/거래 도메인(`com.pokade.domain.{listing,trade}`)과 최상위 패키지 구조를 맞추기 위함
- 이동 과정에서 놓친 부분 수정:
  - main 7개 파일(Card, CardVariant, Expansion, CardRepository, CardService, CardController, CardResponse)이 폴더는 옮겨졌으나 `package` 선언이 안 바뀌어있던 것 수정
  - test 3개 파일(CardControllerTest, CardRepositoryTest, CardServiceTest)은 폴더 이동조차 안 돼있던 것을 `domain.card`로 이동 + package 선언 수정

## 📸 스크린샷 / 테스트 결과
- Docker(Postgres/Redis) 기동 상태에서 `./gradlew build` 전체 통과
- 카드 도메인 테스트 9개 전부 통과 (Controller 2, Repository 6, Service 1)

## 🔍 리뷰 포인트
- 기능 변경은 없고 순수 패키지 구조 정리입니다(API 동작 동일)
- **패키지 구조 자체(레이어별 하위분리 vs 플랫)는 여전히 팀 미확정**입니다 — 이번 건 최상위(`domain.{도메인}`)만 매물/거래 도메인과 맞춘 것이고, 그 안의 `entity/repository/service/controller` 분리 방식을 팀 전체가 따를지는 별도 논의 필요합니다(AGENTS.md 5.2절 관련)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?