### PR TITLE
[Feature] #34 이메일 인증 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/EmailVerificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/EmailVerificationController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.auth.controller;
 
 import com.pokade.domain.auth.dto.request.EmailSendRequest;
+import com.pokade.domain.auth.dto.request.EmailVerifyRequest;
 import com.pokade.domain.auth.service.EmailVerificationService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -21,5 +22,11 @@ public class EmailVerificationController {
     public ApiResponse<Void> send(@Valid @RequestBody EmailSendRequest request) {
         emailVerificationService.send(request.email());
         return ApiResponse.ok("이메일 인증 코드가 발송되었습니다.");
+    }
+
+    @PostMapping("/verify")
+    public ApiResponse<Void> verify(@Valid @RequestBody EmailVerifyRequest request) {
+        emailVerificationService.verify(request.email(), request.code());
+        return ApiResponse.ok("이메일 인증이 완료되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/EmailVerifyRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/EmailVerifyRequest.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailVerifyRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "인증 코드는 6자리 숫자여야 합니다.")
+        String code
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
@@ -8,6 +8,7 @@ import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.mail.MailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -18,6 +19,8 @@ public class EmailVerificationService {
     private final VerificationCodeStore codeStore;
     private final VerificationCodeGenerator codeGenerator;
     private final MailSender mailSender;
+
+    private static final int MAX_VERIFY_ATTEMPTS = 5;
 
     public void send(String email) {
         User user = userRepository.findByEmail(email)
@@ -33,5 +36,30 @@ public class EmailVerificationService {
         String code = codeGenerator.generate();
         codeStore.save(email, code);
         mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
+    }
+
+    @Transactional
+    public void verify(String email, String code) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getStatus() != UserStatus.PENDING) {
+            throw new BusinessException(ErrorCode.EMAIL_ALREADY_VERIFIED);
+        }
+
+        if(codeStore.getAttemptCount(email) >= MAX_VERIFY_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.EMAIL_VERIFY_ATTEMPT_EXCEEDED);
+        }
+
+        String storedCode = codeStore.find(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_CODE_EXPIRED));
+
+        if(!storedCode.equals(code)) {
+            codeStore.incrementAttempt(email);
+            throw new BusinessException(ErrorCode.EMAIL_CODE_MISMATCH);
+        }
+
+        user.verifyEmail();
+        codeStore.delete(email);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     private static final Duration COOLDOWN_TTL = Duration.ofSeconds(60);
     private static final String CODE_KEY_PREFIX = "auth:verify:code:";
     private static final String COOLDOWN_KEY_PREFIX = "auth:verify:cooldown:";
+    private static final String ATTEMPT_KEY_PREFIX = "auth:verify:attempt:";
 
     private final StringRedisTemplate redisTemplate;
 
@@ -26,5 +28,31 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     public void save(String email, String code) {
         redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
         redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+    }
+
+    @Override
+    public Optional<String> find(String email) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(CODE_KEY_PREFIX + email));
+    }
+
+    @Override
+    public long getAttemptCount(String email) {
+        String value = redisTemplate.opsForValue().get(ATTEMPT_KEY_PREFIX + email);
+        return value != null ? Long.parseLong(value) : 0;
+    }
+
+    @Override
+    public void incrementAttempt(String email) {
+        Long count = redisTemplate.opsForValue().increment(ATTEMPT_KEY_PREFIX + email);
+        if (count != null && count == 1) {
+            redisTemplate.expire(ATTEMPT_KEY_PREFIX + email, CODE_TTL);
+        }
+    }
+
+    @Override
+    public void delete(String email) {
+        redisTemplate.delete(CODE_KEY_PREFIX + email);
+        redisTemplate.delete(COOLDOWN_KEY_PREFIX + email);
+        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
@@ -1,6 +1,12 @@
 package com.pokade.domain.auth.service;
 
+import java.util.Optional;
+
 public interface VerificationCodeStore {
     boolean isRecentlySent(String email);
     void save(String email, String code);
+    Optional<String> find (String email);
+    void delete(String email);
+    long getAttemptCount(String email); // 현재 실패 횟수 조회
+    void incrementAttempt(String email); // 실패시 +1
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -88,4 +88,8 @@ public class User {
                 .pointBalance(0)
                 .build();
     }
+
+    public void verifyEmail() {
+        this.status = UserStatus.ACTIVE;
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
@@ -50,4 +50,30 @@ class EmailVerificationControllerTest {
 
         then(emailVerificationService).should(never()).send(any());
     }
+
+    @Test
+    @DisplayName("유효한 이메일과 6자리 코드면 200과 함께 인증 서비스를 호출한다.")
+    void verify_ok() {
+        mockMvcTester.post()
+                .uri("/api/auth/email/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"user@pokade.com\",\"code\":\"123456\"}")
+                .assertThat()
+                .hasStatusOk();
+
+        then(emailVerificationService).should().verify("user@pokade.com", "123456");
+    }
+
+    @Test
+    @DisplayName("코드 형식이 6자리 숫자가 아니면 400을 반환하고 서비스를 호출하지 않는다.")
+    void verify_invalidCode() {
+        mockMvcTester.post()
+                .uri("/api/auth/email/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"user@pokade.com\",\"code\":\"12ab\"}")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+
+        then(emailVerificationService).should(never()).verify(any(), any());
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -117,5 +118,92 @@ public class EmailVerificationServiceTest {
         emailVerificationService.send(email);
 
         then(mailSender).should().send(eq(email), anyString(), contains("123456"));
+    }
+
+    @Test
+    @DisplayName("코드가 일치하면 회원 상태를 ACTIVE로 전환하고 저장된 코드를 삭제한다")
+    void verify_activatesUserAndDeletesCode() {
+        String email = "user@pokade.com";
+        User user = pendingUser(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(codeStore.find(email)).willReturn(Optional.of("123456"));
+
+        emailVerificationService.verify(email, "123456");
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        then(codeStore).should().delete(email);
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 USER_NOT_FOUND 예외를 던지고 코드를 삭제하지 않는다")
+    void verify_rejectsWhenUserNotFound() {
+        String email = "unknown@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> emailVerificationService.verify(email, "123456"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("이미 인증 완료(ACTIVE)된 회원이면 EMAIL_ALREADY_VERIFIED 예외를 던지고 코드를 삭제하지 않는다")
+    void verify_rejectsWhenAlreadyVerified() {
+        String email = "active@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeUser(email)));
+
+        assertThatThrownBy(() -> emailVerificationService.verify(email, "123456"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_ALREADY_VERIFIED);
+
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("저장된 코드가 없으면(만료·미발송) EMAIL_CODE_EXPIRED 예외를 던지고 코드를 삭제하지 않는다")
+    void verify_rejectsWhenCodeExpired() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+        given(codeStore.find(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> emailVerificationService.verify(email, "123456"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_CODE_EXPIRED);
+
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("저장된 코드와 다르면 EMAIL_CODE_MISMATCH 예외를 던지고 상태 전환·삭제를 하지 않는다")
+    void verify_rejectsWhenCodeMismatch() {
+        String email = "user@pokade.com";
+        User user = pendingUser(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(codeStore.find(email)).willReturn(Optional.of("999999"));
+
+        assertThatThrownBy(() -> emailVerificationService.verify(email, "123456"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_CODE_MISMATCH);
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING);
+        then(codeStore).should().incrementAttempt(email);
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패 횟수가 최대치 이상이면 EMAIL_VERIFY_ATTEMPT_EXCEEDED 예외를 던지고 코드 조회조차 하지 않는다")
+    void verify_rejectsWhenAttemptExceeded() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+        given(codeStore.getAttemptCount(email)).willReturn(5L);
+
+        assertThatThrownBy(() -> emailVerificationService.verify(email, "123456"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_VERIFY_ATTEMPT_EXCEEDED);
+
+        then(codeStore).should(never()).find(any());
+        then(codeStore).should(never()).incrementAttempt(any());
+        then(codeStore).should(never()).delete(any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
@@ -42,4 +42,49 @@ public class RedisVerificationCodeStoreTest {
 
         assertThat(store.isRecentlySent(email)).isTrue();
     }
+
+    @Test
+    @DisplayName("save한 코드는 find로 조회되고, 저장 전엔 빈 Optional이다")
+    void find_returnsSavedCode() {
+        String email = "find@pokade.com";
+        assertThat(store.find(email)).isEmpty();
+
+        store.save(email, "123456");
+
+        assertThat(store.find(email)).contains("123456");
+    }
+
+    @Test
+    @DisplayName("delete하면 저장된 코드가 제거되어 find가 빈 Optional을 반환한다")
+    void delete_removesSavedCode() {
+        String email = "delete@pokade.com";
+        store.save(email, "123456");
+
+        store.delete(email);
+
+        assertThat(store.find(email)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("incrementAttempt를 호출한 만큼 getAttemptCount가 증가하고, 호출 전엔 0이다")
+    void incrementAttempt_increasesCount() {
+        String email = "attempt@pokade.com";
+        assertThat(store.getAttemptCount(email)).isZero();
+
+        store.incrementAttempt(email);
+        store.incrementAttempt(email);
+
+        assertThat(store.getAttemptCount(email)).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("delete하면 실패 카운터도 제거되어 getAttemptCount가 0이 된다")
+    void delete_resetsAttemptCount() {
+        String email = "attempt-del@pokade.com";
+        store.incrementAttempt(email);
+
+        store.delete(email);
+
+        assertThat(store.getAttemptCount(email)).isZero();
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #34 

## ✨ 작업 내용
- `POST /api/auth/email/verify` 엔드포인트 추가 (이메일 + 인증 코드 검증)
- `EmailVerifyRequest` DTO 추가 (email `@Email`, code `@Pattern \d{6}` 유효성 검증)
- `VerificationCodeStore`에 코드 조회/삭제 + 시도 횟수 카운터(`getAttemptCount`/`incrementAttempt`) 메서드 추가 및 Redis 구현
- `EmailVerificationService.verify()` 구현 — 검증 성공 시 사용자 상태 `PENDING`→`ACTIVE` 전환, 인증 코드·카운터 삭제
- `User` 엔티티에 상태 전환 도메인 메서드 `verifyEmail()` 추가 (`@Transactional` 변경 감지)
- 실패 처리: 코드 불일치(`EMAIL_CODE_MISMATCH`) / 만료·미발송(`EMAIL_CODE_EXPIRED`) / 시도 5회 초과 잠금(`EMAIL_VERIFY_ATTEMPT_EXCEEDED`)
- 전 계층 테스트 작성 (컨트롤러 / 서비스 / 저장소)

## 📸 스크린샷 / 테스트 결과
<!-- Swagger/Postman 응답 캡처 첨부 예정 -->
- `./gradlew test --tests "com.pokade.domain.auth.*"` → **BUILD SUCCESSFUL** (서비스 6 + 저장소 4 + 컨트롤러 3 통과)

## 🔍 리뷰 포인트
- **시도 횟수 제한 정책**: 최대 5회 / TTL 5분(코드와 동일 창) / 게이트 방식(5회 실패 후 다음 호출부터 차단). 성공 시 카운터 리셋. Redis `INCR`로 원자적 카운트.
- **재발송과 잠금 분리**: `send()`는 시도 카운터를 리셋하지 않음 → 재발송으로 잠금 우회 불가하도록 의도. (잠금 중 재발송 UX는 후속 이슈로 논의 예정)
- **상태 전환 방식**: setter 미개방 유지, 도메인 메서드 `verifyEmail()` + JPA 변경 감지로 UPDATE. 이 방향이 괜찮은지 확인 부탁.
- **검증 순서**: PENDING → 시도횟수 게이트 → 코드 존재(만료) → 일치 비교. 게이트를 코드 조회보다 앞에 둔 의도(잠긴 사용자는 조회 스킵) 검토 부탁.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? <!-- 해당 없음 -->