### PR TITLE
[Feature] #40 JWT 토큰 발급·검증 기반 구축

### DIFF
--- a/Pokade/build.gradle.kts
+++ b/Pokade/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     implementation("software.amazon.awssdk:s3:2.25.6")
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 }
 
 dependencyManagement {

--- a/Pokade/src/main/java/com/pokade/PokadeApplication.java
+++ b/Pokade/src/main/java/com/pokade/PokadeApplication.java
@@ -2,8 +2,10 @@ package com.pokade;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class PokadeApplication {
 
     public static void main(String[] args) {

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -1,24 +1,35 @@
 package com.pokade.global.config;
 
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtAuthenticationFilter;
 import jakarta.servlet.DispatcherType;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
+// Spring Security 설정 — 인증/인가 규칙, CORS, 비밀번호 인코더를 등록
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    // 인증 없이 접근을 허용할 경로 목록
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/**",
             "/swagger-ui/**",
@@ -29,21 +40,26 @@ public class SecurityConfig {
             "/api/ai/grade" // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
     };
 
+    // 보안 필터체인 — CSRF/CORS 설정과 경로별 인가 규칙을 정의
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .requestMatchers("/api/prices/**").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
+    // CORS 설정 — 프론트(localhost:3000)의 인증정보 포함 요청 허용
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
@@ -57,6 +73,7 @@ public class SecurityConfig {
         return source;
     }
 
+    // 비밀번호 해싱 인코더 (BCrypt)
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
     EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.pokade.global.security;
+
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    // 인증 안 된 요청이 보호된 경로 접근시 401 JSON 반환
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.UNAUTHORIZED))
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.pokade.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+// 요청 헤더의 JWT를 검증해, 유효하면 인증 정보를 SecurityContext에 등록하는 필터
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    // 매 요청마다 실행 — Authorization 헤더의 토큰을 확인해 인증 상태를 세팅
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (jwtTokenProvider.isValid(token)) {
+                Long userId = jwtTokenProvider.getUserId(token);
+                String role = jwtTokenProvider.getRole(token);
+                // 토큰이 유효하면 인증 객체를 만들어 SecurityContext에 등록
+                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/JwtProperties.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtProperties.java
@@ -1,0 +1,12 @@
+package com.pokade.global.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        Duration accessExpiration
+) {
+}

--- a/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
@@ -1,0 +1,69 @@
+package com.pokade.global.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+// JWT access token 발급·검증을 담당하는 컴포넌트
+@Component
+public class JwtTokenProvider {
+    private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+
+    // 시크릿 문자열로 서명용 SecretKey를 만들어 캐싱 (앱 기동 시 1회)
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes());
+    }
+
+    // access token 발급 (subject=userId, role 클레임을 담아 서명)
+    public String createAccessToken(Long userId, String role) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("role", role)
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.accessExpiration().toMillis()))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰의 서명·만료를 검증 (유효하면 true, 아니면 false)
+    public boolean isValid(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 토큰에서 userId(subject)를 추출 (실패 시 null)
+    public Long getUserId(String token) {
+        try {
+            return Long.parseLong(Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // 토큰에서 role 클레임을 추출
+    public String getRole(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("role", String.class);
+    }
+
+}

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -16,5 +16,5 @@ spring:
         format_sql: true
 
 jwt:
-  secret: ${JWT_SECRET:}
+  secret: ${JWT_SECRET}            # .env(spring.config.import)로 주입 — 미설정 시 부팅 실패(fail-fast)
   access-expiration: 30m

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -3,9 +3,18 @@ spring:
     name: Pokade
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
+  config:
+    import:
+      - optional:file:.env[.properties]
+      - optional:file:Pokade/.env[.properties]
+      - optional:file:BE/Pokade/.env[.properties]
 
   jpa:
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
+
+jwt:
+  secret: ${JWT_SECRET:}
+  access-expiration: 30m

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
@@ -1,0 +1,29 @@
+package com.pokade.global.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtAuthenticationEntryPointTest {
+
+    private final JwtAuthenticationEntryPoint entryPoint =
+            new JwtAuthenticationEntryPoint(new ObjectMapper());
+
+    @Test
+    @DisplayName("인증되지 않은 요청에 401과 UNAUTHORIZED JSON 응답을 반환한다")
+    void commence_writes401JsonResponse() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        entryPoint.commence(request, response, new InsufficientAuthenticationException("unauthorized"));
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentType()).contains("application/json");
+        assertThat(response.getContentAsString()).contains("UNAUTHORIZED");
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,91 @@
+package com.pokade.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class JwtAuthenticationFilterTest {
+
+    private static final String SECRET = "pokade-local-dev-jwt-secret-key-change-in-prod-0123456789";
+
+    private final JwtTokenProvider jwtTokenProvider =
+            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30)));
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("유효한 Bearer 토큰이면 SecurityContext에 인증 정보를 세팅한다")
+    void doFilterInternal_setsAuthenticationForValidToken() throws Exception {
+        String token = jwtTokenProvider.createAccessToken(42L, "USER");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getPrincipal()).isEqualTo(42L);
+        assertThat(auth.getAuthorities()).extracting("authority").containsExactly("ROLE_USER");
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 인증 없이 통과한다")
+    void doFilterInternal_skipsAuthenticationWhenNoHeader() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn(null);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Bearer 형식이 아닌 헤더면 인증 없이 통과한다")
+    void doFilterInternal_skipsAuthenticationWhenNotBearer() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Basic abc123");
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰이면 인증 없이 통과한다")
+    void doFilterInternal_skipsAuthenticationForInvalidToken() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer not-a-real-token");
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/JwtTokenProviderTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtTokenProviderTest.java
@@ -1,0 +1,52 @@
+package com.pokade.global.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "pokade-local-dev-jwt-secret-key-change-in-prod-0123456789";
+
+    private final JwtTokenProvider provider =
+            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30)));
+
+    @Test
+    @DisplayName("발급한 토큰은 유효하고, userId와 role을 그대로 복원한다")
+    void createAccessToken_isValidAndCarriesClaims() {
+        String token = provider.createAccessToken(42L, "USER");
+
+        assertThat(provider.isValid(token)).isTrue();
+        assertThat(provider.getUserId(token)).isEqualTo(42L);
+        assertThat(provider.getRole(token)).isEqualTo("USER");
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 isValid가 false를 반환한다")
+    void isValid_returnsFalseForExpiredToken() {
+        JwtTokenProvider expiredProvider =
+                new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofSeconds(-1)));
+        String expired = expiredProvider.createAccessToken(42L, "USER");
+
+        assertThat(provider.isValid(expired)).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명된(위조) 토큰은 isValid가 false를 반환한다")
+    void isValid_returnsFalseForForgedToken() {
+        JwtTokenProvider otherKeyProvider =
+                new JwtTokenProvider(new JwtProperties("another-completely-different-secret-key-0123456789", Duration.ofMinutes(30)));
+        String forged = otherKeyProvider.createAccessToken(42L, "USER");
+
+        assertThat(provider.isValid(forged)).isFalse();
+    }
+
+    @Test
+    @DisplayName("형식이 잘못된 문자열은 isValid가 false를 반환한다")
+    void isValid_returnsFalseForMalformedToken() {
+        assertThat(provider.isValid("not-a-real-token")).isFalse();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #40 

## ✨ 작업 내용
JWT 기반 인증의 **토대(토큰 발급·검증 기반)**를 구축했습니다. 로그인/리프레시/로그아웃(②③)은 이 위에 얹습니다.

- `io.jsonwebtoken:jjwt` 0.12.x 의존성 추가
- `application.yaml`에 JWT 설정(`jwt.secret: ${JWT_SECRET}`, `access-expiration: 30m`) 및 **`.env` 네이티브 로딩**(`spring.config.import`) 구성 — EnvFile 플러그인/dotenv 라이브러리 불필요
- `.env.example`에 `JWT_SECRET` 키 추가
- `JwtProperties`(@ConfigurationProperties) + `@ConfigurationPropertiesScan`으로 타입 안전 바인딩
- `JwtTokenProvider` — access token 발급(`sub`=userId, `role`) / 서명·만료 검증 / 클레임 추출
- `JwtAuthenticationFilter` — `Authorization: Bearer` 토큰 검증 후 SecurityContext에 인증 등록 (무효·누락 시 통과, 인가 판단은 SecurityConfig에 위임)
- `JwtAuthenticationEntryPoint` + `ErrorCode.UNAUTHORIZED` — 인증 실패 시 **401 JSON**(`ApiResponse.fail`) 응답
- `SecurityConfig` — `SessionCreationPolicy.STATELESS`, JWT 필터 등록(`addFilterBefore`), `exceptionHandling` 연결

## 📸 스크린샷 / 테스트 결과
<!-- 보호 경로 401 응답 캡처(curl/Postman) 첨부 -->
- `./gradlew test --tests "com.pokade.global.security.*"` → **BUILD SUCCESSFUL** (9개 통과)
  - `JwtTokenProviderTest` 4 (라운드트립 / 만료 / 위조 / 형식오류)
  - `JwtAuthenticationFilterTest` 4 (유효토큰 인증세팅 / 헤더없음 / non-Bearer / 무효토큰)
  - `JwtAuthenticationEntryPointTest` 1 (401 + UNAUTHORIZED JSON)

## 🔍 리뷰 포인트
- **토큰 전달 전략**: access token은 `Authorization` 헤더로 전달(응답 바디). refresh token/쿠키/Redis 저장·회전은 후속 이슈(②③).
- **시크릿 관리**: `jwt.secret: ${JWT_SECRET}`(기본값 없음)으로 `.env`에서 주입 — 미설정 시 부팅 실패(fail-fast). **커밋되는 시크릿 없음**, 운영은 배포 env로 주입. `.env`는 gitignore(팀원 각자 보유), `.env.example`로 필요 키 안내.
- **필터 책임 분리**: 필터는 "토큰 있으면 인증 세팅"만 하고 공개경로/차단 판단은 SecurityConfig가 담당(공개 경로 이중관리 방지).
- **통합 테스트 범위**: 현재는 컴포넌트 유닛 테스트 + 수동 401 확인. "보호경로→401 / 유효토큰→통과" end-to-end 통합 테스트는 로그인(②)에서 추가 예정.
- **403(권한부족) 처리**: 이번엔 401만. `AccessDeniedHandler`는 권한별 경로가 생기는 ②③에서.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? <!-- 해당 없음 -->