### PR TITLE
[Feature] #18 매물 목록 조회 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/Listing.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/Listing.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -65,6 +66,7 @@ public class Listing {
     private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "listing", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
     private final List<ListingImage> images = new ArrayList<>();
 
     @Builder

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -38,4 +38,13 @@ public class ListingController {
     public ResponseEntity<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
         return ResponseEntity.ok(listingService.getActiveListings(cardId));
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<ListingSummaryResponse>> getMyListings(
+            // TODO: 인증 파트 완성되면 SecurityContext에서 sellerId 추출하는 방식으로 교체
+            @RequestHeader("X-USER-ID") Long sellerId,
+            @RequestParam(required = false) ListingStatus status
+    ) {
+        return ResponseEntity.ok(listingService.getMyListings(sellerId, status));
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -2,15 +2,20 @@ package com.pokade.domain.listing;
 
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.domain.listing.dto.ListingSummaryResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/listings")
@@ -27,5 +32,10 @@ public class ListingController {
     ) {
         ListingResponse response = listingService.createListing(sellerId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
+        return ResponseEntity.ok(listingService.getActiveListings(cardId));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -2,6 +2,7 @@ package com.pokade.domain.listing;
 
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.domain.listing.dto.ListingSummaryResponse;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,13 @@ public class ListingService {
 
         Listing saved = listingRepository.save(listing);
         return ListingResponse.of(saved, imageUrls);
+    }
+
+    public List<ListingSummaryResponse> getActiveListings(Long cardId) {
+        return listingRepository.findByCardIdAndStatusOrderByPriceAsc(cardId, ListingStatus.ACTIVE)
+                .stream()
+                .map(ListingSummaryResponse::of)
+                .toList();
     }
 
     private void validateNotDuplicate(Long sellerId, Long cardId, Long variantId) {

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -46,6 +46,16 @@ public class ListingService {
                 .toList();
     }
 
+    public List<ListingSummaryResponse> getMyListings(Long sellerId, ListingStatus status) {
+        List<Listing> listings = status != null
+                ? listingRepository.findBySellerIdAndStatus(sellerId, status)
+                : listingRepository.findBySellerId(sellerId);
+
+        return listings.stream()
+                .map(ListingSummaryResponse::of)
+                .toList();
+    }
+
     private void validateNotDuplicate(Long sellerId, Long cardId, Long variantId) {
         // TODO: "중복 등록" 기준 팀 확정 필요 (현재는 동일 판매자가 같은 카드/variant에 ACTIVE 매물을 이미 가진 경우로 간주)
         boolean exists = listingRepository.existsBySellerIdAndCardIdAndVariantIdAndStatus(

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.pokade.domain.listing.dto;
+
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.listing.ListingStatus;
+
+import java.time.LocalDateTime;
+
+public record ListingSummaryResponse(
+        Long id,
+        Long sellerId,
+        Integer price,
+        ListingGrade grade,
+        ListingStatus status,
+        String thumbnailUrl,
+        LocalDateTime createdAt
+) {
+
+    public static ListingSummaryResponse of(Listing listing) {
+        String thumbnailUrl = listing.getImages().isEmpty()
+                ? null
+                : listing.getImages().get(0).getImageUrl();
+
+        return new ListingSummaryResponse(
+                listing.getId(),
+                listing.getSellerId(),
+                listing.getPrice(),
+                listing.getGrade(),
+                listing.getStatus(),
+                thumbnailUrl,
+                listing.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.pokade.global.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,6 +23,13 @@ public class GlobalExceptionHandler {
                 .findFirst()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .orElse(ErrorCode.INVALID_INPUT.getMessage());
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParameterException(MissingServletRequestParameterException e) {
+        String message = e.getParameterName() + "는 필수입니다.";
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message));
     }

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -114,4 +114,42 @@ class ListingControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
+
+    @Test
+    void 내_매물이_있으면_200과_목록을_반환한다() throws Exception {
+        ListingSummaryResponse summary = new ListingSummaryResponse(
+                1L, 100L, 10000, ListingGrade.A, ListingStatus.ACTIVE,
+                "https://example.com/a.png", LocalDateTime.now());
+
+        given(listingService.getMyListings(100L, null)).willReturn(List.of(summary));
+
+        mockMvc.perform(get("/api/listings/me").header("X-USER-ID", 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(1L));
+    }
+
+    @Test
+    void 등록한_매물이_없으면_200과_빈_목록을_반환한다() throws Exception {
+        given(listingService.getMyListings(100L, null)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/listings/me").header("X-USER-ID", 100L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void status_파라미터로_필터링해서_조회한다() throws Exception {
+        ListingSummaryResponse summary = new ListingSummaryResponse(
+                2L, 100L, 5000, ListingGrade.B, ListingStatus.SOLD,
+                null, LocalDateTime.now());
+
+        given(listingService.getMyListings(100L, ListingStatus.SOLD)).willReturn(List.of(summary));
+
+        mockMvc.perform(get("/api/listings/me")
+                        .header("X-USER-ID", 100L)
+                        .param("status", "SOLD"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].status").value("SOLD"));
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.listing;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.domain.listing.dto.ListingSummaryResponse;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -81,5 +83,35 @@ class ListingControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("DUPLICATE_LISTING"));
+    }
+
+    @Test
+    void 활성_매물이_있으면_200과_가격순_목록을_반환한다() throws Exception {
+        ListingSummaryResponse summary = new ListingSummaryResponse(
+                1L, 100L, 10000, ListingGrade.A, ListingStatus.ACTIVE,
+                "https://example.com/a.png", LocalDateTime.now());
+
+        given(listingService.getActiveListings(1L)).willReturn(List.of(summary));
+
+        mockMvc.perform(get("/api/listings").param("cardId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].id").value(1L));
+    }
+
+    @Test
+    void 활성_매물이_없으면_200과_빈_목록을_반환한다() throws Exception {
+        given(listingService.getActiveListings(1L)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/listings").param("cardId", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void cardId가_없으면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/listings"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #18 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- FR-TRADE-02 매물 목록 조회: `GET /api/listings?cardId=`                                                                                                   
    - `ListingSummaryResponse` DTO 추가 (목록용, 대표 이미지 1장 포함)                                                                                        
    - `Listing.images`에 `@OrderBy("sortOrder ASC")` 추가해 이미지 정렬 순서 보장                                                                             
    - `ListingService.getActiveListings()` — cardId 기준 ACTIVE 매물 가격 오름차순 조회                                                                       
    - `cardId` 누락 시 공통 에러 포맷(400, `INVALID_INPUT`)으로 응답하도록 `GlobalExceptionHandler`에 `MissingServletRequestParameterException` 핸들러 추가   
- FR-TRADE-03 내 매물 조회: `GET /api/listings/me`                                                                                                          
    - `ListingService.getMyListings(sellerId, status)` — `status` 파라미터 있으면 필터링, 없으면 전체 조회                                                    
    - sellerId는 FR-TRADE-01과 동일하게 `X-USER-ID` 헤더로 임시 수신 (인증 파트 완료 후 교체 예정, 코드에 TODO 표시)                                          
                                                                                                                                                              
  ## 📸 스크린샷 / 테스트 결과                                                                                                                                
  <!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->                                                                                
                                                                                                                                                              
  ## 🔍 리뷰 포인트                                                                                                                                           
  <!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->                                                                                        
  - `getImages()`가 LAZY 컬렉션이라 매물 개수만큼 이미지 조회 쿼리가 추가로 나가는 N+1 문제가 있습니다. 지금 데이터量에선 문제없지만 나중에 fetch join이나 batch size 최적화 필요할 수 있습니다.                                                                                                                       
  - `/me` 엔드포인트의 sellerId를 `X-USER-ID` 헤더로 받는 부분은 인증 붙기 전까지의 임시 코드입니다 (별도 교체 예정).               