### PR TITLE
[Feature] #16 카드 상세 API 구현 

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -4,17 +4,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/cards")
+@RequestMapping("/api/cards")
 @RequiredArgsConstructor
 public class CardController {
 
@@ -28,5 +30,10 @@ public class CardController {
             @RequestParam(required = false) String expansionId,
             @PageableDefault(size = 20) Pageable pageable) {
         return cardService.search(name, types, rarity, expansionId, pageable);
+    }
+
+    @GetMapping("/{id}")
+    public CardDetailResponse detail(@PathVariable Long id) {
+        return cardService.getDetail(id);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
@@ -1,0 +1,92 @@
+package com.pokade.domain.card.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.entity.Expansion;
+
+public record CardDetailResponse(
+        Long id,
+        String externalId,
+        String name,
+        String setName,
+        String rarity,
+        String supertype,
+        List<String> types,
+        String artist,
+        String printedNumber,
+        String imageSmall,
+        String imageMedium,
+        String imageLarge,
+        ExpansionSummary expansion,
+        List<VariantSummary> variants
+) {
+
+    public static CardDetailResponse of(Card card, List<CardVariant> variants) {
+        return new CardDetailResponse(
+                card.getId(),
+                card.getExternalId(),
+                card.getName(),
+                card.getSetName(),
+                card.getRarity(),
+                card.getSupertype(),
+                card.getTypes(),
+                card.getArtist(),
+                card.getPrintedNumber(),
+                card.getImageSmall(),
+                card.getImageMedium(),
+                card.getImageLarge(),
+                ExpansionSummary.from(card.getExpansion()),
+                variants.stream().map(VariantSummary::from).toList()
+        );
+    }
+
+    public record ExpansionSummary(
+            String id,
+            String name,
+            String series,
+            String code,
+            Integer total,
+            LocalDate releaseDate,
+            String logo,
+            String symbol
+    ) {
+
+        public static ExpansionSummary from(Expansion expansion) {
+            if (expansion == null) {
+                return null;
+            }
+            return new ExpansionSummary(
+                    expansion.getId(),
+                    expansion.getName(),
+                    expansion.getSeries(),
+                    expansion.getCode(),
+                    expansion.getTotal(),
+                    expansion.getReleaseDate(),
+                    expansion.getLogo(),
+                    expansion.getSymbol()
+            );
+        }
+    }
+
+    public record VariantSummary(
+            Long id,
+            String variantName,
+            boolean primary,
+            String imageSmall,
+            String imageLarge
+    ) {
+
+        public static VariantSummary from(CardVariant variant) {
+            return new VariantSummary(
+                    variant.getId(),
+                    variant.getVariantName(),
+                    variant.isPrimary(),
+                    variant.getImageSmall(),
+                    variant.getImageLarge()
+            );
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -1,12 +1,18 @@
 package com.pokade.domain.card.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.pokade.domain.card.entity.CardVariant;
 
 public interface CardVariantRepository extends JpaRepository<CardVariant, Long> {
 
     List<CardVariant> findByCardIdOrderByPrimaryDescVariantNameAsc(Long cardId);
+
+    @Query("SELECT cv.id FROM CardVariant cv WHERE cv.card.id = :cardId AND cv.primary = true")
+    Optional<Long> findPrimaryVariantId(@Param("cardId") Long cardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -1,0 +1,12 @@
+package com.pokade.domain.card.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.pokade.domain.card.entity.CardVariant;
+
+public interface CardVariantRepository extends JpaRepository<CardVariant, Long> {
+
+    List<CardVariant> findByCardIdOrderByPrimaryDescVariantNameAsc(Long cardId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -5,8 +5,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,10 +23,19 @@ import lombok.RequiredArgsConstructor;
 public class CardService {
 
     private final CardRepository cardRepository;
+    private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
     public Page<CardResponse> search(String name, String types, String rarity, String expansionId, Pageable pageable) {
         return cardRepository.search(name, types, rarity, expansionId, pageable)
                 .map(CardResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public CardDetailResponse getDetail(Long id) {
+        Card card = cardRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+        List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
+        return CardDetailResponse.of(card, variants);
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.GET, "/cards").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .anyRequest().authenticated()
                 );
         return http.build();

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
 
     LISTING_NOT_FOUND(HttpStatus.NOT_FOUND, "매물을 찾을 수 없습니다."),
     TRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
+    CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
     TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다.");

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -4,7 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -16,11 +18,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 
+import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -43,7 +49,7 @@ class CardControllerTest {
                 .willReturn(page);
 
         mockMvcTester.get()
-                .uri("/cards?name=char&types=Fire&rarity=Rare Holo&expansionId=base1")
+                .uri("/api/cards?name=char&types=Fire&rarity=Rare Holo&expansionId=base1")
                 .assertThat()
                 .hasStatusOk()
                 .bodyJson()
@@ -59,8 +65,43 @@ class CardControllerTest {
                 .willReturn(page);
 
         mockMvcTester.get()
-                .uri("/cards")
+                .uri("/api/cards")
                 .assertThat()
                 .hasStatusOk();
+    }
+
+    @Test
+    @DisplayName("t3 존재하는 카드 id로 상세조회하면 200과 확장팩·변형 정보를 포함한 응답을 반환한다")
+    void t3() {
+        CardDetailResponse.ExpansionSummary expansion = new CardDetailResponse.ExpansionSummary(
+                "base1", "Base", "Base", "BS", 102, LocalDate.of(1999, 1, 9), null, null);
+        CardDetailResponse.VariantSummary variant = new CardDetailResponse.VariantSummary(
+                1L, "unlimitedHolofoil", true, null, null);
+        CardDetailResponse detail = new CardDetailResponse(
+                1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), "Mitsuhiro Arita", "4/102", null, null, null,
+                expansion, List.of(variant));
+        given(cardService.getDetail(1L)).willReturn(detail);
+
+        var result = mockMvcTester.get()
+                .uri("/api/cards/1")
+                .assertThat()
+                .hasStatusOk();
+        result.bodyJson().extractingPath("$.name").isEqualTo("Charizard");
+        result.bodyJson().extractingPath("$.expansion.id").isEqualTo("base1");
+        result.bodyJson().extractingPath("$.variants[0].variantName").isEqualTo("unlimitedHolofoil");
+    }
+
+    @Test
+    @DisplayName("t4 존재하지 않는 카드 id로 상세조회하면 404를 반환한다")
+    void t4() {
+        willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND)).given(cardService).getDetail(999L);
+
+        mockMvcTester.get()
+                .uri("/api/cards/999")
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("CARD_NOT_FOUND");
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.pokade.domain.card.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.entity.Expansion;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class CardVariantRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private CardVariantRepository cardVariantRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Card multiVariantCard;
+
+    @BeforeEach
+    void setUp() {
+        Expansion base1 = Expansion.builder()
+                .id("base1")
+                .name("Base")
+                .syncedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(base1);
+
+        multiVariantCard = Card.builder()
+                .name("Charizard")
+                .rarity("Rare Holo")
+                .expansion(base1)
+                .build();
+        entityManager.persist(multiVariantCard);
+
+        persistVariant(multiVariantCard, "firstEditionHolofoil", false);
+        persistVariant(multiVariantCard, "unlimitedHolofoil", true);
+        persistVariant(multiVariantCard, "reverseHolofoil", false);
+    }
+
+    private void persistVariant(Card card, String variantName, boolean primary) {
+        CardVariant variant = CardVariant.builder()
+                .card(card)
+                .variantName(variantName)
+                .primary(primary)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(variant);
+    }
+
+    @Test
+    @DisplayName("t1 카드에 변형이 여러 개 있으면 대표 변형이 먼저, 나머지는 변형명 오름차순으로 조회된다")
+    void t1() {
+        List<CardVariant> result = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(multiVariantCard.getId());
+
+        assertThat(result)
+                .extracting(CardVariant::getVariantName)
+                .containsExactly("unlimitedHolofoil", "firstEditionHolofoil", "reverseHolofoil");
+    }
+
+    @Test
+    @DisplayName("t2 변형이 없는 카드는 빈 목록을 반환한다")
+    void t2() {
+        Card noVariantCard = Card.builder().name("Pikachu").build();
+        entityManager.persist(noVariantCard);
+
+        List<CardVariant> result = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(noVariantCard.getId());
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -1,9 +1,12 @@
 package com.pokade.domain.card.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,15 +19,24 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.entity.Expansion;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 
 @ExtendWith(MockitoExtension.class)
 class CardServiceTest {
 
     @Mock
     private CardRepository cardRepository;
+
+    @Mock
+    private CardVariantRepository cardVariantRepository;
 
     @InjectMocks
     private CardService cardService;
@@ -45,5 +57,57 @@ class CardServiceTest {
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t2 존재하는 id로 상세조회하면 확장팩과 변형 목록을 포함한 상세 응답을 반환한다")
+    void t2() {
+        Expansion expansion = Expansion.builder()
+                .id("base1")
+                .name("Base")
+                .syncedAt(LocalDateTime.now())
+                .build();
+        Card card = Card.builder()
+                .id(1L)
+                .name("Charizard")
+                .rarity("Rare Holo")
+                .types(List.of("Fire"))
+                .expansion(expansion)
+                .build();
+        CardVariant primaryVariant = CardVariant.builder()
+                .id(1L)
+                .card(card)
+                .variantName("unlimitedHolofoil")
+                .primary(true)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        CardVariant secondaryVariant = CardVariant.builder()
+                .id(2L)
+                .card(card)
+                .variantName("firstEditionHolofoil")
+                .primary(false)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(1L))
+                .willReturn(List.of(primaryVariant, secondaryVariant));
+
+        CardDetailResponse result = cardService.getDetail(1L);
+
+        assertThat(result.name()).isEqualTo("Charizard");
+        assertThat(result.expansion().id()).isEqualTo("base1");
+        assertThat(result.variants()).hasSize(2);
+        assertThat(result.variants().get(0).variantName()).isEqualTo("unlimitedHolofoil");
+    }
+
+    @Test
+    @DisplayName("t3 존재하지 않는 id로 상세조회하면 CARD_NOT_FOUND 예외가 발생한다")
+    void t3() {
+        given(cardRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> cardService.getDetail(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
     }
 }

--- a/Pokade/src/test/java/com/pokade/support/AbstractIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/support/AbstractIntegrationTest.java
@@ -4,15 +4,15 @@ import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabas
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
 @ActiveProfiles("test")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public abstract class AbstractIntegrationTest {
 
-    @Container
     @ServiceConnection
     static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>("postgres:17-alpine");
+
+    static {
+        POSTGRES.start();
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #16 

## ✨ 작업 내용
- 카드 상세 조회 API 구현 (GET /api/cards/{id})
- 카드 API 경로를 /cards → /api/cards로 정렬

## 📸 스크린샷 / 테스트 결과
- 전체 통과 (CardControllerTest, CardServiceTest, CardRepositoryTest, CardVariantRepositoryTest (신규), PokadeApplicationTests, TradeDomainFkIntegrationTest)

## 🔍 리뷰 포인트
- SecurityConfig: permitAll을 /api/cards/**로 확장
- AbstractIntegrationTest 수정 (공유 테스트 인프라): 
  기존 방식이 통합 테스트 2개 이상일 때 Connection refused 나는 버그 발견, 싱글톤 컨테이너 패턴으로 전환
- ErrorCode: CARD_NOT_FOUND만 추가, 기존 값 변경 없음
- 시세(card_prices)는 응답에서 제외 — 별도 API 소관

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?