### PR TITLE
[Feature] #49 토큰 재발급·로그아웃 (FR-AUTH-06 / FR-AUTH-05) 

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
@@ -14,10 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -56,5 +53,44 @@ public class AuthController {
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         return ApiResponse.ok("로그인 성공", LoginResponse.of(tokens.accessToken()));
+    }
+
+    @PostMapping("/reissue")
+    public ApiResponse<LoginResponse> reissue(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        TokenPair tokens = authService.reissue(refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokens.refreshToken())
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/api/auth")
+                .maxAge(jwtProperties.refreshExpiration()) // 토큰 만료와 동기화
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.ok("토큰 재발급 성공", LoginResponse.of(tokens.accessToken()));
+    }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        authService.logout(refreshToken);
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .path("/api/auth")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.ok("로그아웃 성공");
+
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
         if (userRepository.existsByEmail(request.email())) {
             throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
         }
-        if(userRepository.existsByNickname(request.nickname())) {
+        if (userRepository.existsByNickname(request.nickname())) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
         String encodedPassword = passwordEncoder.encode(request.password());
@@ -50,7 +50,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
 
-        if(user.getStatus() != UserStatus.ACTIVE) {
+        if (user.getStatus() != UserStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
 
@@ -60,5 +60,54 @@ public class AuthService {
         refreshTokenStore.save(user.getId(), refreshToken);
 
         return new TokenPair(accessToken, refreshToken);
+    }
+
+    public void logout(String accessToken) {
+        Long userId = jwtTokenProvider.getUserId(accessToken);
+        if (userId != null) {
+            refreshTokenStore.delete(userId);
+        }
+    }
+
+    @Transactional
+    public TokenPair reissue(String refreshToken) {
+        if (!jwtTokenProvider.isValid(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Long userId = jwtTokenProvider.getUserId(refreshToken);
+        String stored = refreshTokenStore.find(userId);
+
+        if (stored == null) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        if (!stored.equals(refreshToken)) {
+            String grace = refreshTokenStore.findGrace(userId);
+
+            if (refreshToken.equals(grace)) {
+                String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
+                return new TokenPair(accessToken, stored);
+            }
+            refreshTokenStore.delete(userId);
+            throw new BusinessException(ErrorCode.TOKEN_STOLEN);
+        }
+        String newAccessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        refreshTokenStore.saveGrace(userId, refreshToken);
+        refreshTokenStore.save(userId, newRefreshToken);
+
+        return new TokenPair(newAccessToken, newRefreshToken);
+    }
+
+
+    private String findRole(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    refreshTokenStore.delete(userId);
+                    return new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+                })
+                .getRole().name();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
@@ -5,11 +5,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.time.Duration;
+
 @Repository
 @RequiredArgsConstructor
 public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String REFRESH_KEY_PREFIX = "auth:refresh:";
+    private static final String GRACE_KEY_PREFIX = "auth:refresh:grace:";
+    private static final Duration GRACE_TTL = Duration.ofSeconds(60);
     private final StringRedisTemplate redisTemplate;
     private final JwtProperties jwtProperties;
 
@@ -18,6 +22,27 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
         redisTemplate.opsForValue().set(
                 REFRESH_KEY_PREFIX + userId, refreshToken, jwtProperties.refreshExpiration()
         );
+    }
+
+    @Override
+    public String find(Long userId) {
+        return redisTemplate.opsForValue().get(REFRESH_KEY_PREFIX + userId);
+    }
+
+    @Override
+    public void delete(Long userId) {
+        redisTemplate.delete(REFRESH_KEY_PREFIX + userId);
+        redisTemplate.delete(GRACE_KEY_PREFIX + userId);
+    }
+
+    @Override
+    public void saveGrace(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(GRACE_KEY_PREFIX + userId, refreshToken, GRACE_TTL);
+    }
+
+    @Override
+    public String findGrace(Long userId) {
+        return redisTemplate.opsForValue().get(GRACE_KEY_PREFIX + userId);
     }
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
@@ -2,4 +2,8 @@ package com.pokade.domain.auth.service;
 
 public interface RefreshTokenStore {
     void save(Long userId, String refreshToken);
+    String find(Long userId);
+    void delete(Long userId);
+    void saveGrace(Long userId, String refreshToken);
+    String findGrace(Long userId);
 }

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    TOKEN_STOLEN(HttpStatus.UNAUTHORIZED, "비정상적인 접근이 감지되어 로그아웃되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN,"이메일 인증이 완료되지 않았습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.auth.service.AuthService;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtAuthenticationFilter;
 import com.pokade.global.security.JwtProperties;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,5 +85,44 @@ class AuthControllerTest {
                 .hasStatus(HttpStatus.BAD_REQUEST);
 
         then(authService).should(never()).login(any());
+    }
+
+    @Test
+    @DisplayName("유효한 refresh 쿠키로 재발급하면 200과 함께 새 refresh 쿠키를 세팅하고 access를 반환한다")
+    void reissue_ok() {
+        given(authService.reissue("old-refresh")).willReturn(new TokenPair("new-access", "new-refresh"));
+
+        MvcTestResult result = mockMvcTester.post()
+                .uri("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "old-refresh"))
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result.getResponse().getHeader(HttpHeaders.SET_COOKIE)).contains("refreshToken=new-refresh");
+        then(authService).should().reissue("old-refresh");
+    }
+
+    @Test
+    @DisplayName("로그아웃하면 200과 함께 refresh 쿠키를 만료(Max-Age=0)시키고 로그아웃 서비스를 호출한다")
+    void logout_ok() {
+        MvcTestResult result = mockMvcTester.post()
+                .uri("/api/auth/logout")
+                .cookie(new Cookie("refreshToken", "refresh-token"))
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result.getResponse().getHeader(HttpHeaders.SET_COOKIE)).contains("Max-Age=0");
+        then(authService).should().logout("refresh-token");
+    }
+
+    @Test
+    @DisplayName("refresh 쿠키가 없어도 로그아웃은 200을 반환한다(멱등)")
+    void logout_noCookie() {
+        MvcTestResult result = mockMvcTester.post()
+                .uri("/api/auth/logout")
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        then(authService).should().logout(null);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -163,4 +163,115 @@ class AuthServiceTest {
 
         then(refreshTokenStore).should(never()).save(any(), any());
     }
+
+    @Test
+    @DisplayName("저장된 refresh와 일치하면 회전(새 access+새 refresh)하고 직전 refresh를 grace에 보관한다")
+    void reissue_success() {
+        String oldRefresh = "old-refresh";
+        given(jwtTokenProvider.isValid(oldRefresh)).willReturn(true);
+        given(jwtTokenProvider.getUserId(oldRefresh)).willReturn(1L);
+        given(refreshTokenStore.find(1L)).willReturn(oldRefresh);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
+        given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
+
+        TokenPair result = authService.reissue(oldRefresh);
+
+        assertThat(result.accessToken()).isEqualTo("new-access");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh");
+        then(refreshTokenStore).should().saveGrace(1L, oldRefresh);
+        then(refreshTokenStore).should().save(1L, "new-refresh");
+    }
+
+    @Test
+    @DisplayName("refresh 서명·만료가 유효하지 않으면 INVALID_REFRESH_TOKEN 예외를 던진다")
+    void reissue_invalidToken() {
+        given(jwtTokenProvider.isValid("bad")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.reissue("bad"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("저장된 refresh가 없으면 INVALID_REFRESH_TOKEN 예외를 던진다")
+    void reissue_noStoredToken() {
+        given(jwtTokenProvider.isValid("r")).willReturn(true);
+        given(jwtTokenProvider.getUserId("r")).willReturn(1L);
+        given(refreshTokenStore.find(1L)).willReturn(null);
+
+        assertThatThrownBy(() -> authService.reissue("r"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("저장값과 불일치하고 grace도 아니면 TOKEN_STOLEN 예외를 던지고 저장 토큰을 삭제한다")
+    void reissue_stolen() {
+        String presented = "stale-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.find(1L)).willReturn("current-refresh");
+        given(refreshTokenStore.findGrace(1L)).willReturn(null);
+
+        assertThatThrownBy(() -> authService.reissue(presented))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TOKEN_STOLEN);
+
+        then(refreshTokenStore).should().delete(1L);
+    }
+
+    @Test
+    @DisplayName("저장값과 불일치해도 grace와 일치하면 재회전 없이 새 access만 발급하고 현재 refresh로 수렴한다")
+    void reissue_graceConverges() {
+        String presented = "old-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.find(1L)).willReturn("current-refresh");
+        given(refreshTokenStore.findGrace(1L)).willReturn(presented);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
+        given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
+
+        TokenPair result = authService.reissue(presented);
+
+        assertThat(result.accessToken()).isEqualTo("new-access");
+        assertThat(result.refreshToken()).isEqualTo("current-refresh");
+        then(refreshTokenStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("refresh는 유효하나 유저가 존재하지 않으면 INVALID_REFRESH_TOKEN 예외를 던지고 저장 토큰을 삭제한다")
+    void reissue_userDeleted() {
+        String presented = "current-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.find(1L)).willReturn(presented);
+        given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.reissue(presented))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+        then(refreshTokenStore).should().delete(1L);
+    }
+
+    @Test
+    @DisplayName("로그아웃하면 userId로 refresh와 grace 토큰을 삭제한다")
+    void logout_deletesTokens() {
+        given(jwtTokenProvider.getUserId("refresh")).willReturn(1L);
+
+        authService.logout("refresh");
+
+        then(refreshTokenStore).should().delete(1L);
+    }
+
+    @Test
+    @DisplayName("refresh가 무효·만료여서 userId를 못 구하면 아무것도 삭제하지 않고 예외 없이 넘어간다(멱등)")
+    void logout_idempotentWhenInvalid() {
+        given(jwtTokenProvider.getUserId("bad")).willReturn(null);
+
+        authService.logout("bad");
+
+        then(refreshTokenStore).should(never()).delete(any());
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
@@ -60,4 +60,48 @@ class RedisRefreshTokenStoreTest {
         Long ttl = redisTemplate.getExpire("auth:refresh:1");
         assertThat(ttl).isNotNull().isGreaterThan(0);
     }
+
+    @Test
+    @DisplayName("find는 저장된 refresh 토큰을 반환한다")
+    void find_returnsStoredToken() {
+        store.save(1L, "refresh-token");
+
+        assertThat(store.find(1L)).isEqualTo("refresh-token");
+    }
+
+    @Test
+    @DisplayName("find는 저장된 값이 없으면 null을 반환한다")
+    void find_returnsNullWhenAbsent() {
+        assertThat(store.find(999L)).isNull();
+    }
+
+    @Test
+    @DisplayName("saveGrace하면 auth:refresh:grace:<userId>에 저장되고 TTL이 60초 이하로 설정된다")
+    void saveGrace_storesGraceTokenWithShortTtl() {
+        store.saveGrace(1L, "old-refresh");
+
+        assertThat(redisTemplate.opsForValue().get("auth:refresh:grace:1")).isEqualTo("old-refresh");
+        Long ttl = redisTemplate.getExpire("auth:refresh:grace:1");
+        assertThat(ttl).isNotNull().isGreaterThan(0).isLessThanOrEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("findGrace는 저장된 grace 토큰을 반환한다")
+    void findGrace_returnsStoredGraceToken() {
+        store.saveGrace(1L, "old-refresh");
+
+        assertThat(store.findGrace(1L)).isEqualTo("old-refresh");
+    }
+
+    @Test
+    @DisplayName("delete하면 refresh와 grace 토큰이 함께 제거된다")
+    void delete_removesBothRefreshAndGrace() {
+        store.save(1L, "refresh-token");
+        store.saveGrace(1L, "old-refresh");
+
+        store.delete(1L);
+
+        assertThat(store.find(1L)).isNull();
+        assertThat(store.findGrace(1L)).isNull();
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #49

## ✨ 작업 내용
- `RefreshTokenStore` 확장: `find`/`delete`(refresh+grace 동시 삭제)/`saveGrace`(60초)/`findGrace`
- `ErrorCode` 추가: `INVALID_REFRESH_TOKEN`(401), `TOKEN_STOLEN`(401)
- `AuthService.reissue`: refresh 회전 + 재사용 탐지 + grace period 분기
  - 저장값 일치 → 새 access·refresh 회전, 직전 refresh를 grace에 60초 보관
  - 불일치 + grace 일치 → 재회전 없이 새 access만 발급, 현재 refresh로 수렴(멀티탭 동시요청)
  - 불일치 + grace 아님 → `TOKEN_STOLEN` + refresh 삭제(강제 로그아웃)
  - 재발급 시 role은 DB 조회로 확보(최신 권한 반영 + 유저 존재 재확인)
- `AuthService.logout`: refresh로 userId 판별 → Redis 삭제, 무효·부재여도 멱등 200
- `AuthController`: `POST /api/auth/reissue`(access 바디 + refresh 쿠키 재세팅), `POST /api/auth/logout`(쿠키 만료 maxAge=0)

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과 (store 6 / service 8 / controller 3 신규)

## 🔍 리뷰 포인트
- grace period 분기 로직(동시 reissue를 탈취로 오인하지 않고 수렴시키는 부분)
- 재발급 role을 refresh 클레임이 아니라 DB에서 가져오는 선택(정확성 우선)
- `@CookieValue(required=false)`로 쿠키 부재 시 서비스에서 401 처리(부재→INVALID_REFRESH_TOKEN)
- 로그아웃 후 access는 stateless라 만료까지 유효 → **프론트가 access 폐기 책임**(FE 태스크 별도 공유 필요)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token reissue support to maintain authenticated sessions.
  * Added logout support that invalidates refresh tokens and clears authentication cookies.
  * Added refresh-token rotation and short-term grace handling.
  * Added detection and notification for suspicious token reuse.

* **Bug Fixes**
  * Improved handling of invalid, expired, missing, or compromised refresh tokens.

* **Tests**
  * Added coverage for token renewal, logout, token storage, expiration, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->