### PR TITLE
[Fix] #44 ObjectMapper 객체 생성 방식 변경

### DIFF
--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationEntryPoint.java
@@ -5,7 +5,6 @@ import com.pokade.global.response.ApiResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -14,10 +13,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     // 인증 안 된 요청이 보호된 경로 접근시 401 JSON 반환
     @Override

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationEntryPointTest.java
@@ -5,14 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JwtAuthenticationEntryPointTest {
 
-    private final JwtAuthenticationEntryPoint entryPoint =
-            new JwtAuthenticationEntryPoint(new ObjectMapper());
+    private final JwtAuthenticationEntryPoint entryPoint = new JwtAuthenticationEntryPoint();
 
     @Test
     @DisplayName("인증되지 않은 요청에 401과 UNAUTHORIZED JSON 응답을 반환한다")


### PR DESCRIPTION
## 📌 관련 이슈
- #44
- 후속: #40  — 해당 이슈 머지본에서 발생한 부팅 실패 수정

## ✨ 작업 내용
`JwtAuthenticationEntryPoint`가 `com.fasterxml.jackson.databind.ObjectMapper`를 **주입**받도록 되어 있었으나, Spring Boot 4가 자동 등록하는 ObjectMapper 빈은 Jackson 3(`tools.jackson`)뿐이라 해당 타입 빈을 찾지 못해 애플리케이션 부팅이 실패했습니다.

- `JwtAuthenticationEntryPoint` — ObjectMapper 주입 → **`new ObjectMapper()` 직접 생성**으로 변경, `@RequiredArgsConstructor` 제거
- `JwtAuthenticationEntryPointTest` — 무인자 생성자에 맞게 수정
- 프로젝트 표준(`com.fasterxml`)은 유지하되, `AiGradeService`와 동일하게 `new` 사용

## 📸 스크린샷 / 테스트 결과
- `./gradlew compileJava compileTestJava test --tests "com.pokade.global.security.*"` → **BUILD SUCCESSFUL** (9개 통과)
- 로컬 부팅 정상 확인 (`Started PokadeApplication`)
<!-- 부팅 로그 캡처 첨부 -->

## 🔍 리뷰 포인트
- **왜 주입이 아니라 `new`인가**: Boot 4 자동 등록 ObjectMapper 빈은 Jackson 3(`tools.jackson`) 뿐이라 `com.fasterxml` 타입 주입이 불가. 프로젝트는 `com.fasterxml` ObjectMapper를 `AiGradeService`처럼 `new`로만 사용 중이라 동일 방식으로 맞춤. (401 응답용 단순 직렬화라 Spring 커스텀 모듈 불필요)
- **원인 배경**: 직전 PR 리뷰 반영 중 import를 `tools.jackson`→`com.fasterxml`로 바꾸면서 발생. 주입 대상 빈 타입 불일치.
- **영향 범위**: `develop` 부팅 복구 목적. 병합 후 진행 중 feature 브랜치는 develop 리베이스 권장.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? <!-- 해당 없음 -->