### PR TITLE
[Feature] #13 매물 등록 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/Listing.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/Listing.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.listing;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,6 +8,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -18,6 +20,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "listings")
@@ -60,6 +64,9 @@ public class Listing {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @OneToMany(mappedBy = "listing", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<ListingImage> images = new ArrayList<>();
+
     @Builder
     public Listing(Long cardId, Long sellerId, Long variantId, Integer price, ListingGrade grade) {
         this.cardId = cardId;
@@ -69,6 +76,14 @@ public class Listing {
         this.grade = grade;
         this.status = ListingStatus.ACTIVE;
         this.staleNoticeSent = false;
+    }
+
+    public void addImage(String imageUrl, int sortOrder) {
+        images.add(ListingImage.builder()
+                .listing(this)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build());
     }
 
     public void changePrice(Integer newPrice) {

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -1,0 +1,31 @@
+package com.pokade.domain.listing;
+
+import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.dto.ListingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/listings")
+@RequiredArgsConstructor
+public class ListingController {
+
+    private final ListingService listingService;
+
+    @PostMapping
+    public ResponseEntity<ListingResponse> createListing(
+            // TODO: 인증 파트 완성되면 SecurityContext에서 sellerId 추출하는 방식으로 교체
+            @RequestHeader("X-USER-ID") Long sellerId,
+            @Valid @RequestBody ListingCreateRequest request
+    ) {
+        ListingResponse response = listingService.createListing(sellerId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
@@ -11,4 +11,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
     List<Listing> findBySellerId(Long sellerId);
 
     List<Listing> findBySellerIdAndStatus(Long sellerId, ListingStatus status);
+
+    boolean existsBySellerIdAndCardIdAndVariantIdAndStatus(
+            Long sellerId, Long cardId, Long variantId, ListingStatus status);
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -1,0 +1,49 @@
+package com.pokade.domain.listing;
+
+import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ListingService {
+
+    private final ListingRepository listingRepository;
+
+    @Transactional
+    public ListingResponse createListing(Long sellerId, ListingCreateRequest request) {
+        validateNotDuplicate(sellerId, request.cardId(), request.variantId());
+
+        Listing listing = Listing.builder()
+                .cardId(request.cardId())
+                .sellerId(sellerId)
+                .variantId(request.variantId())
+                .price(request.price())
+                .grade(request.grade())
+                .build();
+
+        List<String> imageUrls = request.imageUrls();
+        for (int i = 0; i < imageUrls.size(); i++) {
+            listing.addImage(imageUrls.get(i), i);
+        }
+
+        Listing saved = listingRepository.save(listing);
+        return ListingResponse.of(saved, imageUrls);
+    }
+
+    private void validateNotDuplicate(Long sellerId, Long cardId, Long variantId) {
+        // TODO: "중복 등록" 기준 팀 확정 필요 (현재는 동일 판매자가 같은 카드/variant에 ACTIVE 매물을 이미 가진 경우로 간주)
+        boolean exists = listingRepository.existsBySellerIdAndCardIdAndVariantIdAndStatus(
+                sellerId, cardId, variantId, ListingStatus.ACTIVE);
+        if (exists) {
+            throw new BusinessException(ErrorCode.DUPLICATE_LISTING);
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingCreateRequest.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.listing.dto;
+
+import com.pokade.domain.listing.ListingGrade;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.List;
+
+public record ListingCreateRequest(
+        @NotNull(message = "cardId는 필수입니다.")
+        Long cardId,
+
+        Long variantId,
+
+        @NotNull(message = "price는 필수입니다.")
+        @Positive(message = "price는 0보다 커야 합니다.")
+        Integer price,
+
+        ListingGrade grade,
+
+        @NotEmpty(message = "사진은 최소 1장 이상 등록해야 합니다.")
+        List<String> imageUrls
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingResponse.java
@@ -1,0 +1,35 @@
+package com.pokade.domain.listing.dto;
+
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.listing.ListingStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ListingResponse(
+        Long id,
+        Long cardId,
+        Long sellerId,
+        Long variantId,
+        Integer price,
+        ListingGrade grade,
+        ListingStatus status,
+        List<String> imageUrls,
+        LocalDateTime createdAt
+) {
+
+    public static ListingResponse of(Listing listing, List<String> imageUrls) {
+        return new ListingResponse(
+                listing.getId(),
+                listing.getCardId(),
+                listing.getSellerId(),
+                listing.getVariantId(),
+                listing.getPrice(),
+                listing.getGrade(),
+                listing.getStatus(),
+                imageUrls,
+                listing.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -1,0 +1,85 @@
+package com.pokade.domain.listing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ListingController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ListingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private ListingService listingService;
+
+    @Test
+    void 매물_등록에_성공하면_201과_등록된_매물을_반환한다() throws Exception {
+        ListingCreateRequest request = new ListingCreateRequest(
+                1L, null, 10000, ListingGrade.A, List.of("https://example.com/a.png"));
+        ListingResponse response = new ListingResponse(
+                1L, 1L, 100L, null, 10000, ListingGrade.A, ListingStatus.ACTIVE,
+                List.of("https://example.com/a.png"), LocalDateTime.now());
+
+        given(listingService.createListing(anyLong(), any(ListingCreateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/listings")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.sellerId").value(100L));
+    }
+
+    @Test
+    void 필수값이_없으면_400을_반환한다() throws Exception {
+        ListingCreateRequest invalidRequest = new ListingCreateRequest(null, null, null, null, List.of());
+
+        mockMvc.perform(post("/api/listings")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 중복_등록이면_409를_반환한다() throws Exception {
+        ListingCreateRequest request = new ListingCreateRequest(
+                1L, null, 10000, ListingGrade.A, List.of("https://example.com/a.png"));
+
+        given(listingService.createListing(anyLong(), any(ListingCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.DUPLICATE_LISTING));
+
+        mockMvc.perform(post("/api/listings")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_LISTING"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #13 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- 매물/거래 도메인 엔티티: `Listing`, `ListingImage`, `Trade`, `Payment` + 관련 enum + Repository                                                          
- 공통 예외 응답 포맷: `ErrorCode`, `BusinessException`, `ErrorResponse`, `GlobalExceptionHandler`                                                         
- FR-TRADE-01 매물 등록 API 구현                                                                                                                           
    - `ListingCreateRequest`/`ListingResponse` DTO                                                                                                           
    - `ListingController` — `POST /api/listings`                                                                                                             
    - `ListingService.createListing()` — 필수값 검증(400), 중복 등록 검증(409), 매물+사진 저장                                                               
 - 로그인 사용자(seller) 식별은 인증 파트가 아직 없어 `X-USER-ID` 헤더로 임시 처리                                        
                             

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- `X-USER-ID` 헤더로 sellerId를 받는 부분은 인증 붙기 전까지의 임시 코드입니다.                                            


## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?