### PR TITLE
[Feature] #25 이메일 인증 코드 발송 기능 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/EmailVerificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/EmailVerificationController.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.auth.controller;
+
+import com.pokade.domain.auth.dto.request.EmailSendRequest;
+import com.pokade.domain.auth.service.EmailVerificationService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/email")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/send")
+    public ApiResponse<Void> send(@Valid @RequestBody EmailSendRequest request) {
+        emailVerificationService.send(request.email());
+        return ApiResponse.ok("이메일 인증 코드가 발송되었습니다.");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/EmailSendRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/EmailSendRequest.java
@@ -1,0 +1,11 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailSendRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
@@ -1,0 +1,37 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.mail.MailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final UserRepository userRepository;
+    private final VerificationCodeStore codeStore;
+    private final VerificationCodeGenerator codeGenerator;
+    private final MailSender mailSender;
+
+    public void send(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.PENDING) {
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_VERIFIED);
+        }
+
+        if(codeStore.isRecentlySent(email)) {
+            throw new BusinessException(ErrorCode.EMAIL_SEND_RATE_LIMITED);
+        }
+        String code = codeGenerator.generate();
+        codeStore.save(email, code);
+        mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -1,0 +1,30 @@
+package com.pokade.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisVerificationCodeStore implements VerificationCodeStore {
+
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration COOLDOWN_TTL = Duration.ofSeconds(60);
+    private static final String CODE_KEY_PREFIX = "auth:verify:code:";
+    private static final String COOLDOWN_KEY_PREFIX = "auth:verify:cooldown:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public boolean isRecentlySent(String email) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(COOLDOWN_KEY_PREFIX + email));
+    }
+
+    @Override
+    public void save(String email, String code) {
+        redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
+        redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeGenerator.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeGenerator.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class VerificationCodeGenerator {
+
+    private final SecureRandom random = new SecureRandom();
+
+    public String generate() {
+        return String.format("%06d", random.nextInt(1_000_000));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
@@ -1,0 +1,6 @@
+package com.pokade.domain.auth.service;
+
+public interface VerificationCodeStore {
+    boolean isRecentlySent(String email);
+    void save(String email, String code);
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
     EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
     EMAIL_CODE_MISMATCH(HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),

--- a/Pokade/src/main/java/com/pokade/global/infra/mail/MailSender.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/mail/MailSender.java
@@ -1,0 +1,5 @@
+package com.pokade.global.infra.mail;
+
+public interface MailSender {
+    void send(String to, String subject, String body);
+}

--- a/Pokade/src/main/java/com/pokade/global/infra/mail/SmtpMailSender.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/mail/SmtpMailSender.java
@@ -1,0 +1,29 @@
+package com.pokade.global.infra.mail;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SmtpMailSender implements MailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void send(String to, String subject, String body) {
+        try{
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(to);
+            message.setSubject(subject);
+            message.setText(body);
+            javaMailSender.send(message);
+        } catch (MailException e) {
+            throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+}

--- a/Pokade/src/main/resources/application-dev.yaml
+++ b/Pokade/src/main/resources/application-dev.yaml
@@ -27,6 +27,18 @@ spring:
         options:
           model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
@@ -1,0 +1,53 @@
+package com.pokade.domain.auth.controller;
+
+import com.pokade.domain.auth.service.EmailVerificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@WebMvcTest(EmailVerificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EmailVerificationControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @MockitoBean
+    private EmailVerificationService emailVerificationService;
+
+    @Test
+    @DisplayName("유효한 이메일이면 200과 함께 인증 코드 발송 서비스를 호출한다.")
+    void send_ok() {
+        mockMvcTester.post()
+                .uri("/api/auth/email/send")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"user@pokade.com\"}")
+                .assertThat()
+                .hasStatusOk();
+
+        then(emailVerificationService).should().send("user@pokade.com");
+    }
+
+    @Test
+    @DisplayName("이메일 형식이 잘못되면 400을 반환하고 서비스를 호출하지 않는다.")
+    void send_invalidEmail() {
+        mockMvcTester.post()
+                .uri("/api/auth/email/send")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"not-an-email\"}")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+
+        then(emailVerificationService).should(never()).send(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,0 +1,121 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.infra.mail.MailSender;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+
+@ExtendWith(MockitoExtension.class)
+public class EmailVerificationServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    VerificationCodeStore codeStore;
+    @Mock
+    VerificationCodeGenerator codeGenerator;
+    @Mock
+    MailSender mailSender;
+    @InjectMocks
+    EmailVerificationService emailVerificationService;
+
+    private User pendingUser(String email) {
+        return User.createLocalUser(email, "ENCODED_PW", "닉네임");
+    }
+
+    private User activeUser(String email) {
+        return User.builder()
+                .email(email)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 생성한 인증 코드를 저장소에 저장한다.")
+    void send_storesGeneratedCode() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(false);
+        given(codeGenerator.generate()).willReturn("123456");
+
+        emailVerificationService.send(email);
+
+        then(codeStore).should().save(email, "123456");
+    }
+
+    @Test
+    @DisplayName("60초 내 재요청이면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenRecentlySent() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(true);
+
+        assertThatThrownBy(() -> emailVerificationService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_RATE_LIMITED);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 USER_NOT_FOUND 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenUserNotFound() {
+        String email = "unknown@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> emailVerificationService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("이미 인증 완료(ACTIVE)된 회원이면 EMAIL_ALREADY_VERIFIED 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenAlreadyVerified() {
+        String email = "active@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeUser(email)));
+
+        assertThatThrownBy(() -> emailVerificationService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_ALREADY_VERIFIED);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 생성한 코드로 인증 메일을 발송한다")
+    void send_sendsVerificationEmail() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(false);
+        given(codeGenerator.generate()).willReturn("123456");
+
+        emailVerificationService.send(email);
+
+        then(mailSender).should().send(eq(email), anyString(), contains("123456"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
@@ -1,0 +1,45 @@
+package com.pokade.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataRedisTest
+@Testcontainers
+@Import(RedisVerificationCodeStore.class)
+public class RedisVerificationCodeStoreTest {
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @Autowired
+    RedisVerificationCodeStore store;
+
+    @Test
+    @DisplayName("save하면 isRecentlySent가 true, 저장 전엔 false")
+    void isRecentlySent_reflectsSave() {
+        String email = "user@pokade.com";
+        assertThat(store.isRecentlySent(email)).isFalse();
+
+        store.save(email, "123456");
+
+        assertThat(store.isRecentlySent(email)).isTrue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/VerificationCodeGeneratorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/VerificationCodeGeneratorTest.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VerificationCodeGeneratorTest {
+
+    private final VerificationCodeGenerator generator = new VerificationCodeGenerator();
+
+    @RepeatedTest(20)
+    @DisplayName("6자리 숫자 코드를 생성한다 (앞자리 0 포함)")
+    void generatesSixDigitNumericCode() {
+        String code = generator.generate();
+
+        assertThat(code).matches("\\d{6}"); // 정확히 숫자 6자리
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/infra/mail/SmtpMailSenderTest.java
+++ b/Pokade/src/test/java/com/pokade/global/infra/mail/SmtpMailSenderTest.java
@@ -1,0 +1,55 @@
+package com.pokade.global.infra.mail;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+public class SmtpMailSenderTest {
+
+    @Mock
+    JavaMailSender javaMailSender;
+    @InjectMocks
+    SmtpMailSender smtpMailSender;
+
+    @Test
+    @DisplayName("수신자·제목·본문을 담은 메일을 전송한다")
+    void send_deliversMessage() {
+        smtpMailSender.send("user@pokade.com", "제목", "본문");
+
+        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+        then(javaMailSender).should().send(captor.capture());
+
+        SimpleMailMessage sent = captor.getValue();
+        assertThat(sent.getTo()).containsExactly("user@pokade.com");
+        assertThat(sent.getSubject()).isEqualTo("제목");
+        assertThat(sent.getText()).isEqualTo("본문");
+    }
+
+    @Test
+    @DisplayName("메일 서버 전송 실패 시 EMAIL_SEND_FAILED 예외를 던진다")
+    void send_throwsWhenMailFails() {
+        willThrow(new MailSendException("smtp down"))
+                .given(javaMailSender).send(any(SimpleMailMessage.class));
+
+        assertThatThrownBy(() -> smtpMailSender.send("user@pokade.com", "제목", "본문"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_FAILED);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #25

## ✨ 작업 내용
회원가입 시 이메일 소유 확인을 위한 **인증 코드 발송** 기능을 구현했습니다.

- `POST /api/auth/email/send` API 추가 — 가입 대기(PENDING) 회원에게 6자리 인증 코드 발송
- **발송 정책 / 검증 로직**
  - 가입되지 않은 이메일 → `USER_NOT_FOUND`
  - 이미 인증된(PENDING 아님) 회원 → `EMAIL_ALREADY_VERIFIED`
  - 60초 이내 재요청 → `EMAIL_SEND_RATE_LIMITED` (쿨다운)
- **인증 코드 저장소 (Redis)**
  - 인증 코드 TTL 5분, 재발송 쿨다운 60초
  - `VerificationCodeStore` 인터페이스 + `RedisVerificationCodeStore` 구현으로 분리
- **메일 발송 인프라**
  - `MailSender` 포트 + `SmtpMailSender`(Gmail SMTP) 어댑터 구조로 구현
  - `application-dev.yaml`에 Gmail SMTP 설정 추가
- 6자리 숫자 인증 코드 생성기(`VerificationCodeGenerator`) 추가
- 컨트롤러 / 서비스 / 저장소 / 메일 전 계층 테스트 작성

## 📸 스크린샷 / 테스트 결과
- 로컬 빌드 및 테스트 성공 (`./gradlew compileJava compileTestJava` → BUILD SUCCESSFUL)

## 🔍 리뷰 포인트
- 메일 발송을 `MailSender`(포트) / `SmtpMailSender`(어댑터)로 분리한 구조가 적절한지
- 재발송 쿨다운 60초 / 코드 만료 5분 정책이 적당한지
- 인증 상태 검증(PENDING만 발송 허용) 흐름이 회원가입 로직과 잘 맞물리는지
- 참고: **코드 검증(verify) 엔드포인트는 이 PR 범위에 포함되지 않았고 후속 PR로 진행 예정**입니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?