### PR TITLE
[Feature] #37 매물 호가 목록 조회 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingController.java
@@ -3,11 +3,14 @@ package com.pokade.domain.listing;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.OrderbookEntryResponse;
+import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -37,6 +40,15 @@ public class ListingController {
     @GetMapping
     public ResponseEntity<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
         return ResponseEntity.ok(listingService.getActiveListings(cardId));
+    }
+
+    @GetMapping("/{cardId}/orderbook")
+    public ApiResponse<List<OrderbookEntryResponse>> getOrderbook(
+            @PathVariable Long cardId,
+            @RequestParam(required = false) Long variantId,
+            @RequestParam(required = false) ListingGrade grade
+    ) {
+        return ApiResponse.ok(listingService.getOrderbook(cardId, variantId, grade));
     }
 
     @GetMapping("/me")

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
@@ -11,6 +11,15 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
 
     List<Listing> findByCardIdAndStatusOrderByPriceAsc(Long cardId, ListingStatus status);
 
+    @Query("SELECT l FROM Listing l "
+            + "WHERE l.cardId = :cardId AND l.variantId = :variantId AND l.status = :status "
+            + "AND (:grade IS NULL OR l.grade = :grade) "
+            + "ORDER BY l.price ASC")
+    List<Listing> findOrderbook(@Param("cardId") Long cardId,
+                                 @Param("variantId") Long variantId,
+                                 @Param("status") ListingStatus status,
+                                 @Param("grade") ListingGrade grade);
+
     List<Listing> findBySellerId(Long sellerId);
 
     List<Listing> findBySellerIdAndStatus(Long sellerId, ListingStatus status);

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingService.java
@@ -1,8 +1,11 @@
 package com.pokade.domain.listing;
 
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.OrderbookEntryResponse;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +20,8 @@ import java.util.List;
 public class ListingService {
 
     private final ListingRepository listingRepository;
+    private final CardRepository cardRepository;
+    private final CardVariantRepository cardVariantRepository;
 
     @Transactional
     public ListingResponse createListing(Long sellerId, ListingCreateRequest request) {
@@ -43,6 +48,23 @@ public class ListingService {
         return listingRepository.findByCardIdAndStatusOrderByPriceAsc(cardId, ListingStatus.ACTIVE)
                 .stream()
                 .map(ListingSummaryResponse::of)
+                .toList();
+    }
+
+    public List<OrderbookEntryResponse> getOrderbook(Long cardId, Long variantId, ListingGrade grade) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
+        Long resolvedVariantId = variantId != null
+                ? variantId
+                : cardVariantRepository.findPrimaryVariantId(cardId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.PRIMARY_VARIANT_NOT_FOUND));
+
+        return listingRepository
+                .findOrderbook(cardId, resolvedVariantId, ListingStatus.ACTIVE, grade)
+                .stream()
+                .map(OrderbookEntryResponse::of)
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/OrderbookEntryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/OrderbookEntryResponse.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.listing.dto;
+
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingGrade;
+
+public record OrderbookEntryResponse(
+        Long listingId,
+        Integer price,
+        ListingGrade grade
+) {
+
+    public static OrderbookEntryResponse of(Listing listing) {
+        return new OrderbookEntryResponse(listing.getId(), listing.getPrice(), listing.getGrade());
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .requestMatchers("/api/prices/**").permitAll()
+                        // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거하거나 정식 공개 여부 팀 결정 필요
+                        .requestMatchers(HttpMethod.GET, "/api/listings/*/orderbook").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -259,3 +259,86 @@ VALUES (
        );
 
 -- Charizard ex sv3pt5-6 : 체결 이력 없음 (빈 목록 검증용, 의도적으로 데이터 없음)
+
+-- =========================================================
+-- 매도 호가창(orderbook) 검증용 추가 시드
+-- Charizard base1-4 : 기존 ACTIVE 2건(2,950,000 / 3,200,000)에 2건 추가 → 총 4건, 가격 오름차순 검증용
+-- =========================================================
+
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2700000, NULL, 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3600000, 'PSA9', 'ACTIVE', now(), now()
+       );
+
+-- Charizard base1-4 : 나머지 등급(S / PSA10 / PSA8)도 grade 필터 테스트가 가능하도록 추가
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2800000, 'PSA8', 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3050000, 'S', 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           4000000, 'PSA10', 'ACTIVE', now(), now()
+       );
+
+-- Charizard base1-4 : 등급(A, PSA9)별로 매물을 여러 건 추가 — grade 필터 적용 시에도
+-- 가격 오름차순 정렬이 유지되는지 확인용 (일부러 오름차순이 아닌 순서로 INSERT)
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3450000, 'A', 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2900000, 'A', 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3900000, 'PSA9', 'ACTIVE', now(), now()
+       );
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3350000, 'PSA9', 'ACTIVE', now(), now()
+       );
+
+-- Charizard base1-4 : HIDDEN 1건 (status 필터링 검증용, 조회에 잡히면 안 됨)
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2600000, NULL, 'HIDDEN', now(), now()
+       );

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -181,6 +181,10 @@ CREATE TABLE IF NOT EXISTS trades (
 
 -- 카드별 체결 내역 조회(FR-PRICE-02, listings.card_id 조인) 최적화
 CREATE INDEX IF NOT EXISTS idx_listings_card_id ON listings(card_id);
+
+-- 매도 호가창(orderbook) 조회 최적화 (카드/변형 기준 ACTIVE 매물 가격 오름차순)
+CREATE INDEX IF NOT EXISTS idx_listings_orderbook
+    ON listings(card_id, variant_id, status, price ASC);
 CREATE INDEX IF NOT EXISTS idx_trades_listing_status ON trades(listing_id, status, confirmed_at DESC);
 
 CREATE TABLE IF NOT EXISTS payments (

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
@@ -1,6 +1,8 @@
 package com.pokade.domain.auth.controller;
 
 import com.pokade.domain.auth.service.EmailVerificationService;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,12 @@ class EmailVerificationControllerTest {
 
     @MockitoBean
     private EmailVerificationService emailVerificationService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     @DisplayName("유효한 이메일이면 200과 함께 인증 코드 발송 서비스를 호출한다.")

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -27,6 +27,8 @@ import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
 
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -37,6 +39,12 @@ class CardControllerTest {
 
     @MockitoBean
     private CardService cardService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     @DisplayName("t1 쿼리 파라미터로 카드를 검색하면 200과 페이지 결과를 반환한다")

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -53,7 +53,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1");
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq("Fire"), eq("Rare Holo"), eq("base1"), any(Pageable.class)))
+        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), eq("base1"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -8,6 +8,8 @@ import com.pokade.domain.listing.dto.OrderbookEntryResponse;
 import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -42,6 +44,12 @@ class ListingControllerTest {
 
     @MockitoBean
     private ListingService listingService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     void 매물_등록에_성공하면_201과_등록된_매물을_반환한다() throws Exception {

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
 import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.dto.ListingSummaryResponse;
+import com.pokade.domain.listing.dto.OrderbookEntryResponse;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.Test;
@@ -113,6 +114,57 @@ class ListingControllerTest {
         mockMvc.perform(get("/api/listings"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 활성_매도호가가_있으면_200과_가격_오름차순_목록을_반환한다() throws Exception {
+        List<OrderbookEntryResponse> orderbook = List.of(
+                new OrderbookEntryResponse(3L, 2700000, null),
+                new OrderbookEntryResponse(1L, 2950000, ListingGrade.B),
+                new OrderbookEntryResponse(2L, 3200000, ListingGrade.A)
+        );
+
+        given(listingService.getOrderbook(1L, null, null)).willReturn(orderbook);
+
+        mockMvc.perform(get("/api/listings/1/orderbook"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].price").value(2700000))
+                .andExpect(jsonPath("$.data[1].price").value(2950000))
+                .andExpect(jsonPath("$.data[2].price").value(3200000));
+    }
+
+    @Test
+    void 매도호가가_없으면_200과_빈_목록을_반환한다() throws Exception {
+        given(listingService.getOrderbook(1L, null, null)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/listings/1/orderbook"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void 존재하지_않는_카드의_호가창_조회는_404를_반환한다() throws Exception {
+        given(listingService.getOrderbook(999L, null, null))
+                .willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        mockMvc.perform(get("/api/listings/999/orderbook"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CARD_NOT_FOUND"));
+    }
+
+    @Test
+    void grade_파라미터로_필터링해서_호가창을_조회한다() throws Exception {
+        List<OrderbookEntryResponse> filtered = List.of(
+                new OrderbookEntryResponse(2L, 3200000, ListingGrade.A)
+        );
+
+        given(listingService.getOrderbook(1L, null, ListingGrade.A)).willReturn(filtered);
+
+        mockMvc.perform(get("/api/listings/1/orderbook").param("grade", "A"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].grade").value("A"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -5,6 +5,8 @@ import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -30,6 +32,12 @@ class PriceControllerTest {
 
     @MockitoBean
     private PriceService priceService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     void 체결_내역이_있으면_200과_최신순_목록을_반환한다() throws Exception {


### PR DESCRIPTION
## 📌 관련 이슈
- #37

## ✨ 작업 내용
- 매도 호가창(orderbook) 조회 API 구현 (`GET /api/listings/{cardId}/orderbook`)
- 카드의 활성(`ACTIVE`) 매도호가를 가격 오름차순으로 반환
- `variantId` 미지정 시 대표 변형(`is_primary`) 기준 처리 (FR-PRICE-01 `PriceService`와 동일 패턴)
- `grade` 쿼리 파라미터로 등급별 필터링 지원 (`?grade=A` 등) — 미지정 시 전체 등급 조회
- 존재하지 않는 cardId → 404, 활성 매도호가 없음 → 200 + 빈 배열
- 호가창 조회 최적화 인덱스 추가: `idx_listings_orderbook (card_id, variant_id, status, price ASC)`
- 호가창 검증용 시드 데이터 보강 (`data.sql`) — Charizard(base1-4) 기준 6개 등급(S/A/B/PSA10/PSA9/PSA8) + 무등급(RAW) 매물, 일부 등급은 정렬 검증을 위해 여러 건 추가. CANCELLED/SOLD/HIDDEN 등 비활성 매물도 포함해 상태 필터링 검증 가능
- `PriceController` 응답을 `ApiResponse<T>`로 통일 (`CardController`와 동일 포맷, 팀 결정 반영)

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과 (Docker/Testcontainers 포함 전체 스위트, 회귀 없음)
- dev 프로파일 기동 후 curl로 실제 응답 확인
- `GET /api/listings/{cardId}/orderbook` → 등급 섞인 매물 전체 가격 오름차순 정상 반환
- `?grade=A`, `?grade=PSA9` 등 필터 시 해당 등급 내에서도 가격 오름차순 정상 유지 (동일 등급 매물 3건씩으로 정렬 검증)
- 존재하지 않는 cardId → 404 `CARD_NOT_FOUND`
- 매도호가 없는 카드 → 200 + 빈 배열

## 🔍 리뷰 포인트
- `SecurityConfig`에 `GET /api/listings/*/orderbook`만 임시 `permitAll` 처리했습니다 (`/api/ai/grade`와 동일한 TODO 주석 패턴). 이 API를 `/api/prices/**`처럼 비회원에게도 공개할지, 아니면 인증 붙을 때까지 보류하고 추후 로그인 필요 API로 둘지 팀 결정이 필요합니다. 회원 전용으로 확정되면 이 permitAll 한 줄만 제거하면 됩니다.
- `PriceController`는 `ApiResponse<T>`로 래핑됐지만, 같은 `ListingController` 안에서도 새 orderbook 엔드포인트만 `ApiResponse<T>`이고 기존 매물 등록/수정/삭제/조회 엔드포인트는 아직 `ResponseEntity` 언래핑 상태라 컨트롤러 내 응답 포맷이 당분간 혼재합니다.
- grade 필터는 무등급(RAW, DB상 `grade IS NULL`)만 따로 조회할 방법이 없습니다 — enum에 없는 값이라 쿼리파라미터로 명시 불가능한 구조적 한계입니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?