### PR TITLE
[Feature] #41 FR-TRADE-06 즉시구매 요청 API 구현

### DIFF
--- a/Pokade/.gitignore
+++ b/Pokade/.gitignore
@@ -45,3 +45,4 @@ out/
 ### AI Tools ###
 .claude/
 .omc/
+SESSION_NOTES.md

--- a/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/ListingRepository.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.listing;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -23,4 +24,10 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
     Optional<Integer> findLowestActivePrice(@Param("cardId") Long cardId,
                                              @Param("variantId") Long variantId,
                                              @Param("status") ListingStatus status);
+
+    // ACTIVE 상태인 매물만 원자적으로 TRADING으로 전환. 반환값 0 = 이미 팔렸거나 존재하지 않음(동시 구매 충돌)
+    @Modifying
+    @Query("UPDATE Listing l SET l.status = com.pokade.domain.listing.ListingStatus.TRADING "
+            + "WHERE l.id = :id AND l.status = com.pokade.domain.listing.ListingStatus.ACTIVE")
+    int markAsTrading(@Param("id") Long listingId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/TradeController.java
@@ -1,0 +1,31 @@
+package com.pokade.domain.trade;
+
+import com.pokade.domain.trade.dto.TradeCreateRequest;
+import com.pokade.domain.trade.dto.TradeResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/trades")
+@RequiredArgsConstructor
+public class TradeController {
+
+    private final TradeService tradeService;
+
+    @PostMapping
+    public ResponseEntity<TradeResponse> createTrade(
+            // TODO: 인증 파트 완성되면 SecurityContext에서 buyerId 추출하는 방식으로 교체
+            @RequestHeader("X-USER-ID") Long buyerId,
+            @Valid @RequestBody TradeCreateRequest request
+    ) {
+        TradeResponse response = tradeService.createTrade(buyerId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/TradeService.java
@@ -1,0 +1,56 @@
+package com.pokade.domain.trade;
+
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingRepository;
+import com.pokade.domain.trade.dto.TradeCreateRequest;
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TradeService {
+
+    private final ListingRepository listingRepository;
+    private final TradeRepository tradeRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public TradeResponse createTrade(Long buyerId, TradeCreateRequest request) {
+        Listing listing = listingRepository.findById(request.listingId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.LISTING_NOT_FOUND));
+
+        if (listing.getSellerId().equals(buyerId)) {
+            throw new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED);
+        }
+
+        int updated = listingRepository.markAsTrading(listing.getId());
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.TRADE_CONFLICT);
+        }
+
+        Trade trade = tradeRepository.save(
+                Trade.builder()
+                        .listing(listing)
+                        .buyerId(buyerId)
+                        .price(listing.getPrice())
+                        .build()
+        );
+
+        // TODO: 실제 PG 연동 전까지는 결제가 항상 성공한다고 가정 (에스크로 보류 상태로만 생성)
+        paymentRepository.save(
+                Payment.builder()
+                        .trade(trade)
+                        .buyerId(buyerId)
+                        .amount(trade.getPrice())
+                        .method(PaymentMethod.CARD)
+                        .build()
+        );
+
+        return TradeResponse.of(trade);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeCreateRequest.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.trade.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record TradeCreateRequest(
+        @NotNull(message = "listingId는 필수입니다.")
+        Long listingId
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
@@ -1,0 +1,33 @@
+package com.pokade.domain.trade.dto;
+
+import com.pokade.domain.trade.Trade;
+import com.pokade.domain.trade.TradeStatus;
+
+import java.time.LocalDateTime;
+
+public record TradeResponse(
+        Long id,
+        Long listingId,
+        Long buyerId,
+        Integer price,
+        TradeStatus status,
+        LocalDateTime shippedAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime settledAt,
+        LocalDateTime createdAt
+) {
+
+    public static TradeResponse of(Trade trade) {
+        return new TradeResponse(
+                trade.getId(),
+                trade.getListing().getId(),
+                trade.getBuyerId(),
+                trade.getPrice(),
+                trade.getStatus(),
+                trade.getShippedAt(),
+                trade.getConfirmedAt(),
+                trade.getSettledAt(),
+                trade.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/ListingRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/ListingRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.pokade.domain.listing;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ListingRepositoryTest {
+
+    @Autowired
+    private ListingRepository listingRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void ACTIVE_매물은_markAsTrading_호출시_TRADING으로_전환되고_1을_반환한다() {
+        Listing listing = saveListing(insertUser("seller-a@test.com"), insertCard("mark-trading-1"));
+
+        int updated = listingRepository.markAsTrading(listing.getId());
+        entityManager.clear();
+
+        assertThat(updated).isEqualTo(1);
+        Listing found = listingRepository.findById(listing.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(ListingStatus.TRADING);
+    }
+
+    @Test
+    void 이미_ACTIVE가_아닌_매물은_markAsTrading_호출시_0을_반환하고_상태가_바뀌지_않는다() {
+        Listing listing = saveListing(insertUser("seller-b@test.com"), insertCard("mark-trading-2"));
+        listingRepository.markAsTrading(listing.getId());
+        entityManager.clear();
+
+        int secondAttempt = listingRepository.markAsTrading(listing.getId());
+        entityManager.clear();
+
+        assertThat(secondAttempt).isEqualTo(0);
+        Listing found = listingRepository.findById(listing.getId()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(ListingStatus.TRADING);
+    }
+
+    @Test
+    void 존재하지_않는_매물은_markAsTrading_호출시_0을_반환한다() {
+        int updated = listingRepository.markAsTrading(999_999_999L);
+
+        assertThat(updated).isEqualTo(0);
+    }
+
+    private Listing saveListing(Long sellerId, Long cardId) {
+        return listingRepository.save(
+                Listing.builder()
+                        .cardId(cardId)
+                        .sellerId(sellerId)
+                        .price(10000)
+                        .build()
+        );
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Repo Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/trade/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/TradeControllerTest.java
@@ -1,0 +1,113 @@
+package com.pokade.domain.trade;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pokade.domain.trade.dto.TradeCreateRequest;
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TradeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TradeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private TradeService tradeService;
+
+    @Test
+    void 즉시구매에_성공하면_201과_생성된_거래를_반환한다() throws Exception {
+        TradeCreateRequest request = new TradeCreateRequest(1L);
+        TradeResponse response = new TradeResponse(
+                1L, 1L, 200L, 10000, TradeStatus.PENDING,
+                null, null, null, LocalDateTime.now());
+
+        given(tradeService.createTrade(anyLong(), any(TradeCreateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/trades")
+                        .header("X-USER-ID", 200L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.buyerId").value(200L))
+                .andExpect(jsonPath("$.status").value("PENDING"));
+    }
+
+    @Test
+    void listingId가_없으면_400을_반환한다() throws Exception {
+        TradeCreateRequest invalidRequest = new TradeCreateRequest(null);
+
+        mockMvc.perform(post("/api/trades")
+                        .header("X-USER-ID", 200L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 본인_매물을_구매하려하면_400을_반환한다() throws Exception {
+        TradeCreateRequest request = new TradeCreateRequest(1L);
+
+        given(tradeService.createTrade(anyLong(), any(TradeCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED));
+
+        mockMvc.perform(post("/api/trades")
+                        .header("X-USER-ID", 100L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("SELF_PURCHASE_NOT_ALLOWED"));
+    }
+
+    @Test
+    void 존재하지_않는_매물이면_404를_반환한다() throws Exception {
+        TradeCreateRequest request = new TradeCreateRequest(999L);
+
+        given(tradeService.createTrade(anyLong(), any(TradeCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));
+
+        mockMvc.perform(post("/api/trades")
+                        .header("X-USER-ID", 200L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LISTING_NOT_FOUND"));
+    }
+
+    @Test
+    void 이미_거래중인_매물이면_409를_반환한다() throws Exception {
+        TradeCreateRequest request = new TradeCreateRequest(1L);
+
+        given(tradeService.createTrade(anyLong(), any(TradeCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.TRADE_CONFLICT));
+
+        mockMvc.perform(post("/api/trades")
+                        .header("X-USER-ID", 200L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("TRADE_CONFLICT"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #41

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- FR-TRADE-06 즉시구매 요청: `POST /api/trades`                                                                                                    
    - `TradeCreateRequest`/`TradeResponse` DTO 추가                                                                                                  
    - `ListingRepository.markAsTrading()` — 동시구매 충돌 방지를 위해 ACTIVE 상태인 매물만 조건부 UPDATE로 TRADING 전환 (영향 row 0건이면 충돌로 판단)                                                                                                                                              
    - `TradeController.createTrade()` / `TradeService.createTrade()` 구현                                                                            
      - 매물 없음 → 404, 본인 매물 구매 시도 → 400, 동시구매 충돌 → 409                                                                              
      - 성공 시 `Trade`(PENDING) + `Payment`(ESCROW_HELD) 생성                                                                                       
  - 결제는 실제 PG 미연동 상태라 항상 성공하는 것으로 스텁 처리 (TODO 표시)                                                                          
  - buyerId는 기존 파트와 동일하게 `X-USER-ID` 헤더로 임시 수신                                                                                      
                                                                     

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- `ListingRepositoryTest`: 실제 Postgres에 대고 `markAsTrading` 원자적 전환 검증 (성공 / 이미 전환된 매물 재시도 시 0 / 존재하지 않는 id 시 0) —   
  3건                                                                                                                                                
- `TradeControllerTest`: 성공(201) / listingId 누락(400) / 본인 매물 구매(400) / 매물 없음(404) / 거래중 충돌(409) — 5건

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
  - 동시성 처리를 낙관적 락(`@Version`) 대신 조건부 UPDATE 쿼리 방식으로 구현했습니다. 스키마 변경 없이 원자적 전환만 필요해서 이 방식을 택했는데,   
  방향 괜찮은지 확인 부탁드립니다.                                                                                                                   
  - 결제(Payment)는 실제 PG 연동이 없어서 지금은 항상 `ESCROW_HELD`로 성공 처리됩니다. 402(결제 실패) 케이스는 실제 PG 붙을 때 채울 예정입니다.

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [ ] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?