### PR TITLE
[Feature] #20 이메일 회원가입 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.pokade.domain.auth.controller;
+
+import com.pokade.domain.auth.dto.request.SignupRequest;
+import com.pokade.domain.auth.dto.response.SignupResponse;
+import com.pokade.domain.auth.service.AuthService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ApiResponse<SignupResponse> signup(
+            @Valid @RequestBody SignupRequest request
+    ) {
+        return ApiResponse.ok(
+                "회원가입이 완료되었습니다. 이메일 인증을 진행해주세요.",
+                authService.signup(request)
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/SignupRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/SignupRequest.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)\\S+$",
+                message = "비밀번호는 영문과 숫자를 포함하며 공백을 포함할 수 없습니다."
+        )
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+        String nickname
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/response/SignupResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,20 @@
+package com.pokade.domain.auth.dto.response;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+
+public record SignupResponse(
+        Long userId,
+        String email,
+        String nickname,
+        UserStatus status
+) {
+    public static SignupResponse from (User user) {
+        return new SignupResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getStatus()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.auth.dto.request.SignupRequest;
+import com.pokade.domain.auth.dto.response.SignupResponse;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public SignupResponse signup(SignupRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        if(userRepository.existsByNickname(request.nickname())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+        String encodedPassword = passwordEncoder.encode(request.password());
+        User user = userRepository.save(
+                User.createLocalUser(request.email(), encodedPassword, request.nickname())
+        );
+
+        return SignupResponse.from(user);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -31,8 +31,8 @@ public class User {
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    @Column(name = "nickname_change_at")
-    private LocalDateTime nicknameChangeAt;
+    @Column(name = "nickname_changed_at")
+    private LocalDateTime nicknameChangedAt;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -58,6 +58,9 @@ public class User {
     @Column(name = "terms_agreed_at", nullable = false)
     private LocalDateTime termsAgreedAt;
 
+    @Column(name = "marketing_opt_in", nullable = false)
+    private boolean marketingOptIn;
+
     @Column(name = "point_balance", nullable = false)
     private Integer pointBalance;
 
@@ -72,4 +75,17 @@ public class User {
     @Column(name = "updated_at")
     private LocalDateTime updated_At;
 
+    public static User createLocalUser(String email, String encodedPassword, String nickname) {
+        return User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .provider(Provider.LOCAL)
+                .role(Role.USER)
+                .status(UserStatus.PENDING)
+                .termsAgreedAt(LocalDateTime.now())
+                .marketingOptIn(false)
+                .pointBalance(0)
+                .build();
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,89 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.auth.dto.request.SignupRequest;
+import com.pokade.domain.auth.dto.response.SignupResponse;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
+    @InjectMocks
+    AuthService authService;
+
+    private SignupRequest request(String email, String pw, String nickname) {
+        return new SignupRequest(email, pw, nickname);
+    }
+
+    @Test
+    @DisplayName("정상 가입 시 비밀번호를 암호화해 PENDING 상태로 저장하고 응답을 반환한다")
+    void signup_success() {
+        // given
+        SignupRequest req = request("test@pokade.com", "pokade1234", "홍길동");
+        given(userRepository.existsByEmail(req.email())).willReturn(false);
+        given(userRepository.existsByNickname(req.nickname())).willReturn(false);
+        given(passwordEncoder.encode(req.password())).willReturn("ENCODED_PW");
+        given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+
+        // when
+        SignupResponse res = authService.signup(req);
+
+        // then
+        assertThat(res.email()).isEqualTo("test@pokade.com");
+        assertThat(res.nickname()).isEqualTo("홍길동");
+        assertThat(res.status()).isEqualTo(UserStatus.PENDING);
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        then(userRepository).should().save(captor.capture());
+        User saved = captor.getValue();
+        assertThat(saved.getPassword()).isEqualTo("ENCODED_PW"); // 평문 저장 아님
+        assertThat(saved.getStatus()).isEqualTo(UserStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("이메일이 중복되면 DUPLICATE_EMAIL 예외를 던지고 저장하지 않는다")
+    void signup_duplicateEmail() {
+        SignupRequest req = request("dup@pokade.com", "pokade1234", "홍길동");
+        given(userRepository.existsByEmail(req.email())).willReturn(true);
+
+        assertThatThrownBy(() -> authService.signup(req))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+
+        then(userRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외를 던진다")
+    void signup_duplicateNickname() {
+        SignupRequest req = request("new@pokade.com", "pokade1234", "중복닉");
+        given(userRepository.existsByEmail(req.email())).willReturn(false);
+        given(userRepository.existsByNickname(req.nickname())).willReturn(true);
+
+        assertThatThrownBy(() -> authService.signup(req))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #20 

- `POST /api/auth/signup` 구현 — 이메일·비밀번호·닉네임 입력 → **PENDING** 상태로 가입
- 이메일/닉네임 중복 검증(409), 비밀번호 **BCrypt** 암호화
- 공통 응답 `ApiResponse<T>`로 반환, 실패는 `ErrorCode`/`GlobalExceptionHandler`
- `User.createLocalUser` 정적 팩토리 + `marketingOptIn` 컬럼 매핑 추가
- (fix) `User` 엔티티 컬럼명 오타 정정: `nickname_change_at` → `nickname_changed_at`
- (test) `AuthService` 단위 테스트 추가 (정상 가입 / 이메일·닉네임 중복)

## 📸 스크린샷 / 테스트 결과
- 로컬 실행 검증: `200`(가입, data.status=PENDING) / `409`(이메일 중복) / `400`(비번 규칙 위반) 확인
- DB 저장 확인: 비밀번호 BCrypt 해시, status=PENDING, provider=LOCAL
- `./gradlew test --tests '*AuthServiceTest'` 통과

## 🔍 리뷰 포인트
- **응답 필드 불일치**: 성공은 `ApiResponse.msg`, 에러는 `ErrorResponse.message`. 에러도 `ApiResponse`로 통일할지 팀 논의 필요 (관련: `문서/BE-의사결정기록.md`)
- **공용 엔티티 수정**: `User`에 `marketingOptIn` 매핑 추가 + 컬럼명 오타 정정. 다른 도메인 영향 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?
