### PR TITLE
[Feature] 매물 수정/삭제 API 구현 (FR-TRADE-04, FR-TRADE-05)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -59,5 +60,15 @@ public class ListingController {
             @Valid @RequestBody ListingUpdateRequest request
     ) {
         return ResponseEntity.ok(listingService.updatePrice(sellerId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteListing(
+            // TODO: 인증 파트 완성되면 SecurityContext에서 sellerId 추출하는 방식으로 교체
+            @RequestHeader("X-USER-ID") Long sellerId,
+            @PathVariable Long id
+    ) {
+        listingService.deleteListing(sellerId, id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -3,12 +3,15 @@ package com.pokade.domain.listing;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -46,5 +49,15 @@ public class ListingController {
             @RequestParam(required = false) ListingStatus status
     ) {
         return ResponseEntity.ok(listingService.getMyListings(sellerId, status));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ListingResponse> updateListing(
+            // TODO: 인증 파트 완성되면 SecurityContext에서 sellerId 추출하는 방식으로 교체
+            @RequestHeader("X-USER-ID") Long sellerId,
+            @PathVariable Long id,
+            @Valid @RequestBody ListingUpdateRequest request
+    ) {
+        return ResponseEntity.ok(listingService.updatePrice(sellerId, id, request));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -3,6 +3,7 @@ package com.pokade.domain.listing;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,28 @@ public class ListingService {
         return listings.stream()
                 .map(ListingSummaryResponse::of)
                 .toList();
+    }
+
+    @Transactional
+    public ListingResponse updatePrice(Long sellerId, Long listingId, ListingUpdateRequest request) {
+        Listing listing = getOwnedListing(sellerId, listingId);
+
+        listing.changePrice(request.price());
+
+        List<String> imageUrls = listing.getImages().stream()
+                .map(ListingImage::getImageUrl)
+                .toList();
+        return ListingResponse.of(listing, imageUrls);
+    }
+
+    private Listing getOwnedListing(Long sellerId, Long listingId) {
+        Listing listing = listingRepository.findById(listingId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.LISTING_NOT_FOUND));
+
+        if (!listing.getSellerId().equals(sellerId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+        return listing;
     }
 
     private void validateNotDuplicate(Long sellerId, Long cardId, Long variantId) {

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -69,6 +69,12 @@ public class ListingService {
         return ListingResponse.of(listing, imageUrls);
     }
 
+    @Transactional
+    public void deleteListing(Long sellerId, Long listingId) {
+        Listing listing = getOwnedListing(sellerId, listingId);
+        listing.cancel();
+    }
+
     private Listing getOwnedListing(Long sellerId, Long listingId) {
         Listing listing = listingRepository.findById(listingId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.LISTING_NOT_FOUND));

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.pokade.domain.listing.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record ListingUpdateRequest(
+        @NotNull(message = "price는 필수입니다.")
+        @Positive(message = "price는 0보다 커야 합니다.")
+        Integer price
+) {
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
@@ -20,8 +21,12 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -151,5 +156,118 @@ class ListingControllerTest {
                         .param("status", "SOLD"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].status").value("SOLD"));
+    }
+
+    @Test
+    void 매물_수정에_성공하면_200과_수정된_매물을_반환한다() throws Exception {
+        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingResponse response = new ListingResponse(
+                1L, 1L, 100L, null, 20000, ListingGrade.A, ListingStatus.ACTIVE,
+                List.of("https://example.com/a.png"), LocalDateTime.now());
+
+        given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/api/listings/1")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.price").value(20000));
+    }
+
+    @Test
+    void 수정시_가격이_없으면_400을_반환한다() throws Exception {
+        ListingUpdateRequest invalidRequest = new ListingUpdateRequest(null);
+
+        mockMvc.perform(put("/api/listings/1")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void ACTIVE_상태가_아니면_수정시_400을_반환한다() throws Exception {
+        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+
+        given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.INVALID_LISTING_STATUS));
+
+        mockMvc.perform(put("/api/listings/1")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_LISTING_STATUS"));
+    }
+
+    @Test
+    void 본인_매물이_아니면_수정시_403을_반환한다() throws Exception {
+        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+
+        given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.ACCESS_DENIED));
+
+        mockMvc.perform(put("/api/listings/1")
+                        .header("X-USER-ID", 999L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void 존재하지_않는_매물_수정시_404를_반환한다() throws Exception {
+        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+
+        given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));
+
+        mockMvc.perform(put("/api/listings/999")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LISTING_NOT_FOUND"));
+    }
+
+    @Test
+    void 매물_삭제에_성공하면_204를_반환한다() throws Exception {
+        willDoNothing().given(listingService).deleteListing(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/listings/1").header("X-USER-ID", 100L))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void ACTIVE_상태가_아니면_삭제시_400을_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INVALID_LISTING_STATUS))
+                .given(listingService).deleteListing(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/listings/1").header("X-USER-ID", 100L))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_LISTING_STATUS"));
+    }
+
+    @Test
+    void 본인_매물이_아니면_삭제시_403을_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.ACCESS_DENIED))
+                .given(listingService).deleteListing(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/listings/1").header("X-USER-ID", 999L))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void 존재하지_않는_매물_삭제시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND))
+                .given(listingService).deleteListing(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/listings/999").header("X-USER-ID", 100L))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LISTING_NOT_FOUND"));
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #29 

## ✨ 작업 내용
 - FR-TRADE-04 매물 가격 수정: `PUT /api/listings/{id}`                                                                                 
    - `ListingUpdateRequest` DTO 추가 (price 필수/양수 검증)                                                                             
    - `ListingService.updatePrice()` — 존재하지 않는 매물 404, 본인 매물 아니면 403, ACTIVE 아니면 400(`Listing.changePrice()` 가드      
  재사용)                                                                                                                                
  - FR-TRADE-05 매물 삭제: `DELETE /api/listings/{id}`                                                                                   
    - `ListingService.deleteListing()` — 위와 동일한 검증 + `Listing.cancel()` 호출, 성공 시 204 No Content                              
  - 두 기능 모두 소유권 확인 로직을 `getOwnedListing()` private 헬퍼로 공통화                                                            
  - sellerId는 기존과 동일하게 `X-USER-ID` 헤더로 임시 수신 (인증 파트 완료 후 교체 예정)                                                
                                                                                                                                         
  ## 📸 스크린샷 / 테스트 결과                                                                                                           

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
 - 명세에는 403(본인 아님)이 명시돼 있지 않았지만, 소유권 체크 없이는 남의 매물도 수정/삭제 가능해지므로 추가했습니다. 방향 맞는지 확인 
  부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?