### PR TITLE
[Feature] #38 카드 타입·레어도 필터 API 확장

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -27,8 +27,8 @@ public class CardController {
 
     @GetMapping
     public ApiResponse<Page<CardResponse>> search(
-            @RequestParam(required = false) String types,
-            @RequestParam(required = false) String rarity,
+            @RequestParam(required = false) List<String> types,
+            @RequestParam(required = false) List<String> rarity,
             @RequestParam(required = false) String expansionId,
             @PageableDefault(size = 20) Pageable pageable) {
         return ApiResponse.ok(cardService.search(types, rarity, expansionId, pageable));

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -14,21 +14,33 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     @Query(value = """
             SELECT c.* FROM cards c WHERE
-            (:types IS NULL OR CAST(:types AS text) = ANY(c.types)) AND
-            (:rarity IS NULL OR c.rarity = :rarity) AND
+            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
+            (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             countQuery = """
             SELECT COUNT(*) FROM cards c WHERE
-            (:types IS NULL OR CAST(:types AS text) = ANY(c.types)) AND
-            (:rarity IS NULL OR c.rarity = :rarity) AND
+            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
+            (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             nativeQuery = true)
-    Page<Card> search(@Param("types") String types,
-                       @Param("rarity") String rarity,
-                       @Param("expansionId") String expansionId,
-                       Pageable pageable);
+    Page<Card> searchInternal(@Param("hasTypes") boolean hasTypes,
+                               @Param("types") List<String> types,
+                               @Param("hasRarities") boolean hasRarities,
+                               @Param("rarities") List<String> rarities,
+                               @Param("expansionId") String expansionId,
+                               Pageable pageable);
+
+    default Page<Card> search(List<String> types, List<String> rarities, String expansionId, Pageable pageable) {
+        boolean hasTypes = types != null && !types.isEmpty();
+        boolean hasRarities = rarities != null && !rarities.isEmpty();
+        return searchInternal(
+                hasTypes, hasTypes ? types : List.of(""),
+                hasRarities, hasRarities ? rarities : List.of(""),
+                expansionId,
+                pageable);
+    }
 
     Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);
 

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -26,7 +26,7 @@ public class CardService {
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(String types, String rarity, String expansionId, Pageable pageable) {
+    public Page<CardResponse> search(List<String> types, List<String> rarity, String expansionId, Pageable pageable) {
         return cardRepository.search(types, rarity, expansionId, pageable)
                 .map(CardResponse::from);
     }

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -45,7 +45,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1");
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq("Fire"), eq("Rare Holo"), eq("base1"), any(Pageable.class)))
+        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), eq("base1"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -54,6 +54,21 @@ class CardControllerTest {
                 .hasStatusOk()
                 .bodyJson()
                 .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t11 types를 콤마로, rarity를 반복 파라미터로 넘기면 둘 다 다중 값 목록으로 위임한다")
+    void t11() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
+        given(cardService.search(
+                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), any(Pageable.class)))
+                .willReturn(page);
+
+        mockMvcTester.get()
+                .uri("/api/cards?types=Fire,Water&rarity=Common&rarity=Rare Holo")
+                .assertThat()
+                .hasStatusOk();
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -27,6 +27,7 @@ import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtTokenProvider;
 
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -37,6 +38,11 @@ class CardControllerTest {
 
     @MockitoBean
     private CardService cardService;
+
+    // JwtAuthenticationFilter가 OncePerRequestFilter라 슬라이스에 자동 포함되는데,
+    // 그 생성자가 요구하는 JwtTokenProvider가 없으면 컨텍스트 로딩 자체가 실패한다.
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("t1 쿼리 파라미터로 카드를 검색하면 200과 페이지 결과를 반환한다")

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -93,7 +93,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
-        Page<Card> result = cardRepository.search("Fire", null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -103,7 +103,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t3 rarity가 정확히 일치하는 카드만 조회한다")
     void t3() {
-        Page<Card> result = cardRepository.search(null, "Common", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common"), null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -123,7 +123,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 여러 조건을 조합하면 AND로 필터링된다")
     void t5() {
-        Page<Card> result = cardRepository.search("Fire", null, "base1", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, "base1", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -138,6 +138,55 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
         assertThat(result.getTotalPages()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("t12 타입을 여러 개 선택하면 하나라도 포함된 카드를 OR로 조회한다")
+    void t12() {
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Charizard", "Blastoise", "Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t13 레어도를 여러 개 선택하면 하나라도 일치하는 카드를 OR로 조회한다")
+    void t13() {
+        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Pikachu", "Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t14 타입·레어도·세트를 동시에 지정하면 AND로 결합되어 모두 만족하는 카드만 조회한다")
+    void t14() {
+        Page<Card> result = cardRepository.search(
+                List.of("Fire"), List.of("Rare Holo"), "base1", PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard");
+    }
+
+    @Test
+    @DisplayName("t15 조건을 모두 만족하는 카드가 없으면 빈 페이지를 반환한다")
+    void t15() {
+        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("t16 존재하지 않는 타입 값으로 조회해도 예외 없이 빈 페이지를 반환한다")
+    void t16() {
+        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -190,6 +190,17 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("t17 타입을 여러 개, 레어도를 여러 개 동시에 선택하면 각 조건 내부는 OR, 조건 간에는 AND로 결합된다")
+    void t17() {
+        Page<Card> result = cardRepository.search(
+                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Charizard", "Blastoise", "Charizard ex");
+    }
+
+    @Test
     @DisplayName("t7 같은 포켓몬 도감번호를 가진 다른 카드를 유사 카드로 조회한다")
     void t7() {
         List<Card> result = cardRepository.findRelatedByPokedexNumber(charizard.getId());

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -54,12 +54,32 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search("Fire", "Rare Holo", "base1", pageable)).willReturn(page);
+        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), "base1", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search("Fire", "Rare Holo", "base1", pageable);
+        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), "base1", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t13 타입·레어도를 여러 개 선택해도 리포지토리에 그대로 위임한다")
+    void t13() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("Blastoise")
+                .types(List.of("Water"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, pageable))
+                .willReturn(page);
+
+        Page<CardResponse> result = cardService.search(
+                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("Blastoise");
     }
 
     @Test

--- a/Pokade/src/test/resources/application-test.yaml
+++ b/Pokade/src/test/resources/application-test.yaml
@@ -9,3 +9,7 @@ spring:
     init:
       mode: always
       data-locations: optional:classpath:no-data.sql
+
+jwt:
+  secret: test-only-jwt-secret-key-for-unit-tests-not-a-real-secret-1234567890
+  access-expiration: 30m


### PR DESCRIPTION
## 📌 관련 이슈
- #38

## ✨ 작업 내용
- GET /api/cards에 types(타입), rarity(레어도) 파라미터 추가
- 다중 선택 가능 (반복 파라미터 또는 콤마 구분 둘 다 지원)
- 같은 필터 내부는 OR, 서로 다른 필터 간은 AND로 조합
- 존재하지 않는 값 → 400 아닌 빈 결과 반환 (기존 세트 필터와 일관성 유지)

## 📸 스크린샷 / 테스트 결과
- 전체 카드 도메인 테스트 통과
- FE 연동까지 실제 브라우저로 다중 선택 정상 작동 확인

## 🔍 리뷰 포인트
- 다중 선택은 OR, 필터 종류 간은 AND 
- 다중 선택 시 결과 안 나오던 버그 발견·수정 
- 사용 예시: `GET /api/cards?types=Fire,Water&rarity=Common,Rare Holo`
-  jwt.secret 누락으로 테스트 실패하던 문제 부분 해결 (카드 도메인은 완전 해결, 나머지 25건은 담당자 확인 필요)
- "Pokémon" 인코딩 깨짐 확인 (일본어 카드명 인코딩 문제 추정)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?