### PR TITLE
chore: CodeRabbit 리뷰 지침에 팀 컨벤션(네이밍, 커밋, 주석 규칙) 반영

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,14 @@
 language: "ko-KR"
 
+tone_instructions: >
+  팀 컨벤션 문서를 기준으로 리뷰해줘. 변수/메서드명은 camelCase, 클래스명은 PascalCase,
+  상수는 UPPER_SNAKE_CASE를 따르는지 확인해줘. 커밋 메시지는 "type: 작업 내용" 형식이며
+  type은 feat/fix/docs/style/refactor/test/chore/design/comment/rename/remove/!HOTFIX
+  중 하나여야 하고, 실제 작업 내용과 타입이 일치하는지 확인해줘. 주석은 코드만으로 의도가
+  명확하지 않은 경우에만 작성되어야 하고, 임시 주석이 남아있거나 TODO에 담당자/목적이
+  없으면 지적해줘. System.out.println 등 디버그용 출력이 남아있으면 제거를 제안해줘.
+  사용하지 않는 import나 변수가 남아있지 않은지도 확인해줘.
+
 reviews:
   profile: "chill"
   request_changes_workflow: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,29 +1,45 @@
-language: "ko-KR"
+# ---------------------------------------------------------------- #
+# AI 기본 설정 (언어 및 페르소나)
+# ---------------------------------------------------------------- #
 
+# AI가 응답할 때 사용할 기본 언어를 설정합니다.
+language: ko-KR
+
+# AI의 페르소나와 응답 톤앤매너를 지시합니다. (tone_instructions는 최대 250자 제한)
 tone_instructions: >
-  모든 리뷰 코멘트, 요약, 설명은 영어를 섞지 말고 반드시 한글로만 작성해줘. 단, 코드
-  식별자(변수명/함수명/클래스명/파일명)나 기술 용어(API, JWT 등 고유명사)는 원문 그대로
-  표기해도 된다. 팀 컨벤션 문서를 기준으로 리뷰해줘. 변수/메서드명은 camelCase, 클래스명은 PascalCase,
-  상수는 UPPER_SNAKE_CASE를 따르는지 확인해줘. 커밋 메시지는 "type: 작업 내용" 형식이며
-  type은 feat/fix/docs/style/refactor/test/chore/design/comment/rename/remove/!HOTFIX
-  중 하나여야 하고, 실제 작업 내용과 타입이 일치하는지 확인해줘. 주석은 코드만으로 의도가
-  명확하지 않은 경우에만 작성되어야 하고, 임시 주석이 남아있거나 TODO에 담당자/목적이
-  없으면 지적해줘. System.out.println 등 디버그용 출력이 남아있으면 제거를 제안해줘.
-  사용하지 않는 import나 변수가 남아있지 않은지도 확인해줘.
+  Pokade 백엔드 리뷰어: 모든 리뷰는 한글로만 작성하세요(코드 식별자·기술 용어는 원문 유지).
+  문제 원인과 개선 방법을 제시하고, 비판보다 개선 제안을 우선하세요.
 
+# ---------------------------------------------------------------- #
+# 코드 리뷰 기능 세부 설정
+# ---------------------------------------------------------------- #
 reviews:
-  profile: "chill"
+  # 리뷰의 전반적인 스타일. 'chill'은 비교적 덜 엄격하고 부드러운 톤을 의미합니다.
+  profile: chill
+  # PR은 2명 이상 리뷰어의 Approve가 필요하다는 팀 컨벤션이 있어 false로 설정합니다.
   request_changes_workflow: false
+  # PR의 전체적인 변경 사항에 대한 고수준 요약(summary)을 생성합니다.
   high_level_summary: true
+  # 변경된 각 파일별 요약. PR이 너무 길어지는 것을 방지하기 위해 비활성화합니다.
+  changed_files_summary: false
+  # 코드 실행 흐름을 보여주는 시퀀스 다이어그램. PR이 길어지는 것을 방지하기 위해 비활성화합니다.
+  sequence_diagrams: false
+  # PR에 연결된 이슈를 분석하여 리뷰 컨텍스트에 활용합니다.
+  assess_linked_issues: true
+  # 연관된 다른 이슈/PR을 찾아 링크하는 기능은 사용하지 않습니다.
+  related_issues: false
+  related_prs: false
+  # 레이블/리뷰어 자동 제안 및 자동 할당은 사용하지 않습니다.
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  # 리뷰 요약에 위트 있는 시(poem)를 붙이는 기능은 끕니다.
   poem: false
   review_status: true
   collapse_walkthrough: false
-  auto_review:
-    enabled: true
-    drafts: false
-    base_branches:
-      - "main"
-      - "develop"
+
+  # build/gradle wrapper/seed sql 등은 리뷰 대상에서 제외합니다.
   path_filters:
     - "!**/build/**"
     - "!**/.gradle/**"
@@ -32,34 +48,86 @@ reviews:
     - "!gradlew.bat"
     - "!**/*.sql"
     - "!.idea/**"
-  path_instructions:
-    - path: "src/main/java/**/controller/*.java"
-      instructions: >
-        Spring MVC 컨트롤러 리뷰 기준: 요청 검증(@Valid)이 누락되지 않았는지,
-        응답이 공통 Response 래퍼(global/response)를 일관되게 사용하는지,
-        비즈니스 로직이 컨트롤러에 새어나오지 않고 service로 위임되는지 확인해줘.
-    - path: "src/main/java/**/service/*.java"
-      instructions: >
-        서비스 계층 리뷰 기준: @Transactional 범위가 적절한지(읽기 전용은 readOnly=true),
-        N+1 쿼리 위험이 있는 반복 조회가 있는지, 예외는 global/exception의 커스텀 예외를
-        사용하는지 확인해줘.
-    - path: "src/main/java/**/repository/*.java"
-      instructions: >
-        JPA 리포지토리 리뷰 기준: fetch join 없이 연관 엔티티를 순회 조회해서 N+1이 발생하지
-        않는지, 메서드 이름 기반 쿼리가 복잡해지면 @Query 사용을 제안해줘.
-    - path: "src/main/java/**/entity/*.java"
-      instructions: >
-        JPA 엔티티 리뷰 기준: setter를 무분별하게 열어두지 않았는지, 연관관계의 주인과
-        fetch 전략(LAZY 권장)이 명확한지, 생성자는 정적 팩토리 메서드나 빌더 패턴을
-        따르는지 확인해줘.
-    - path: "src/main/java/com/pokade/global/security/**/*.java"
-      instructions: >
-        Spring Security/JWT/OAuth2 설정 리뷰 기준: 토큰 검증 로직에 취약점이 없는지,
-        비밀값이 하드코딩되지 않고 환경변수/설정으로 분리되어 있는지 꼼꼼히 확인해줘.
-    - path: "src/test/java/**/*.java"
-      instructions: >
-        테스트 코드 리뷰 기준: given-when-then 구조가 명확한지, 실제 동작 검증 없이
-        mock 호출 여부만 확인하는 얕은 테스트는 아닌지 지적해줘.
 
+  # 특정 파일 경로에 따라 다른 리뷰 지침을 적용합니다.
+  path_instructions:
+    - path: "src/main/java/**/*.java"
+      instructions: |
+        팀 컨벤션(AGENTS.md) 기준 공통 체크리스트:
+        1. 변수/메서드명은 camelCase, 클래스명은 PascalCase, 상수는 UPPER_SNAKE_CASE를
+           따르는지 확인해주세요.
+        2. 커밋 메시지는 "type: 작업 내용" 형식이며 type은
+           feat/fix/docs/style/refactor/test/chore/design/comment/rename/remove/!HOTFIX
+           중 하나여야 하고, 실제 작업 내용과 타입이 일치하는지 확인해주세요.
+        3. 주석은 코드만으로 의도가 명확하지 않은 경우에만 작성되어야 하고, 임시 주석이
+           남아있거나 TODO에 담당자/목적이 없으면 지적해주세요.
+        4. System.out.println 등 디버그용 출력, 사용하지 않는 import/변수가 남아있지
+           않은지 확인해주세요.
+    - path: "src/main/java/**/controller/*.java"
+      instructions: |
+        1. 팀 컨벤션(AGENTS.md)과 Spring MVC 공식 가이드를 기준으로 리뷰해주세요.
+        2. 요청 검증(@Valid) 누락 여부, 공통 Response 래퍼(global/response) 사용 여부,
+           컨트롤러에 비즈니스 로직이 새어나오지 않고 service로 위임되는지 확인해주세요.
+        3. 문제점과 대안을 논리적으로 제시하고, 필요하면 예시 코드를 추가해주세요.
+        4. 리뷰는 해당 라인 범위의 코멘트로 남겨주세요.
+    - path: "src/main/java/**/service/*.java"
+      instructions: |
+        1. @Transactional 범위(읽기 전용은 readOnly=true), N+1 쿼리 위험, 커스텀 예외
+           사용 여부를 확인해주세요.
+        2. 서비스/도메인 설계, 책임 분리, 확장성 관점에서도 검토해주세요.
+        3. 문제점과 대안을 논리적으로 제시하고, 필요하면 예시 코드를 추가해주세요.
+    - path: "src/main/java/**/repository/*.java"
+      instructions: |
+        fetch join 없이 연관 엔티티를 순회 조회해서 N+1이 발생하지 않는지, 메서드 이름
+        기반 쿼리가 복잡해지면 @Query 사용을 제안해주세요.
+    - path: "src/main/java/**/entity/*.java"
+      instructions: |
+        setter 남용 여부, 연관관계 주인과 fetch 전략(LAZY 권장), 생성자가 정적 팩토리
+        메서드/빌더 패턴을 따르는지 확인해주세요.
+    - path: "src/main/java/com/pokade/global/security/**/*.java"
+      instructions: |
+        JWT/OAuth2 토큰 검증 로직의 취약점, 비밀값 하드코딩 여부를 꼼꼼히 확인해주세요.
+    - path: "src/test/java/**/*.java"
+      instructions: |
+        1. given-when-then 구조가 명확한지, mock 호출 여부만 확인하는 얕은 테스트는
+           아닌지 지적해주세요.
+        2. 미작성된 테스트 케이스가 있다면 어떤 테스트(API/Service/Repository 단위)가
+           필요한지 제안해주세요.
+
+  # ---------------------------------------------------------------- #
+  # 자동 리뷰 트리거 설정
+  # ---------------------------------------------------------------- #
+  auto_review:
+    enabled: true
+    drafts: false
+    # 이미 리뷰가 진행된 PR에 새 커밋이 추가되면 변경분만 자동으로 다시 리뷰합니다.
+    auto_incremental_review: true
+    base_branches:
+      - "main"
+      - "develop"
+
+# ---------------------------------------------------------------- #
+# 채팅 기능 설정
+# ---------------------------------------------------------------- #
 chat:
   auto_reply: true
+
+# ---------------------------------------------------------------- #
+# CodeRabbit의 지식 기반(Knowledge Base) 설정
+# ---------------------------------------------------------------- #
+knowledge_base:
+  # 웹 검색을 통해 최신 정보나 공식 문서를 참조할 수 있도록 허용합니다.
+  web_search:
+    enabled: true
+  # 레포지토리 내 코딩 규칙 문서를 스타일 가이드라인으로 사용합니다.
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+  # CodeRabbit이 학습한 내용을 저장/참조하는 범위. 'local'은 이 레포지토리에 한정됩니다.
+  learnings:
+    scope: local
+  issues:
+    scope: local
+  pull_requests:
+    scope: local

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,9 @@
 language: "ko-KR"
 
 tone_instructions: >
-  팀 컨벤션 문서를 기준으로 리뷰해줘. 변수/메서드명은 camelCase, 클래스명은 PascalCase,
+  모든 리뷰 코멘트, 요약, 설명은 영어를 섞지 말고 반드시 한글로만 작성해줘. 단, 코드
+  식별자(변수명/함수명/클래스명/파일명)나 기술 용어(API, JWT 등 고유명사)는 원문 그대로
+  표기해도 된다. 팀 컨벤션 문서를 기준으로 리뷰해줘. 변수/메서드명은 camelCase, 클래스명은 PascalCase,
   상수는 UPPER_SNAKE_CASE를 따르는지 확인해줘. 커밋 메시지는 "type: 작업 내용" 형식이며
   type은 feat/fix/docs/style/refactor/test/chore/design/comment/rename/remove/!HOTFIX
   중 하나여야 하고, 실제 작업 내용과 타입이 일치하는지 확인해줘. 주석은 코드만으로 의도가


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (팀 공용 도구 설정)

## ✨ 작업 내용
- 팀 컨벤션 문서(브랜치 전략, 코드 스타일, 네이밍, 커밋 규칙)를 기반으로
  `.coderabbit.yaml`의 `tone_instructions`에 리뷰 기준 추가
- 네이밍 규칙(camelCase/PascalCase/UPPER_SNAKE_CASE), 커밋 타입 일치 여부,
  불필요한 주석/TODO 규칙을 CodeRabbit이 리뷰 시 체크하도록 설정

## 📸 스크린샷 / 테스트 결과
- 설정 파일 변경으로 별도 실행 검증 대상 없음. 이후 PR에서 CodeRabbit이
  해당 기준으로 코멘트를 다는지 확인 예정

## 🔍 리뷰 포인트
- 팀 컨벤션 내용이 빠짐없이 반영됐는지 확인 부탁드립니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (설정 파일만 변경, 빌드 영향 없음)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 코드 리뷰 시 적용할 명명 규칙, 커밋 메시지 형식 및 점검 항목을 문서화했습니다.
  * 주석, TODO, 디버그 출력, 미사용 코드 검토 기준을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->