### PR TITLE
[Feature] #26 Scrydex 배치 구조 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
+import com.pokade.global.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,17 +24,17 @@ public class CardController {
     private final CardService cardService;
 
     @GetMapping
-    public Page<CardResponse> search(
+    public ApiResponse<Page<CardResponse>> search(
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String types,
             @RequestParam(required = false) String rarity,
             @RequestParam(required = false) String expansionId,
             @PageableDefault(size = 20) Pageable pageable) {
-        return cardService.search(name, types, rarity, expansionId, pageable);
+        return ApiResponse.ok(cardService.search(name, types, rarity, expansionId, pageable));
     }
 
     @GetMapping("/{id}")
-    public CardDetailResponse detail(@PathVariable Long id) {
-        return cardService.getDetail(id);
+    public ApiResponse<CardDetailResponse> detail(@PathVariable Long id) {
+        return ApiResponse.ok(cardService.getDetail(id));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/MockScrydexClient.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/MockScrydexClient.java
@@ -1,0 +1,129 @@
+package com.pokade.domain.sync.client;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardPriceDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+
+/**
+ * data.sql에 시딩된 카드 목데이터와 동일한 형태를 반환하는 ScrydexClient 구현체.
+ * 실제 HTTP 호출 없이 고정된 더미 데이터만 반환한다.
+ */
+@Component
+public class MockScrydexClient implements ScrydexClient {
+
+    private record PriceFixture(String grade, BigDecimal low, BigDecimal mid, BigDecimal high,
+                                 BigDecimal market, String currency) {
+    }
+
+    private record CardFixture(String externalId, String name, String setName, String rarity, String supertype,
+                                List<String> types, String printedNumber, String expansionId,
+                                String variantName, List<PriceFixture> prices) {
+    }
+
+    private static final List<ExpansionDto> EXPANSIONS = List.of(
+            new ExpansionDto("base1", "Base", "Base", null, 102, "EN", LocalDate.of(1999, 1, 9)),
+            new ExpansionDto("sv3pt5", "151", "Scarlet & Violet", null, 207, "EN", LocalDate.of(2023, 6, 16)),
+            new ExpansionDto("zsv10pt5", "Black Bolt", "Scarlet & Violet", null, 172, "EN", LocalDate.of(2025, 7, 18)),
+            new ExpansionDto("sm11", "Unified Minds", "Sun & Moon", null, 260, "EN", LocalDate.of(2019, 8, 2)),
+            new ExpansionDto("xy7", "Ancient Origins", "XY", null, 98, "EN", LocalDate.of(2015, 8, 12)),
+            new ExpansionDto("sm3", "Burning Shadows", "Sun & Moon", null, 168, "EN", LocalDate.of(2017, 8, 4)),
+            new ExpansionDto("me1", "Mega Evolution", "Mega Evolution", null, 188, "EN", LocalDate.of(2025, 9, 26)),
+            new ExpansionDto("sv10_ja", "サンダー", "Scarlet & Violet", null, 98, "JA", LocalDate.of(2024, 11, 1))
+    );
+
+    private static final List<CardFixture> CARDS = List.of(
+            new CardFixture("base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                    List.of("Fire"), "4/102", "base1", "unlimitedHolofoil",
+                    prices("2350.0", "2566.0", "2650.0", "2567.88", "780.0", "845.0", "910.0", "848.67", "USD")),
+            new CardFixture("base1-2", "Blastoise", "Base", "Rare Holo", "Pokémon",
+                    List.of("Water"), "2/102", "base1", "unlimitedHolofoil",
+                    prices("720.0", "760.0", "810.0", "768.4", "610.0", "655.0", "700.0", "648.0", "USD")),
+            new CardFixture("base1-58", "Pikachu", "Base", "Common", "Pokémon",
+                    List.of("Lightning"), "58/102", "base1", "unlimited",
+                    prices("210.0", "235.0", "260.0", "238.4", "60.0", "68.0", "75.0", "69.2", "USD")),
+            new CardFixture("sv3pt5-6", "Charizard ex", "151", "Double Rare", "Pokémon",
+                    List.of("Fire"), "006/165", "sv3pt5", "holofoil",
+                    prices("320.0", "340.0", "365.0", "342.5", "165.0", "178.0", "190.0", "180.2", "USD")),
+            new CardFixture("sv3pt5-54", "Blastoise ex", "151", "Double Rare", "Pokémon",
+                    List.of("Water"), "054/165", "sv3pt5", "holofoil",
+                    prices("140.0", "150.0", "162.0", "151.8", "70.0", "76.0", "82.0", "77.1", "USD")),
+            new CardFixture("sv3pt5-25", "Pikachu", "151", "Common", "Pokémon",
+                    List.of("Lightning"), "025/165", "sv3pt5", "normal",
+                    prices("22.0", "25.0", "28.0", "25.6", "8.0", "9.2", "10.5", "9.4", "USD")),
+            new CardFixture("zsv10pt5-105", "Seismitoad", "Black Bolt", "Illustration Rare", "Pokémon",
+                    List.of("Water"), "105/086", "zsv10pt5", "holofoil",
+                    prices("2200.0", "2350.0", "2450.0", "2399.0", "780.0", "820.0", "860.0", "822.4", "USD")),
+            new CardFixture("sm11-95", "Alakazam GX", "Unified Minds", "Rare Holo GX", "Pokémon",
+                    List.of("Psychic"), "95/236", "sm11", "holofoil",
+                    prices("24.0", "27.0", "30.0", "27.4", "10.0", "11.5", "13.0", "11.8", "USD")),
+            new CardFixture("xy7-54", "Gardevoir-EX", "Ancient Origins", "Rare Holo EX", "Pokémon",
+                    List.of("Fairy"), "54/98", "xy7", "holofoil",
+                    prices("68.0", "74.0", "80.0", "75.2", "28.0", "31.0", "34.0", "31.6", "USD")),
+            new CardFixture("sm3-20", "Charizard-GX", "Burning Shadows", "Rare Holo GX", "Pokémon",
+                    List.of("Fire"), "20/147", "sm3", "holofoil",
+                    prices("210.0", "225.0", "240.0", "228.0", "88.0", "95.0", "102.0", "96.4", "USD")),
+            new CardFixture("me1-12", "Mega Lucario ex", "Mega Evolution", "Double Rare", "Pokémon",
+                    List.of("Fighting"), "012/132", "me1", "holofoil",
+                    prices("46.0", "50.0", "55.0", "51.2", "20.0", "22.5", "25.0", "22.9", "USD")),
+            new CardFixture("sv10_ja-1", "クヌギダマ", "サンダー", "通常", "ポケモン",
+                    List.of("草"), "001/098", "sv10_ja", "normal",
+                    prices("5.0", "5.6", "6.2", "5.7", "2.0", "2.3", "2.6", "2.35", "JPY"))
+    );
+
+    private static List<PriceFixture> prices(String grade10Low, String grade10Mid, String grade10High,
+                                              String grade10Market, String grade9Low, String grade9Mid,
+                                              String grade9High, String grade9Market, String currency) {
+        return List.of(
+                new PriceFixture("10", new BigDecimal(grade10Low), new BigDecimal(grade10Mid),
+                        new BigDecimal(grade10High), new BigDecimal(grade10Market), currency),
+                new PriceFixture("9", new BigDecimal(grade9Low), new BigDecimal(grade9Mid),
+                        new BigDecimal(grade9High), new BigDecimal(grade9Market), currency)
+        );
+    }
+
+    private static String variantId(String cardExternalId, String variantName) {
+        return cardExternalId + "-" + variantName;
+    }
+
+    @Override
+    public List<ExpansionDto> fetchExpansions() {
+        return EXPANSIONS;
+    }
+
+    @Override
+    public List<CardDto> fetchCards(String expansionId) {
+        return CARDS.stream()
+                .filter(c -> c.expansionId().equals(expansionId))
+                .map(c -> new CardDto(c.externalId(), c.name(), c.setName(), c.rarity(), c.supertype(),
+                        c.types(), c.printedNumber(), c.expansionId()))
+                .toList();
+    }
+
+    @Override
+    public List<CardVariantDto> fetchCardVariants(String cardId) {
+        return CARDS.stream()
+                .filter(c -> c.externalId().equals(cardId))
+                .map(c -> new CardVariantDto(variantId(c.externalId(), c.variantName()), c.externalId(),
+                        c.variantName(), true))
+                .toList();
+    }
+
+    @Override
+    public List<CardPriceDto> fetchCardPrices(String variantId) {
+        return CARDS.stream()
+                .filter(c -> variantId(c.externalId(), c.variantName()).equals(variantId))
+                .findFirst()
+                .map(c -> c.prices().stream()
+                        .map(p -> new CardPriceDto(variantId, "graded", p.grade(), "PSA",
+                                p.low(), p.mid(), p.high(), p.market(), p.currency()))
+                        .toList())
+                .orElse(List.of());
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/ScrydexClient.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/ScrydexClient.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.sync.client;
+
+import java.util.List;
+
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardPriceDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+
+public interface ScrydexClient {
+
+    List<ExpansionDto> fetchExpansions();
+
+    List<CardDto> fetchCards(String expansionId);
+
+    List<CardVariantDto> fetchCardVariants(String cardId);
+
+    List<CardPriceDto> fetchCardPrices(String variantId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardDto.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardDto.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.sync.client.dto;
+
+import java.util.List;
+
+public record CardDto(
+        String externalId,
+        String name,
+        String setName,
+        String rarity,
+        String supertype,
+        List<String> types,
+        String printedNumber,
+        String expansionId
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardPriceDto.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardPriceDto.java
@@ -1,0 +1,16 @@
+package com.pokade.domain.sync.client.dto;
+
+import java.math.BigDecimal;
+
+public record CardPriceDto(
+        String variantId,
+        String priceType,
+        String grade,
+        String company,
+        BigDecimal low,
+        BigDecimal mid,
+        BigDecimal high,
+        BigDecimal market,
+        String currency
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardVariantDto.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/dto/CardVariantDto.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.sync.client.dto;
+
+public record CardVariantDto(
+        String variantId,
+        String cardExternalId,
+        String variantName,
+        boolean primary
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/client/dto/ExpansionDto.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/client/dto/ExpansionDto.java
@@ -1,0 +1,14 @@
+package com.pokade.domain.sync.client.dto;
+
+import java.time.LocalDate;
+
+public record ExpansionDto(
+        String id,
+        String name,
+        String series,
+        String code,
+        Integer total,
+        String languageCode,
+        LocalDate releaseDate
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/entity/SyncLog.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/entity/SyncLog.java
@@ -1,0 +1,59 @@
+package com.pokade.domain.sync.entity;
+
+import java.time.LocalDateTime;
+
+import com.pokade.domain.sync.entity.type.SyncStatus;
+import com.pokade.domain.sync.entity.type.SyncType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "sync_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SyncLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sync_type", nullable = false, length = 20)
+    private SyncType syncType;
+
+    @Column(length = 100)
+    private String target;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SyncStatus status;
+
+    @Column(name = "records_synced")
+    private Integer recordsSynced;
+
+    @Column(name = "credits_used")
+    private Integer creditsUsed;
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/entity/type/SyncStatus.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/entity/type/SyncStatus.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.sync.entity.type;
+
+public enum SyncStatus {
+    SUCCESS,
+    PARTIAL,
+    FAILED
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/entity/type/SyncType.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/entity/type/SyncType.java
@@ -1,0 +1,8 @@
+package com.pokade.domain.sync.entity.type;
+
+public enum SyncType {
+    EXPANSION,
+    CARD,
+    CARD_VARIANT,
+    PRICE
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/repository/SyncLogRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/repository/SyncLogRepository.java
@@ -1,0 +1,12 @@
+package com.pokade.domain.sync.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.pokade.domain.sync.entity.SyncLog;
+import com.pokade.domain.sync.entity.type.SyncStatus;
+import com.pokade.domain.sync.entity.type.SyncType;
+
+public interface SyncLogRepository extends JpaRepository<SyncLog, Long> {
+
+    boolean existsBySyncTypeAndStatus(SyncType syncType, SyncStatus status);
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/service/SyncService.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/service/SyncService.java
@@ -1,0 +1,101 @@
+package com.pokade.domain.sync.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pokade.domain.sync.client.ScrydexClient;
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardPriceDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+import com.pokade.domain.sync.entity.SyncLog;
+import com.pokade.domain.sync.entity.type.SyncStatus;
+import com.pokade.domain.sync.entity.type.SyncType;
+import com.pokade.domain.sync.repository.SyncLogRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * expansions → cards → card_variants → card_prices 순서로 Scrydex 데이터를 동기화한다.
+ * 각 단계의 성공/실패는 sync_logs에 기록되며, 이미 성공한 단계는 재실행 시 로그를 다시 남기지 않고
+ * 실패했던 단계부터 이어서 진행한다(단, 목데이터 특성상 이전 단계 데이터는 매 호출마다 다시 조회한다).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SyncService {
+
+    private final ScrydexClient scrydexClient;
+    private final SyncLogRepository syncLogRepository;
+
+    @Value("${sync.enabled:false}")
+    private boolean syncEnabled;
+
+    @Transactional
+    public void sync() {
+        if (!syncEnabled) {
+            log.info("sync.enabled=false - 동기화를 실행하지 않습니다.");
+            return;
+        }
+
+        List<ExpansionDto> expansions = runStep(SyncType.EXPANSION, scrydexClient::fetchExpansions);
+        if (expansions == null) {
+            return;
+        }
+
+        List<CardDto> cards = runStep(SyncType.CARD, () -> expansions.stream()
+                .flatMap(e -> scrydexClient.fetchCards(e.id()).stream())
+                .toList());
+        if (cards == null) {
+            return;
+        }
+
+        List<CardVariantDto> variants = runStep(SyncType.CARD_VARIANT, () -> cards.stream()
+                .flatMap(c -> scrydexClient.fetchCardVariants(c.externalId()).stream())
+                .toList());
+        if (variants == null) {
+            return;
+        }
+
+        runStep(SyncType.PRICE, () -> variants.stream()
+                .flatMap(v -> scrydexClient.fetchCardPrices(v.variantId()).stream())
+                .toList());
+    }
+
+    private <T> List<T> runStep(SyncType syncType, Supplier<List<T>> fetcher) {
+        if (syncLogRepository.existsBySyncTypeAndStatus(syncType, SyncStatus.SUCCESS)) {
+            return fetcher.get();
+        }
+
+        LocalDateTime startedAt = LocalDateTime.now();
+        try {
+            List<T> result = fetcher.get();
+            syncLogRepository.save(SyncLog.builder()
+                    .syncType(syncType)
+                    .status(SyncStatus.SUCCESS)
+                    .recordsSynced(result.size())
+                    .creditsUsed(0)
+                    .startedAt(startedAt)
+                    .finishedAt(LocalDateTime.now())
+                    .build());
+            return result;
+        } catch (RuntimeException e) {
+            log.error("{} 단계 동기화 실패", syncType, e);
+            syncLogRepository.save(SyncLog.builder()
+                    .syncType(syncType)
+                    .status(SyncStatus.FAILED)
+                    .creditsUsed(0)
+                    .errorMessage(e.getMessage())
+                    .startedAt(startedAt)
+                    .finishedAt(LocalDateTime.now())
+                    .build());
+            return null;
+        }
+    }
+}

--- a/Pokade/src/main/resources/application-dev.yaml
+++ b/Pokade/src/main/resources/application-dev.yaml
@@ -27,6 +27,9 @@ spring:
         options:
           model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
 
+sync:
+  enabled: false
+
 pokade:
   ai:
     grade:

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -53,7 +53,7 @@ class CardControllerTest {
                 .assertThat()
                 .hasStatusOk()
                 .bodyJson()
-                .extractingPath("$.content[0].name").isEqualTo("Charizard");
+                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
     }
 
     @Test
@@ -87,9 +87,30 @@ class CardControllerTest {
                 .uri("/api/cards/1")
                 .assertThat()
                 .hasStatusOk();
-        result.bodyJson().extractingPath("$.name").isEqualTo("Charizard");
-        result.bodyJson().extractingPath("$.expansion.id").isEqualTo("base1");
-        result.bodyJson().extractingPath("$.variants[0].variantName").isEqualTo("unlimitedHolofoil");
+        result.bodyJson().extractingPath("$.data.name").isEqualTo("Charizard");
+        result.bodyJson().extractingPath("$.data.expansion.id").isEqualTo("base1");
+        result.bodyJson().extractingPath("$.data.variants[0].variantName").isEqualTo("unlimitedHolofoil");
+    }
+
+    @Test
+    @DisplayName("t5 카드 상세조회 응답은 status/code/msg/data 형태의 ApiResponse 구조를 따른다")
+    void t5() {
+        CardDetailResponse.ExpansionSummary expansion = new CardDetailResponse.ExpansionSummary(
+                "base1", "Base", "Base", "BS", 102, LocalDate.of(1999, 1, 9), null, null);
+        CardDetailResponse detail = new CardDetailResponse(
+                1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), "Mitsuhiro Arita", "4/102", null, null, null,
+                expansion, List.of());
+        given(cardService.getDetail(1L)).willReturn(detail);
+
+        var result = mockMvcTester.get()
+                .uri("/api/cards/1")
+                .assertThat()
+                .hasStatusOk();
+        result.bodyJson().extractingPath("$.status").isEqualTo(200);
+        result.bodyJson().extractingPath("$.code").isEqualTo("OK");
+        result.bodyJson().extractingPath("$.msg").isNotNull();
+        result.bodyJson().extractingPath("$.data.name").isEqualTo("Charizard");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/sync/client/MockScrydexClientTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/client/MockScrydexClientTest.java
@@ -1,0 +1,77 @@
+package com.pokade.domain.sync.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardPriceDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+
+class MockScrydexClientTest {
+
+    private final MockScrydexClient client = new MockScrydexClient();
+
+    @Test
+    @DisplayName("t1 data.sql과 동일한 8개의 세트를 반환한다")
+    void t1() {
+        List<ExpansionDto> expansions = client.fetchExpansions();
+
+        assertThat(expansions).hasSize(8);
+        assertThat(expansions)
+                .filteredOn(e -> e.id().equals("base1"))
+                .singleElement()
+                .satisfies(e -> {
+                    assertThat(e.name()).isEqualTo("Base");
+                    assertThat(e.total()).isEqualTo(102);
+                });
+    }
+
+    @Test
+    @DisplayName("t2 세트 ID로 조회하면 해당 세트에 속한 카드만 반환한다")
+    void t2() {
+        List<CardDto> cards = client.fetchCards("base1");
+
+        assertThat(cards)
+                .extracting(CardDto::externalId)
+                .containsExactlyInAnyOrder("base1-4", "base1-2", "base1-58");
+        assertThat(cards).allMatch(c -> c.expansionId().equals("base1"));
+    }
+
+    @Test
+    @DisplayName("t3 존재하지 않는 세트 ID로 조회하면 빈 목록을 반환한다")
+    void t3() {
+        List<CardDto> cards = client.fetchCards("no-such-expansion");
+
+        assertThat(cards).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t4 카드 ID로 조회하면 대표 변형 1개를 반환한다")
+    void t4() {
+        List<CardVariantDto> variants = client.fetchCardVariants("base1-4");
+
+        assertThat(variants).singleElement().satisfies(v -> {
+            assertThat(v.variantName()).isEqualTo("unlimitedHolofoil");
+            assertThat(v.primary()).isTrue();
+            assertThat(v.cardExternalId()).isEqualTo("base1-4");
+        });
+    }
+
+    @Test
+    @DisplayName("t5 변형 ID로 조회하면 PSA 10등급/9등급 시세 2건을 반환한다")
+    void t5() {
+        CardVariantDto variant = client.fetchCardVariants("base1-4").get(0);
+
+        List<CardPriceDto> prices = client.fetchCardPrices(variant.variantId());
+
+        assertThat(prices)
+                .extracting(CardPriceDto::grade)
+                .containsExactlyInAnyOrder("10", "9");
+        assertThat(prices).allMatch(p -> p.company().equals("PSA") && p.priceType().equals("graded"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/sync/repository/SyncLogRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/repository/SyncLogRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.pokade.domain.sync.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import com.pokade.domain.sync.entity.SyncLog;
+import com.pokade.domain.sync.entity.type.SyncStatus;
+import com.pokade.domain.sync.entity.type.SyncType;
+import com.pokade.support.AbstractIntegrationTest;
+
+@DataJpaTest
+class SyncLogRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private SyncLogRepository syncLogRepository;
+
+    @Test
+    @DisplayName("t1 특정 동기화 타입이 성공으로 기록되어 있으면 존재 여부가 true다")
+    void t1() {
+        syncLogRepository.save(SyncLog.builder()
+                .syncType(SyncType.EXPANSION)
+                .status(SyncStatus.SUCCESS)
+                .recordsSynced(8)
+                .creditsUsed(0)
+                .startedAt(LocalDateTime.now())
+                .finishedAt(LocalDateTime.now())
+                .build());
+
+        boolean exists = syncLogRepository.existsBySyncTypeAndStatus(SyncType.EXPANSION, SyncStatus.SUCCESS);
+
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("t2 실패로만 기록된 타입은 SUCCESS 존재 여부가 false다")
+    void t2() {
+        syncLogRepository.save(SyncLog.builder()
+                .syncType(SyncType.CARD_VARIANT)
+                .status(SyncStatus.FAILED)
+                .errorMessage("scrydex 응답 오류")
+                .creditsUsed(0)
+                .startedAt(LocalDateTime.now())
+                .finishedAt(LocalDateTime.now())
+                .build());
+
+        boolean exists = syncLogRepository.existsBySyncTypeAndStatus(SyncType.CARD_VARIANT, SyncStatus.SUCCESS);
+
+        assertThat(exists).isFalse();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/sync/service/SyncServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/service/SyncServiceTest.java
@@ -1,0 +1,133 @@
+package com.pokade.domain.sync.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.pokade.domain.sync.client.ScrydexClient;
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardPriceDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+import com.pokade.domain.sync.entity.SyncLog;
+import com.pokade.domain.sync.entity.type.SyncStatus;
+import com.pokade.domain.sync.entity.type.SyncType;
+import com.pokade.domain.sync.repository.SyncLogRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SyncServiceTest {
+
+    @Mock
+    private ScrydexClient scrydexClient;
+
+    @Mock
+    private SyncLogRepository syncLogRepository;
+
+    @InjectMocks
+    private SyncService syncService;
+
+    @Captor
+    private ArgumentCaptor<SyncLog> syncLogCaptor;
+
+    private ExpansionDto expansion;
+    private CardDto card;
+    private CardVariantDto variant;
+    private CardPriceDto price;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(syncService, "syncEnabled", true);
+
+        expansion = new ExpansionDto("base1", "Base", "Base", null, 102, "EN", null);
+        card = new CardDto("base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), "4/102", "base1");
+        variant = new CardVariantDto("base1-4-unlimitedHolofoil", "base1-4", "unlimitedHolofoil", true);
+        price = new CardPriceDto("base1-4-unlimitedHolofoil", "graded", "10", "PSA",
+                BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, "USD");
+    }
+
+    @Test
+    @DisplayName("t1 sync.enabled=false이면 아무 단계도 실행하지 않는다")
+    void t1() {
+        ReflectionTestUtils.setField(syncService, "syncEnabled", false);
+
+        syncService.sync();
+
+        verify(scrydexClient, never()).fetchExpansions();
+        verify(syncLogRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("t2 4단계 모두 성공하면 각 단계마다 SUCCESS 로그를 순서대로 기록한다")
+    void t2() {
+        given(scrydexClient.fetchExpansions()).willReturn(List.of(expansion));
+        given(scrydexClient.fetchCards("base1")).willReturn(List.of(card));
+        given(scrydexClient.fetchCardVariants("base1-4")).willReturn(List.of(variant));
+        given(scrydexClient.fetchCardPrices("base1-4-unlimitedHolofoil")).willReturn(List.of(price));
+
+        syncService.sync();
+
+        verify(syncLogRepository, times(4)).save(syncLogCaptor.capture());
+        List<SyncLog> logs = syncLogCaptor.getAllValues();
+        assertThat(logs).extracting(SyncLog::getSyncType)
+                .containsExactly(SyncType.EXPANSION, SyncType.CARD, SyncType.CARD_VARIANT, SyncType.PRICE);
+        assertThat(logs).allMatch(l -> l.getStatus() == SyncStatus.SUCCESS);
+        assertThat(logs).extracting(SyncLog::getRecordsSynced).containsExactly(1, 1, 1, 1);
+    }
+
+    @Test
+    @DisplayName("t3 중간 단계(CARD_VARIANT)에서 실패하면 실패 기록을 남기고 이후 단계(PRICE)는 진행하지 않는다")
+    void t3() {
+        given(scrydexClient.fetchExpansions()).willReturn(List.of(expansion));
+        given(scrydexClient.fetchCards("base1")).willReturn(List.of(card));
+        given(scrydexClient.fetchCardVariants("base1-4")).willThrow(new RuntimeException("scrydex 응답 오류"));
+
+        syncService.sync();
+
+        verify(syncLogRepository, times(3)).save(syncLogCaptor.capture());
+        List<SyncLog> logs = syncLogCaptor.getAllValues();
+        assertThat(logs).extracting(SyncLog::getSyncType)
+                .containsExactly(SyncType.EXPANSION, SyncType.CARD, SyncType.CARD_VARIANT);
+        assertThat(logs.get(2).getStatus()).isEqualTo(SyncStatus.FAILED);
+        assertThat(logs.get(2).getErrorMessage()).contains("scrydex 응답 오류");
+        verify(scrydexClient, never()).fetchCardPrices(any());
+    }
+
+    @Test
+    @DisplayName("t4 이미 성공한 단계는 재실행 시 로그를 다시 남기지 않고 다음 단계부터 재개한다")
+    void t4() {
+        given(syncLogRepository.existsBySyncTypeAndStatus(SyncType.EXPANSION, SyncStatus.SUCCESS)).willReturn(true);
+        given(syncLogRepository.existsBySyncTypeAndStatus(SyncType.CARD, SyncStatus.SUCCESS)).willReturn(true);
+        given(scrydexClient.fetchExpansions()).willReturn(List.of(expansion));
+        given(scrydexClient.fetchCards("base1")).willReturn(List.of(card));
+        given(scrydexClient.fetchCardVariants("base1-4")).willReturn(List.of(variant));
+        given(scrydexClient.fetchCardPrices("base1-4-unlimitedHolofoil")).willReturn(List.of(price));
+
+        syncService.sync();
+
+        verify(scrydexClient).fetchExpansions();
+        verify(scrydexClient).fetchCards("base1");
+        verify(syncLogRepository, times(2)).save(syncLogCaptor.capture());
+        List<SyncLog> logs = syncLogCaptor.getAllValues();
+        assertThat(logs).extracting(SyncLog::getSyncType)
+                .containsExactly(SyncType.CARD_VARIANT, SyncType.PRICE);
+        assertThat(logs).allMatch(l -> l.getStatus() == SyncStatus.SUCCESS);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #26

## ✨ 작업 내용
- CardController 응답을 ApiResponse<T>로 래핑
- Scrydex 동기화 배치 구조 구현

## 📸 스크린샷 / 테스트 결과
- 전체 테스트 통과 (MockScrydexClientTest 5, SyncServiceTest 4, SyncLogRepositoryTest 2 신규 포함)

## 🔍 리뷰 포인트
- 응답 구조 변경: Page<CardResponse> → {status,code,msg,data:{...}} — FE는 아직 목업 제거 전이라 영향 없음
- GlobalExceptionHandler(에러 응답)는 여전히 ErrorResponse — 범위 밖
- 실제 DB upsert는 범위 밖, 구조+로그 기록까지만
- SyncType.CARD_VARIANT는 schema.sql 주석에 없던 값 추가

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?