### PR TITLE
[Feature] #23 즉시구매/판매가 조회 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingGrade.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingGrade.java
@@ -3,5 +3,8 @@ package com.pokade.domain.listing;
 public enum ListingGrade {
     S,
     A,
-    B
+    B,
+    PSA10,
+    PSA9,
+    PSA8
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.controller;
 
 import com.pokade.domain.price.dto.PriceSummaryResponse;
+import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/prices")
@@ -22,5 +25,10 @@ public class PriceController {
             @RequestParam(required = false) Long variantId
     ) {
         return priceService.getSummary(cardId, variantId);
+    }
+
+    @GetMapping("/{cardId}/trades")
+    public List<TradeSummaryResponse> getRecentTrades(@PathVariable Long cardId) {
+        return priceService.getRecentTrades(cardId);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -3,6 +3,7 @@ package com.pokade.domain.price.controller;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
+import com.pokade.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,15 +21,15 @@ public class PriceController {
     private final PriceService priceService;
 
     @GetMapping("/{cardId}/summary")
-    public PriceSummaryResponse getSummary(
+    public ApiResponse<PriceSummaryResponse> getSummary(
             @PathVariable Long cardId,
             @RequestParam(required = false) Long variantId
     ) {
-        return priceService.getSummary(cardId, variantId);
+        return ApiResponse.ok(priceService.getSummary(cardId, variantId));
     }
 
     @GetMapping("/{cardId}/trades")
-    public List<TradeSummaryResponse> getRecentTrades(@PathVariable Long cardId) {
-        return priceService.getRecentTrades(cardId);
+    public ApiResponse<List<TradeSummaryResponse>> getRecentTrades(@PathVariable Long cardId) {
+        return ApiResponse.ok(priceService.getRecentTrades(cardId));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/TradeSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/TradeSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.pokade.domain.price.dto;
+
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.trade.Trade;
+
+import java.time.LocalDateTime;
+
+public record TradeSummaryResponse(
+        LocalDateTime tradedAt,
+        Integer price,
+        ListingGrade grade
+) {
+
+    public static TradeSummaryResponse of(Trade trade) {
+        return new TradeSummaryResponse(
+                trade.getConfirmedAt(),
+                trade.getPrice(),
+                trade.getListing().getGrade()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -5,12 +5,18 @@ import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.ListingRepository;
 import com.pokade.domain.listing.ListingStatus;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
+import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.trade.TradeRepository;
+import com.pokade.domain.trade.TradeStatus;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +24,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class PriceService {
 
     private static final String CURRENCY = "KRW";
+    private static final int RECENT_TRADES_LIMIT = 20;
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final ListingRepository listingRepository;
     private final BuyOfferRepository buyOfferRepository;
+    private final TradeRepository tradeRepository;
 
     public PriceSummaryResponse getSummary(Long cardId, Long variantId) {
         if (!cardRepository.existsById(cardId)) {
@@ -40,5 +48,17 @@ public class PriceService {
         Integer sellPrice = buyOfferRepository.findHighestActivePrice(cardId, resolvedVariantId).orElse(null);
 
         return new PriceSummaryResponse(buyPrice, sellPrice, CURRENCY);
+    }
+
+    public List<TradeSummaryResponse> getRecentTrades(Long cardId) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
+        return tradeRepository
+                .findRecentCompletedTrades(cardId, TradeStatus.COMPLETED, PageRequest.of(0, RECENT_TRADES_LIMIT))
+                .stream()
+                .map(TradeSummaryResponse::of)
+                .toList();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/TradeRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/TradeRepository.java
@@ -1,6 +1,18 @@
 package com.pokade.domain.trade;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
+
+    @Query("SELECT t FROM Trade t JOIN FETCH t.listing l "
+            + "WHERE l.cardId = :cardId AND t.status = :status "
+            + "ORDER BY t.confirmedAt DESC")
+    List<Trade> findRecentCompletedTrades(@Param("cardId") Long cardId,
+                                           @Param("status") TradeStatus status,
+                                           Pageable pageable);
 }

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -93,6 +93,8 @@ INSERT INTO card_prices (variant_id, price_type, grade, company, low, mid, high,
 -- =========================================================
 
 -- 재기동 시 중복 방지 (테스트 데이터만 정리)
+-- trades가 listings를 FK로 참조하므로 자식(trades)부터 삭제
+DELETE FROM trades;
 DELETE FROM buy_offers;
 DELETE FROM listings;
 
@@ -196,3 +198,64 @@ VALUES (
        );
 
 -- Charizard ex sv3pt5-6 : 매도·매수 모두 없음 (양쪽 빈 값 검증용, 의도적으로 데이터 없음)
+
+-- =========================================================
+-- FR-PRICE-02 검증용 시드 (trades — status='COMPLETED')
+-- =========================================================
+
+-- ---------- listings (체결 완료된 매물 3건, 등급별 확인용) ----------
+
+-- Charizard base1-4 : PSA10 등급, 5,000,000원에 체결
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           5000000, 'PSA10', 'SOLD', now() - interval '1 day', now() - interval '1 day'
+       );
+
+-- Charizard base1-4 : 자체 AI등급 S, 3,000,000원에 체결
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3000000, 'S', 'SOLD', now() - interval '3 days', now() - interval '3 days'
+       );
+
+-- Charizard base1-4 : 등급 없음(RAW), 2,500,000원에 체결
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2500000, NULL, 'SOLD', now() - interval '10 days', now() - interval '10 days'
+       );
+
+-- ---------- trades (체결 완료, 최신순 정렬 검증용으로 confirmed_at 스태거) ----------
+
+-- PSA10 매물 체결 (1일 전 - 가장 최근)
+INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_at, created_at)
+VALUES (
+           (SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 5000000 AND grade = 'PSA10'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           5000000, 'COMPLETED', now() - interval '1 day', now() - interval '1 day', now() - interval '1 day'
+       );
+
+-- S등급 매물 체결 (3일 전)
+INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_at, created_at)
+VALUES (
+           (SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 3000000 AND grade = 'S'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           3000000, 'COMPLETED', now() - interval '3 days', now() - interval '3 days', now() - interval '3 days'
+       );
+
+-- RAW(등급 없음) 매물 체결 (10일 전 - 가장 오래됨)
+INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_at, created_at)
+VALUES (
+           (SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 2500000 AND grade IS NULL),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           2500000, 'COMPLETED', now() - interval '10 days', now() - interval '10 days', now() - interval '10 days'
+       );
+
+-- Charizard ex sv3pt5-6 : 체결 이력 없음 (빈 목록 검증용, 의도적으로 데이터 없음)

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -179,6 +179,10 @@ CREATE TABLE IF NOT EXISTS trades (
     created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- 카드별 체결 내역 조회(FR-PRICE-02, listings.card_id 조인) 최적화
+CREATE INDEX IF NOT EXISTS idx_listings_card_id ON listings(card_id);
+CREATE INDEX IF NOT EXISTS idx_trades_listing_status ON trades(listing_id, status, confirmed_at DESC);
+
 CREATE TABLE IF NOT EXISTS payments (
     id            BIGSERIAL PRIMARY KEY,
     trade_id      BIGINT NOT NULL UNIQUE REFERENCES trades(id),

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -1,0 +1,69 @@
+package com.pokade.domain.price.controller;
+
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.price.dto.TradeSummaryResponse;
+import com.pokade.domain.price.service.PriceService;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PriceController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PriceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PriceService priceService;
+
+    @Test
+    void 체결_내역이_있으면_200과_최신순_목록을_반환한다() throws Exception {
+        List<TradeSummaryResponse> trades = List.of(
+                new TradeSummaryResponse(LocalDateTime.now().minusDays(1), 5000000, ListingGrade.PSA10),
+                new TradeSummaryResponse(LocalDateTime.now().minusDays(3), 3000000, ListingGrade.S),
+                new TradeSummaryResponse(LocalDateTime.now().minusDays(10), 2500000, null)
+        );
+        given(priceService.getRecentTrades(1L)).willReturn(trades);
+
+        mockMvc.perform(get("/api/prices/1/trades"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(3))
+                .andExpect(jsonPath("$[0].grade").value("PSA10"))
+                .andExpect(jsonPath("$[0].price").value(5000000))
+                .andExpect(jsonPath("$[2].grade").value(nullValue()));
+    }
+
+    @Test
+    void 체결_이력이_없으면_200과_빈_목록을_반환한다() throws Exception {
+        given(priceService.getRecentTrades(1L)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/prices/1/trades"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void 존재하지_않는_카드면_404를_반환한다() throws Exception {
+        given(priceService.getRecentTrades(999L))
+                .willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        mockMvc.perform(get("/api/prices/999/trades"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CARD_NOT_FOUND"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -42,10 +42,10 @@ class PriceControllerTest {
 
         mockMvc.perform(get("/api/prices/1/trades"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(3))
-                .andExpect(jsonPath("$[0].grade").value("PSA10"))
-                .andExpect(jsonPath("$[0].price").value(5000000))
-                .andExpect(jsonPath("$[2].grade").value(nullValue()));
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].grade").value("PSA10"))
+                .andExpect(jsonPath("$.data[0].price").value(5000000))
+                .andExpect(jsonPath("$.data[2].grade").value(nullValue()));
     }
 
     @Test
@@ -54,7 +54,7 @@ class PriceControllerTest {
 
         mockMvc.perform(get("/api/prices/1/trades"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/trade/TradeRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/TradeRepositoryTest.java
@@ -1,0 +1,152 @@
+package com.pokade.domain.trade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.listing.ListingRepository;
+import com.pokade.domain.user.entity.User;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class TradeRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private TradeRepository tradeRepository;
+
+    @Autowired
+    private ListingRepository listingRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Long cardId;
+    private Long buyerId;
+
+    @BeforeEach
+    void setUp() {
+        Card card = Card.builder().name("Charizard").build();
+        entityManager.persist(card);
+        cardId = card.getId();
+
+        User seller = User.createLocalUser("trade-seller@test.com", "hashed", "seller");
+        User buyer = User.createLocalUser("trade-buyer@test.com", "hashed", "buyer");
+        entityManager.persist(seller);
+        entityManager.persist(buyer);
+        buyerId = buyer.getId();
+    }
+
+    private Listing persistListing(Long sellerId, int price, ListingGrade grade) {
+        return listingRepository.save(
+                Listing.builder()
+                        .cardId(cardId)
+                        .sellerId(sellerId)
+                        .price(price)
+                        .grade(grade)
+                        .build()
+        );
+    }
+
+    private Trade persistCompletedTrade(Listing listing, LocalDateTime confirmedAt) {
+        Trade trade = tradeRepository.save(
+                Trade.builder()
+                        .listing(listing)
+                        .buyerId(buyerId)
+                        .price(listing.getPrice())
+                        .build()
+        );
+        trade.complete();
+        entityManager.flush();
+        // complete()는 confirmed_at을 항상 now()로 고정하므로, 정렬 검증을 위해 원하는 시각으로 직접 덮어씀
+        entityManager.createNativeQuery("UPDATE trades SET confirmed_at = :confirmedAt WHERE id = :id")
+                .setParameter("confirmedAt", confirmedAt)
+                .setParameter("id", trade.getId())
+                .executeUpdate();
+        entityManager.clear();
+        return trade;
+    }
+
+    @Test
+    @DisplayName("t1 체결 완료 건이 여러 개면 confirmed_at 최신순으로 조회된다")
+    void t1() {
+        Long sellerId = ((Number) entityManager.createNativeQuery(
+                "SELECT id FROM users WHERE email = 'trade-seller@test.com'").getSingleResult()).longValue();
+
+        Listing psa10 = persistListing(sellerId, 5000000, ListingGrade.PSA10);
+        Listing s = persistListing(sellerId, 3000000, ListingGrade.S);
+        Listing raw = persistListing(sellerId, 2500000, null);
+
+        persistCompletedTrade(psa10, LocalDateTime.now().minusDays(1));
+        persistCompletedTrade(s, LocalDateTime.now().minusDays(3));
+        persistCompletedTrade(raw, LocalDateTime.now().minusDays(10));
+
+        List<Trade> result = tradeRepository.findRecentCompletedTrades(
+                cardId, TradeStatus.COMPLETED, PageRequest.of(0, 20));
+
+        assertThat(result)
+                .extracting(t -> t.getListing().getGrade())
+                .containsExactly(ListingGrade.PSA10, ListingGrade.S, null);
+    }
+
+    @Test
+    @DisplayName("t2 COMPLETED가 아닌 거래는 조회되지 않는다")
+    void t2() {
+        Long sellerId = ((Number) entityManager.createNativeQuery(
+                "SELECT id FROM users WHERE email = 'trade-seller@test.com'").getSingleResult()).longValue();
+
+        Listing listing = persistListing(sellerId, 1000000, ListingGrade.A);
+        tradeRepository.save(
+                Trade.builder().listing(listing).buyerId(buyerId).price(1000000).build()
+        );
+
+        List<Trade> result = tradeRepository.findRecentCompletedTrades(
+                cardId, TradeStatus.COMPLETED, PageRequest.of(0, 20));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t3 Pageable로 상위 N건만 조회된다")
+    void t3() {
+        Long sellerId = ((Number) entityManager.createNativeQuery(
+                "SELECT id FROM users WHERE email = 'trade-seller@test.com'").getSingleResult()).longValue();
+
+        Listing first = persistListing(sellerId, 1000000, ListingGrade.A);
+        Listing second = persistListing(sellerId, 2000000, ListingGrade.B);
+        Listing third = persistListing(sellerId, 3000000, ListingGrade.S);
+
+        persistCompletedTrade(first, LocalDateTime.now().minusDays(1));
+        persistCompletedTrade(second, LocalDateTime.now().minusDays(2));
+        persistCompletedTrade(third, LocalDateTime.now().minusDays(3));
+
+        List<Trade> result = tradeRepository.findRecentCompletedTrades(
+                cardId, TradeStatus.COMPLETED, PageRequest.of(0, 2));
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("t4 체결 이력이 없는 카드는 빈 목록을 반환한다")
+    void t4() {
+        Card otherCard = Card.builder().name("Pikachu").build();
+        entityManager.persist(otherCard);
+
+        List<Trade> result = tradeRepository.findRecentCompletedTrades(
+                otherCard.getId(), TradeStatus.COMPLETED, PageRequest.of(0, 20));
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #23 

## ✨ 작업 내용
- 최근 체결 내역 조회 API 구현 (GET /api/prices/{cardId}/trades)
  - 카드 기준 COMPLETED 상태 거래(trades)를 체결일시(tradedAt) 최신순 최대 20건 반환
  - 체결 이력이 없으면 빈 배열 반환
  - grade는 체결된 매물(listing)의 등급을 그대로 사용 (자체 AI등급 S/A/B 또는 무등급=RAW, 또는 PSA10/9/8 등 공인등급)
- 응답 DTO TradeSummaryResponse 추가 (tradedAt / price / grade)
- TradeRepository에 카드별 최근 체결 내역 조회 쿼리 추가 (listing fetch join, status=COMPLETED 필터)
- ListingGrade enum 값 보강
- FR-PRICE-02 검증용 시드 데이터 추가 (data.sql) — base1-4(Charizard) 카드에 PSA10/S/RAW 등급으로 SOLD 매물 3건 + COMPLETED 거래 3건(1/3/10일 전 staggered)

## 📸 스크린샷 / 테스트 결과
- 로컬 ./gradlew test 전체 통과 (기존 테스트 포함 회귀 없음 확인)
- PriceControllerTest / TradeRepositoryTest 신규 작성 및 통과
- dev 프로파일 기동 후 Swagger/curl로 실제 응답 확인
 - GET /api/prices/{cardId}/trades → PSA10/S/RAW 3건, 최신순 정상 반환
 - 체결 이력 없는 카드 → 빈 배열 반환
 - 존재하지 않는 cardId → 404 (BusinessException/CARD_NOT_FOUND) 정상 처리

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?