### PR TITLE
[Feature]/#43 이메일/비밀번호 로그인 API 구현 (access·refresh 토큰 발급)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
@@ -1,11 +1,19 @@
 package com.pokade.domain.auth.controller;
 
+import com.pokade.domain.auth.dto.TokenPair;
+import com.pokade.domain.auth.dto.request.LoginRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
+import com.pokade.domain.auth.dto.response.LoginResponse;
 import com.pokade.domain.auth.dto.response.SignupResponse;
 import com.pokade.domain.auth.service.AuthService;
 import com.pokade.global.response.ApiResponse;
+import com.pokade.global.security.JwtProperties;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,8 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
 
     private final AuthService authService;
+    private final JwtProperties jwtProperties;
 
     @PostMapping("/signup")
     public ApiResponse<SignupResponse> signup(
@@ -26,5 +37,24 @@ public class AuthController {
                 "회원가입이 완료되었습니다. 이메일 인증을 진행해주세요.",
                 authService.signup(request)
         );
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        TokenPair tokens = authService.login(request);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/api/auth")
+                .maxAge(jwtProperties.refreshExpiration()) // 토큰 만료와 동기화
+                .sameSite("Lax") //CSRF 관련 로컬(3000)/API(8080)가 같은 site(localhost)로 인식되도록 lax로 설정
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.ok("로그인 성공", LoginResponse.of(tokens.accessToken()));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/TokenPair.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/TokenPair.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.auth.dto;
+
+public record TokenPair(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/LoginRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/response/LoginResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/response/LoginResponse.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.auth.dto.response;
+
+public record LoginResponse(String accessToken) {
+
+    public static LoginResponse of(String accessToken) {
+        return new LoginResponse(accessToken);
+    }
+
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -1,11 +1,15 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.dto.TokenPair;
+import com.pokade.domain.auth.dto.request.LoginRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
 import com.pokade.domain.auth.dto.response.SignupResponse;
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +21,9 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -32,5 +39,26 @@ public class AuthService {
         );
 
         return SignupResponse.from(user);
+    }
+
+    @Transactional
+    public TokenPair login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new BusinessException(ErrorCode.LOGIN_FAILED));
+
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.LOGIN_FAILED);
+        }
+
+        if(user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        refreshTokenStore.save(user.getId(), refreshToken);
+
+        return new TokenPair(accessToken, refreshToken);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
@@ -1,0 +1,23 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.global.security.JwtProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private static final String REFRESH_KEY_PREFIX = "auth:refresh:";
+    private final StringRedisTemplate redisTemplate;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public void save(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                REFRESH_KEY_PREFIX + userId, refreshToken, jwtProperties.refreshExpiration()
+        );
+    }
+
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
@@ -1,0 +1,5 @@
+package com.pokade.domain.auth.service;
+
+public interface RefreshTokenStore {
+    void save(Long userId, String refreshToken);
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN,"이메일 인증이 완료되지 않았습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
     EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
@@ -32,11 +32,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = jwtTokenProvider.getUserId(token);
                 String role = jwtTokenProvider.getRole(token);
                 // 토큰이 유효하면 인증 객체를 만들어 SecurityContext에 등록
-                List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+                if (userId != null && role != null) {
+                    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
-                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
+                    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);
 
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
 

--- a/Pokade/src/main/java/com/pokade/global/security/JwtProperties.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtProperties.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
         String secret,
-        Duration accessExpiration
+        Duration accessExpiration,
+        Duration refreshExpiration
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
@@ -67,12 +67,15 @@ public class JwtTokenProvider {
 
     // 토큰에서 role 클레임을 추출
     public String getRole(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .get("role", String.class);
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get("role", String.class);
+        } catch (Exception e) {
+            return null;
+        }
     }
-
 }

--- a/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
@@ -29,6 +29,15 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    // refresh token 발급 (subject=userId만, role 없이 최소 구성)
+    public String createRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .expiration(new Date(System.currentTimeMillis() + jwtProperties.refreshExpiration().toMillis()))
+                .signWith(secretKey)
+                .compact();
+    }
+
     // 토큰의 서명·만료를 검증 (유효하면 true, 아니면 false)
     public boolean isValid(String token) {
         try {

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -22,6 +22,11 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 
+# 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
+app:
+  cookie:
+    secure: true
+
 pokade:
   ai:
     grade:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -18,3 +18,4 @@ spring:
 jwt:
   secret: ${JWT_SECRET}            # .env(spring.config.import)로 주입 — 미설정 시 부팅 실패(fail-fast)
   access-expiration: 30m
+  refresh-expiration: 14d      # 추가 (Spring Duration이 14d = 14일로 파싱)

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,88 @@
+package com.pokade.domain.auth.controller;
+
+import com.pokade.domain.auth.dto.TokenPair;
+import com.pokade.domain.auth.service.AuthService;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtAuthenticationFilter;
+import com.pokade.global.security.JwtProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthControllerTest.TestConfig.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @MockitoBean
+    private AuthService authService;
+
+    // SecurityConfig가 생성자에서 요구하는 빈들 — 슬라이스엔 없으므로 목으로 채움
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        JwtProperties jwtProperties() {
+            return new JwtProperties(
+                    "test-secret-key-at-least-32-bytes-0123456789",
+                    Duration.ofMinutes(30),
+                    Duration.ofDays(14)
+            );
+        }
+    }
+
+    @Test
+    @DisplayName("유효한 로그인 요청이면 200과 함께 refresh 쿠키를 세팅하고 로그인 서비스를 호출한다")
+    void login_ok() {
+        given(authService.login(any())).willReturn(new TokenPair("access-token", "refresh-token"));
+
+        MvcTestResult result = mockMvcTester.post()
+                .uri("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"user@pokade.com\",\"password\":\"pokade1234\"}")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result.getResponse().getHeader(HttpHeaders.SET_COOKIE)).contains("refreshToken=refresh-token");
+        then(authService).should().login(any());
+    }
+
+    @Test
+    @DisplayName("이메일 형식이 잘못되면 400을 반환하고 서비스를 호출하지 않는다")
+    void login_invalidEmail() {
+        mockMvcTester.post()
+                .uri("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"not-an-email\",\"password\":\"pokade1234\"}")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+
+        then(authService).should(never()).login(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/EmailVerificationControllerTest.java
@@ -1,6 +1,8 @@
 package com.pokade.domain.auth.controller;
 
 import com.pokade.domain.auth.service.EmailVerificationService;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,12 @@ class EmailVerificationControllerTest {
 
     @MockitoBean
     private EmailVerificationService emailVerificationService;
+
+    // SecurityConfig가 생성자에서 요구하는 빈들 — 슬라이스엔 없으므로 목으로 채움
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Test
     @DisplayName("유효한 이메일이면 200과 함께 인증 코드 발송 서비스를 호출한다.")

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -1,12 +1,16 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.dto.TokenPair;
+import com.pokade.domain.auth.dto.request.LoginRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
 import com.pokade.domain.auth.dto.response.SignupResponse;
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +19,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,11 +36,25 @@ class AuthServiceTest {
     UserRepository userRepository;
     @Mock
     PasswordEncoder passwordEncoder;
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
+    @Mock
+    RefreshTokenStore refreshTokenStore;
     @InjectMocks
     AuthService authService;
 
     private SignupRequest request(String email, String pw, String nickname) {
         return new SignupRequest(email, pw, nickname);
+    }
+
+    private User userWithStatus(String email, UserStatus status) {
+        return User.builder()
+                .id(1L)
+                .email(email)
+                .password("ENCODED_PW")
+                .role(Role.USER)
+                .status(status)
+                .build();
     }
 
     @Test
@@ -85,5 +105,62 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.signup(req))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("정상 로그인 시 access·refresh 토큰을 발급하고 refresh를 저장한 뒤 TokenPair를 반환한다")
+    void login_success() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.ACTIVE)));
+        given(passwordEncoder.matches("pokade1234", "ENCODED_PW")).willReturn(true);
+        given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("refresh-token");
+
+        TokenPair result = authService.login(new LoginRequest(email, "pokade1234"));
+
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        then(refreshTokenStore).should().save(1L, "refresh-token");
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 LOGIN_FAILED 예외를 던지고 토큰을 발급·저장하지 않는다")
+    void login_wrongPassword() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.ACTIVE)));
+        given(passwordEncoder.matches("wrong", "ENCODED_PW")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest(email, "wrong")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED);
+
+        then(refreshTokenStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 LOGIN_FAILED 예외를 던진다")
+    void login_userNotFound() {
+        String email = "unknown@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest(email, "pokade1234")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED);
+
+        then(refreshTokenStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("이메일 미인증(PENDING) 회원이면 EMAIL_NOT_VERIFIED 예외를 던진다")
+    void login_notVerified() {
+        String email = "pending@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.PENDING)));
+        given(passwordEncoder.matches("pokade1234", "ENCODED_PW")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest(email, "pokade1234")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_NOT_VERIFIED);
+
+        then(refreshTokenStore).should(never()).save(any(), any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
@@ -1,0 +1,63 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.global.security.JwtProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@Testcontainers
+@Import({RedisRefreshTokenStore.class, RedisRefreshTokenStoreTest.TestConfig.class})
+class RedisRefreshTokenStoreTest {
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        JwtProperties jwtProperties() {
+            return new JwtProperties(
+                    "test-secret-key-at-least-32-bytes-0123456789",
+                    Duration.ofMinutes(30),
+                    Duration.ofDays(14)
+            );
+        }
+    }
+
+    @Autowired
+    RedisRefreshTokenStore store;
+    @Autowired
+    StringRedisTemplate redisTemplate;
+
+    @Test
+    @DisplayName("save하면 auth:refresh:<userId> 키에 토큰이 저장되고 TTL이 설정된다")
+    void save_storesTokenWithTtl() {
+        store.save(1L, "refresh-token");
+
+        assertThat(redisTemplate.opsForValue().get("auth:refresh:1")).isEqualTo("refresh-token");
+        Long ttl = redisTemplate.getExpire("auth:refresh:1");
+        assertThat(ttl).isNotNull().isGreaterThan(0);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -1,5 +1,7 @@
 package com.pokade.global.security;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,7 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.crypto.SecretKey;
 import java.time.Duration;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -87,5 +91,47 @@ class JwtAuthenticationFilterTest {
 
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
         verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("서명은 유효하지만 subject가 숫자가 아니면 인증 없이 통과한다")
+    void doFilterInternal_skipsAuthenticationWhenSubjectNotNumeric() throws Exception {
+        String token = signedToken("not-a-number", "USER");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("서명은 유효하지만 role 클레임이 없으면 인증 없이 통과한다")
+    void doFilterInternal_skipsAuthenticationWhenRoleMissing() throws Exception {
+        String token = signedToken("42", null);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    // 같은 시크릿으로 서명하되 클레임을 임의 구성한 토큰 생성 (role=null이면 role 클레임 생략)
+    private String signedToken(String subject, String role) {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes());
+        var builder = Jwts.builder()
+                .subject(subject)
+                .expiration(new Date(System.currentTimeMillis() + 60_000));
+        if (role != null) {
+            builder.claim("role", role);
+        }
+        return builder.signWith(key).compact();
     }
 }

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -21,7 +21,7 @@ class JwtAuthenticationFilterTest {
     private static final String SECRET = "pokade-local-dev-jwt-secret-key-change-in-prod-0123456789";
 
     private final JwtTokenProvider jwtTokenProvider =
-            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30)));
+            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30), Duration.ofDays(14)));
     private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
 
     @AfterEach

--- a/Pokade/src/test/java/com/pokade/global/security/JwtTokenProviderTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtTokenProviderTest.java
@@ -12,7 +12,7 @@ class JwtTokenProviderTest {
     private static final String SECRET = "pokade-local-dev-jwt-secret-key-change-in-prod-0123456789";
 
     private final JwtTokenProvider provider =
-            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30)));
+            new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30), Duration.ofDays(14)));
 
     @Test
     @DisplayName("발급한 토큰은 유효하고, userId와 role을 그대로 복원한다")
@@ -28,7 +28,7 @@ class JwtTokenProviderTest {
     @DisplayName("만료된 토큰은 isValid가 false를 반환한다")
     void isValid_returnsFalseForExpiredToken() {
         JwtTokenProvider expiredProvider =
-                new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofSeconds(-1)));
+                new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofSeconds(-1), Duration.ofDays(14)));
         String expired = expiredProvider.createAccessToken(42L, "USER");
 
         assertThat(provider.isValid(expired)).isFalse();
@@ -38,7 +38,7 @@ class JwtTokenProviderTest {
     @DisplayName("다른 키로 서명된(위조) 토큰은 isValid가 false를 반환한다")
     void isValid_returnsFalseForForgedToken() {
         JwtTokenProvider otherKeyProvider =
-                new JwtTokenProvider(new JwtProperties("another-completely-different-secret-key-0123456789", Duration.ofMinutes(30)));
+                new JwtTokenProvider(new JwtProperties("another-completely-different-secret-key-0123456789", Duration.ofMinutes(30), Duration.ofDays(14)));
         String forged = otherKeyProvider.createAccessToken(42L, "USER");
 
         assertThat(provider.isValid(forged)).isFalse();


### PR DESCRIPTION
## 📌 관련 이슈
- #43

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- JWT refresh 발급·설정 추가 — `JwtProperties.refreshExpiration`, `JwtTokenProvider.createRefreshToken`, `jwt.refresh-expiration=14d`
- 로그인 DTO 추가 — `LoginRequest`(email/password 유효성 검증), `LoginResponse`(accessToken), `TokenPair`
- `RefreshTokenStore` 인터페이스 + `RedisRefreshTokenStore` — `save(userId, refreshToken)` TTL 14일 (회전·무효화는 후속 이슈 ③)
- `AuthService.login` — 이메일 조회 / BCrypt 검증 / `status == ACTIVE` 확인 / access·refresh 발급 / refresh Redis 저장
- 로그인 `ErrorCode` 추가 — `LOGIN_FAILED`(401, 자격증명 불일치), `EMAIL_NOT_VERIFIED`(403, 미인증)
- `AuthController` `POST /api/auth/login` — access는 응답 바디, refresh는 httpOnly 쿠키(`ResponseCookie`, Secure 프로필 분기)
- prod 쿠키 `Secure=true` 설정(`app.cookie.secure`) — 운영 HTTPS 전송 강제, dev는 기본값 false 유지
- [이슈 ①에서 이월] `JwtAuthenticationFilter` 클레임 방어 — `userId`/`role` 추출 실패 시 인증 스킵, `getRole` null-safe

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- (로그인 200 + Set-Cookie 응답 Postman/Swagger 캡처 첨부 예정)
- 단위/슬라이스 테스트: 서비스(성공/비번틀림/유저없음/미인증), 컨트롤러(200+쿠키/검증 400), 저장소(refresh save+TTL), 필터 클레임 방어(잘못된 sub·role 없음 → 인증 스킵)

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 로그인 실패 정책: 자격증명 불일치는 `LOGIN_FAILED`로 뭉개고 미인증만 `EMAIL_NOT_VERIFIED`로 분기(계정 열거 절충) — 의도대로인지
- 쿠키 정책: `httpOnly` + `Secure`(prod) + `SameSite=Lax` + `path=/api/auth`, `maxAge`는 refresh 만료와 동기화
- 범위 구분: refresh는 이번 이슈에서 Redis `save`만, 검증·회전·로그아웃은 이슈 ③로 이월

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [ ] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?