### PR TITLE
[Feature] #11 ApiResponse형식 작성 및 공통 기반 설정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -1,0 +1,75 @@
+package com.pokade.domain.user.entity;
+
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    @Column(name = "nickname_change_at")
+    private LocalDateTime nicknameChangeAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    @Column(name = "phone_number", length = 20)
+    private String phoneNumber;
+
+    @Column(name = "terms_agreed_at", nullable = false)
+    private LocalDateTime termsAgreedAt;
+
+    @Column(name = "point_balance", nullable = false)
+    private Integer pointBalance;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deleted_At;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime created_At;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updated_At;
+
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/type/Provider.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/type/Provider.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.user.entity.type;
+
+public enum Provider {
+    LOCAL,
+    GOOGLE,
+    KAKAO
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/type/Role.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/type/Role.java
@@ -1,0 +1,6 @@
+package com.pokade.domain.user.entity.type;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
@@ -1,0 +1,8 @@
+package com.pokade.domain.user.entity.type;
+
+public enum UserStatus {
+    PENDING,
+    ACTIVE,
+    SUSPENDED,
+    DELETED
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.pokade.domain.user.repository;
+
+import com.pokade.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
+
+}

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -1,23 +1,41 @@
-package com.pokade.global;
+package com.pokade.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private static final String[] AUTH_WHITELIST = {
+            "/api/auth/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/actuator/health",
+            "/actuator/prometheus"
+    };
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/cards").permitAll()
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated()
                 );
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SwaggerConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.pokade.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                    .title("Pokade API")
+                    .description("Pokade API 문서")
+                    .version("v0.0.1"));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -19,7 +19,17 @@ public enum ErrorCode {
     TRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
-    TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다.");
+    TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다."),
+
+    // ===== 인증 (Auth) =====
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
+    EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
+    EMAIL_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+    EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
+    EMAIL_VERIFY_ATTEMPT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/Pokade/src/main/java/com/pokade/global/response/ApiResponse.java
+++ b/Pokade/src/main/java/com/pokade/global/response/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.pokade.global.response;
+
+import com.pokade.global.exception.ErrorCode;
+import lombok.NonNull;
+
+public record ApiResponse<T>(
+        int status,          // HTTP 상태 (예: 200, 409) — 파싱 안 함
+        @NonNull String code, // 의미 있는 코드 ("OK", "DUPLICATE_EMAIL")
+        @NonNull String msg,
+        T data
+
+) {
+    public static <T> ApiResponse<T> ok(T data) {
+            return new ApiResponse<>(200, "OK", "요청이 성공했습니다.", data);
+    }
+    public static <T> ApiResponse<T> ok(String msg, T data) {
+            return new ApiResponse<>(200, "OK", msg, data);
+    }
+    public static ApiResponse<Void> ok(String msg) {
+            return new ApiResponse<>(200, "OK", msg, null);
+    }
+    public static ApiResponse<Void> fail(ErrorCode e) {
+            return new ApiResponse<>(e.getStatus().value(), e.name(), e.getMessage(), null);
+    }
+}
+


### PR DESCRIPTION
## 📌 관련 이슈
- #11

## ✨ 작업 내용
- `User` 엔티티 + `Provider`/`Role`/`UserStatus` enum, `UserRepository` 추가
- 공통 응답 `ApiResponse<T>` 추가 (성공/실패 동일 포맷: `status`/`code`/`msg`/`data`)
- `ErrorCode`에 인증 관련 항목 추가 (이메일/닉네임 중복, 인증코드 발송·검증 등)
- `PasswordEncoder`(BCrypt) 빈 + `SecurityConfig` 인증 경로 permitAll (→ `global/config`로 이동)
- `SwaggerConfig` 추가

## 📸 스크린샷 / 테스트 결과
- 로컬 `./gradlew compileJava` 성공
- Swagger UI 정상 노출: `/swagger-ui.html`

## 🔍 리뷰 포인트
- **`ApiResponse<T>` 형식** — 팀 공통 응답 포맷입니다. 성공/에러를 같은 모양으로 통일했고, `code`는 `ErrorCode` 이름을 재사용합니다. (관련 논의: `문서/BE-의사결정기록.md`)
- **공용 파일 변경** — `ErrorCode`에 인증 항목 추가, `SecurityConfig`를 `global/config`로 이동했습니다. 충돌/컨벤션 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?