### PR TITLE
[Feature] #31 카드 키워드 검색 + 유사 카드 추천 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.card.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -25,16 +27,27 @@ public class CardController {
 
     @GetMapping
     public ApiResponse<Page<CardResponse>> search(
-            @RequestParam(required = false) String name,
             @RequestParam(required = false) String types,
             @RequestParam(required = false) String rarity,
             @RequestParam(required = false) String expansionId,
             @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(cardService.search(name, types, rarity, expansionId, pageable));
+        return ApiResponse.ok(cardService.search(types, rarity, expansionId, pageable));
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<Page<CardResponse>> searchByKeyword(
+            @RequestParam(required = false) String q,
+            @PageableDefault(size = 20) Pageable pageable) {
+        return ApiResponse.ok(cardService.searchByKeyword(q, pageable));
     }
 
     @GetMapping("/{id}")
     public ApiResponse<CardDetailResponse> detail(@PathVariable Long id) {
         return ApiResponse.ok(cardService.getDetail(id));
+    }
+
+    @GetMapping("/{id}/related")
+    public ApiResponse<List<CardResponse>> related(@PathVariable Long id) {
+        return ApiResponse.ok(cardService.getRelated(id));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.card.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,22 +14,42 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     @Query(value = """
             SELECT c.* FROM cards c WHERE
-            (:name IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :name, '%'))) AND
             (:types IS NULL OR CAST(:types AS text) = ANY(c.types)) AND
             (:rarity IS NULL OR c.rarity = :rarity) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             countQuery = """
             SELECT COUNT(*) FROM cards c WHERE
-            (:name IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :name, '%'))) AND
             (:types IS NULL OR CAST(:types AS text) = ANY(c.types)) AND
             (:rarity IS NULL OR c.rarity = :rarity) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             nativeQuery = true)
-    Page<Card> search(@Param("name") String name,
-                       @Param("types") String types,
+    Page<Card> search(@Param("types") String types,
                        @Param("rarity") String rarity,
                        @Param("expansionId") String expansionId,
                        Pageable pageable);
+
+    Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);
+
+    @Query(value = """
+            SELECT c.* FROM cards c
+            JOIN cards src ON src.id = :id
+            WHERE c.id <> :id
+            AND c.national_pokedex_numbers && src.national_pokedex_numbers
+            ORDER BY c.name
+            LIMIT 20
+            """,
+            nativeQuery = true)
+    List<Card> findRelatedByPokedexNumber(@Param("id") Long id);
+
+    @Query(value = """
+            SELECT c.* FROM cards c
+            WHERE c.id <> :excludeCardId
+            AND c.expansion_id = :expansionId
+            ORDER BY c.name
+            LIMIT 20
+            """,
+            nativeQuery = true)
+    List<Card> findRelatedByExpansion(@Param("expansionId") String expansionId, @Param("excludeCardId") Long excludeCardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -52,9 +52,14 @@ public class CardService {
     public List<CardResponse> getRelated(Long id) {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
-        List<Card> related = hasPokedexNumber(card)
-                ? cardRepository.findRelatedByPokedexNumber(id)
-                : cardRepository.findRelatedByExpansion(card.getExpansion().getId(), id);
+        List<Card> related;
+        if (hasPokedexNumber(card)) {
+            related = cardRepository.findRelatedByPokedexNumber(id);
+        } else if (card.getExpansion() != null) {
+            related = cardRepository.findRelatedByExpansion(card.getExpansion().getId(), id);
+        } else {
+            related = List.of();
+        }
         return related.stream()
                 .map(CardResponse::from)
                 .toList();

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -26,8 +26,8 @@ public class CardService {
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(String name, String types, String rarity, String expansionId, Pageable pageable) {
-        return cardRepository.search(name, types, rarity, expansionId, pageable)
+    public Page<CardResponse> search(String types, String rarity, String expansionId, Pageable pageable) {
+        return cardRepository.search(types, rarity, expansionId, pageable)
                 .map(CardResponse::from);
     }
 
@@ -37,5 +37,30 @@ public class CardService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
         return CardDetailResponse.of(card, variants);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CardResponse> searchByKeyword(String q, Pageable pageable) {
+        if (q == null || q.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        return cardRepository.findByNameContainingIgnoreCase(q.trim(), pageable)
+                .map(CardResponse::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CardResponse> getRelated(Long id) {
+        Card card = cardRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+        List<Card> related = hasPokedexNumber(card)
+                ? cardRepository.findRelatedByPokedexNumber(id)
+                : cardRepository.findRelatedByExpansion(card.getExpansion().getId(), id);
+        return related.stream()
+                .map(CardResponse::from)
+                .toList();
+    }
+
+    private boolean hasPokedexNumber(Card card) {
+        return card.getNationalPokedexNumbers() != null && !card.getNationalPokedexNumbers().isEmpty();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -9,6 +9,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -28,6 +33,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
@@ -36,6 +42,19 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 );
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -45,11 +45,11 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1");
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq("char"), eq("Fire"), eq("Rare Holo"), eq("base1"), any(Pageable.class)))
+        given(cardService.search(eq("Fire"), eq("Rare Holo"), eq("base1"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
-                .uri("/api/cards?name=char&types=Fire&rarity=Rare Holo&expansionId=base1")
+                .uri("/api/cards?types=Fire&rarity=Rare Holo&expansionId=base1")
                 .assertThat()
                 .hasStatusOk()
                 .bodyJson()
@@ -61,7 +61,7 @@ class CardControllerTest {
     void t2() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -120,6 +120,78 @@ class CardControllerTest {
 
         mockMvcTester.get()
                 .uri("/api/cards/999")
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("CARD_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("t6 검색어로 카드 이름 키워드 검색을 하면 200과 페이지 결과를 반환한다")
+    void t6() {
+        CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), null, null, "base1");
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardService.searchByKeyword(eq("char"), any(Pageable.class))).willReturn(page);
+
+        mockMvcTester.get()
+                .uri("/api/cards/search?q=char")
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t7 검색어 없이 키워드 검색을 요청하면 400을 반환한다")
+    void t7() {
+        willThrow(new BusinessException(ErrorCode.INVALID_INPUT))
+                .given(cardService).searchByKeyword(eq(null), any(Pageable.class));
+
+        mockMvcTester.get()
+                .uri("/api/cards/search")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("INVALID_INPUT");
+    }
+
+    @Test
+    @DisplayName("t8 존재하는 카드 id로 유사 카드를 조회하면 200과 목록을 반환한다")
+    void t8() {
+        CardResponse related = new CardResponse(2L, "sv3pt5-6", "Charizard ex", "151", "Double Rare", "Pokémon",
+                List.of("Fire"), null, null, "sv3pt5");
+        given(cardService.getRelated(1L)).willReturn(List.of(related));
+
+        mockMvcTester.get()
+                .uri("/api/cards/1/related")
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.data[0].name").isEqualTo("Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t9 유사 카드가 없으면 200과 빈 목록을 반환한다")
+    void t9() {
+        given(cardService.getRelated(1L)).willReturn(List.of());
+
+        mockMvcTester.get()
+                .uri("/api/cards/1/related")
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.data").isEmpty();
+    }
+
+    @Test
+    @DisplayName("t10 존재하지 않는 카드 id로 유사 카드를 조회하면 404를 반환한다")
+    void t10() {
+        willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND)).given(cardService).getRelated(999L);
+
+        mockMvcTester.get()
+                .uri("/api/cards/999/related")
                 .assertThat()
                 .hasStatus(HttpStatus.NOT_FOUND)
                 .bodyJson()

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -28,15 +28,23 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Autowired
     private EntityManager entityManager;
 
+    private Card charizard;
+    private Card charizardEx;
+    private Card professorsResearch;
+    private Card quickBall;
+
     @BeforeEach
     void setUp() {
         Expansion base1 = persistExpansion("base1", "Base");
         Expansion sv3pt5 = persistExpansion("sv3pt5", "151");
+        Expansion swsh1 = persistExpansion("swsh1", "Sword & Shield");
 
-        persistCard("Charizard", "Rare Holo", base1, "Fire");
-        persistCard("Blastoise", "Rare Holo", base1, "Water");
-        persistCard("Pikachu", "Common", base1, "Lightning");
-        persistCard("Charizard ex", "Double Rare", sv3pt5, "Fire");
+        charizard = persistCard("Charizard", "Rare Holo", base1, "Fire", List.of(6));
+        persistCard("Blastoise", "Rare Holo", base1, "Water", List.of(9));
+        persistCard("Pikachu", "Common", base1, "Lightning", List.of(25));
+        charizardEx = persistCard("Charizard ex", "Double Rare", sv3pt5, "Fire", List.of(6));
+        professorsResearch = persistTrainerCard("Professor's Research", base1);
+        quickBall = persistTrainerCard("Quick Ball", swsh1);
     }
 
     private Expansion persistExpansion(String id, String name) {
@@ -49,20 +57,33 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         return expansion;
     }
 
-    private void persistCard(String name, String rarity, Expansion expansion, String type) {
+    private Card persistCard(String name, String rarity, Expansion expansion, String type, List<Integer> pokedexNumbers) {
         Card card = Card.builder()
                 .name(name)
                 .rarity(rarity)
+                .supertype("Pokémon")
                 .expansion(expansion)
-                .types(List.of(type))
+                .types(type != null ? List.of(type) : null)
+                .nationalPokedexNumbers(pokedexNumbers)
                 .build();
         entityManager.persist(card);
+        return card;
+    }
+
+    private Card persistTrainerCard(String name, Expansion expansion) {
+        Card card = Card.builder()
+                .name(name)
+                .supertype("Trainer")
+                .expansion(expansion)
+                .build();
+        entityManager.persist(card);
+        return card;
     }
 
     @Test
-    @DisplayName("t1 이름에 검색어가 포함된 카드를 부분 일치로 조회한다")
+    @DisplayName("t1 이름 키워드에 부분 일치하는 카드를 대소문자 구분 없이 조회한다")
     void t1() {
-        Page<Card> result = cardRepository.search("char", null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.findByNameContainingIgnoreCase("CHAR", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -72,7 +93,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
-        Page<Card> result = cardRepository.search(null, "Fire", null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search("Fire", null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -82,7 +103,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t3 rarity가 정확히 일치하는 카드만 조회한다")
     void t3() {
-        Page<Card> result = cardRepository.search(null, null, "Common", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, "Common", null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -92,7 +113,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t4 expansionId가 정확히 일치하는 카드만 조회한다")
     void t4() {
-        Page<Card> result = cardRepository.search(null, null, null, "sv3pt5", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, "sv3pt5", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -102,7 +123,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 여러 조건을 조합하면 AND로 필터링된다")
     void t5() {
-        Page<Card> result = cardRepository.search("char", "Fire", null, "base1", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search("Fire", null, "base1", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -112,10 +133,54 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t6 조건이 없으면 전체 카드를 페이지 크기만큼 반환한다")
     void t6() {
-        Page<Card> result = cardRepository.search(null, null, null, null, PageRequest.of(0, 2));
+        Page<Card> result = cardRepository.search(null, null, null, PageRequest.of(0, 2));
 
         assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getTotalElements()).isEqualTo(4);
-        assertThat(result.getTotalPages()).isEqualTo(2);
+        assertThat(result.getTotalElements()).isEqualTo(6);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("t7 같은 포켓몬 도감번호를 가진 다른 카드를 유사 카드로 조회한다")
+    void t7() {
+        List<Card> result = cardRepository.findRelatedByPokedexNumber(charizard.getId());
+
+        assertThat(result)
+                .extracting(Card::getName)
+                .containsExactly("Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t8 유사 카드 조회 결과에서 자기 자신은 제외된다")
+    void t8() {
+        List<Card> result = cardRepository.findRelatedByPokedexNumber(charizard.getId());
+
+        assertThat(result).extracting(Card::getId).doesNotContain(charizard.getId());
+    }
+
+    @Test
+    @DisplayName("t9 도감번호가 없는 카드는 유사 카드 조회 결과가 빈 목록이다")
+    void t9() {
+        List<Card> result = cardRepository.findRelatedByPokedexNumber(professorsResearch.getId());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t10 같은 세트에 속한 다른 카드를 유사 카드로 조회한다")
+    void t10() {
+        List<Card> result = cardRepository.findRelatedByExpansion("base1", professorsResearch.getId());
+
+        assertThat(result)
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Charizard", "Blastoise", "Pikachu");
+    }
+
+    @Test
+    @DisplayName("t11 같은 세트에 다른 카드가 없으면 유사 카드 조회 결과가 빈 목록이다")
+    void t11() {
+        List<Card> result = cardRepository.findRelatedByExpansion("swsh1", quickBall.getId());
+
+        assertThat(result).isEmpty();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -211,6 +211,19 @@ class CardServiceTest {
     }
 
     @Test
+    @DisplayName("t12 트레이너 카드인데 세트 정보(expansion)가 없으면 빈 목록을 반환한다")
+    void t12() {
+        Card card = Card.builder().id(1L).name("Professor's Research").build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).isEmpty();
+        verify(cardRepository, never()).findRelatedByPokedexNumber(any());
+        verify(cardRepository, never()).findRelatedByExpansion(any(), any());
+    }
+
+    @Test
     @DisplayName("t11 존재하지 않는 id로 유사 카드를 조회하면 CARD_NOT_FOUND 예외가 발생한다")
     void t11() {
         given(cardRepository.findById(999L)).willReturn(Optional.empty());

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -2,7 +2,10 @@ package com.pokade.domain.card.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -51,9 +54,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search("char", "Fire", "Rare Holo", "base1", pageable)).willReturn(page);
+        given(cardRepository.search("Fire", "Rare Holo", "base1", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search("char", "Fire", "Rare Holo", "base1", pageable);
+        Page<CardResponse> result = cardService.search("Fire", "Rare Holo", "base1", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -106,6 +109,113 @@ class CardServiceTest {
         given(cardRepository.findById(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> cardService.getDetail(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("t4 이름 키워드로 검색하면 리포지토리에 위임하고 결과를 응답 DTO 목록으로 변환한다")
+    void t4() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("Charizard")
+                .types(List.of("Fire"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.searchByKeyword("char", pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t5 검색어가 없으면 INVALID_INPUT 예외가 발생한다")
+    void t5() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        assertThatThrownBy(() -> cardService.searchByKeyword(null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t6 검색어가 공백뿐이면 INVALID_INPUT 예외가 발생한다")
+    void t6() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        assertThatThrownBy(() -> cardService.searchByKeyword("   ", pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t7 포켓몬 카드(도감번호 있음)는 도감번호 겹침 기준으로 유사 카드를 조회한다")
+    void t7() {
+        Card card = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
+        Card related = Card.builder().id(2L).name("Charizard ex").build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByPokedexNumber(1L)).willReturn(List.of(related));
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("Charizard ex");
+        verify(cardRepository, never()).findRelatedByExpansion(any(), any());
+    }
+
+    @Test
+    @DisplayName("t8 포켓몬 카드인데 도감번호가 겹치는 카드가 없으면 빈 목록을 반환한다")
+    void t8() {
+        Card card = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByPokedexNumber(1L)).willReturn(List.of());
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t9 트레이너 카드(도감번호 없음)는 같은 세트 기준으로 유사 카드를 조회한다")
+    void t9() {
+        Expansion expansion = Expansion.builder().id("base1").name("Base").syncedAt(LocalDateTime.now()).build();
+        Card card = Card.builder().id(1L).name("Professor's Research").expansion(expansion).build();
+        Card related = Card.builder().id(2L).name("Charizard").build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByExpansion("base1", 1L)).willReturn(List.of(related));
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).name()).isEqualTo("Charizard");
+        verify(cardRepository, never()).findRelatedByPokedexNumber(any());
+    }
+
+    @Test
+    @DisplayName("t10 트레이너 카드인데 같은 세트에 다른 카드가 없으면 빈 목록을 반환한다")
+    void t10() {
+        Expansion expansion = Expansion.builder().id("swsh1").name("Sword & Shield").syncedAt(LocalDateTime.now()).build();
+        Card card = Card.builder().id(1L).name("Quick Ball").expansion(expansion).build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByExpansion("swsh1", 1L)).willReturn(List.of());
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t11 존재하지 않는 id로 유사 카드를 조회하면 CARD_NOT_FOUND 예외가 발생한다")
+    void t11() {
+        given(cardRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> cardService.getRelated(999L))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.CARD_NOT_FOUND);


### PR DESCRIPTION
## 📌 관련 이슈
- #31

## ✨ 작업 내용
- 카드 키워드 검색 API 구현 (`GET /api/cards/search?q=`)
- 기존 `GET /api/cards`에서 `name` 파라미터 제거 (필터 검색 전용으로 정리)
- 유사 카드 추천 API 구현 (`GET /api/cards/{id}/related`)
- CORS 설정 추가 (FE `localhost:3000` → BE `localhost:8080` 연동용)

## 📸 스크린샷 / 테스트 결과
- 전체 테스트 통과 (CardControllerTest, CardServiceTest, CardRepositoryTest)
- FE `/search` 페이지 실제 API 연동 확인 완료

## 🔍 리뷰 포인트
- API 스펙 변경(FE 영향): `GET /api/cards`의 `name` 파라미터가 제거됐습니다.
  이름 검색은 `GET /api/cards/search?q=`를 사용해야 합니다.
- 유사 카드 판단 기준: 도감번호(포켓몬 카드) 있으면 그걸로, 없으면(트레이너/에너지)
  같은 세트(`expansion_id`) 기준으로 대체. 세트 정보도 없으면 빈 목록 반환(NPE 방지)
- 유사 카드 개수 제한 20건, 정렬 이름순 — 스펙에 명시 없어 임의 설정, 필요시 조정
- `q` 파라미터 특수문자 검증은 기존 검색과 동일 수준(추가 이스케이프 없음)
- CORS 설정(공유 파일, `SecurityConfig`): `http://localhost:3000` 오리진 허용,
  토큰이 쿠키 기반이라 `allowCredentials(true)`도 포함. 기존 permitAll 목록은
  변경 없음. 배포 도메인 추가 시 `allowedOrigins`에 실제 주소 추가 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?