### PR TITLE
[Chore]#56 dev 테스트 계정 시드 + SecurityConfig 방어적 설정

### DIFF
--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -45,8 +45,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .formLogin(form -> form.disable()) // 명시 안하면 disable 문서화 목적
-                .httpBasic(httpBasic -> httpBasic.disable())  // 명시 안하면 disable 문서화 목적
+                // 폼 로그인·HTTP Basic·기본 로그아웃 미사용 — JWT REST 전용이라 명시적으로 비활성화(방어적 설정)
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
                 .logout(logout -> logout.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -45,6 +45,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable()) // 명시 안하면 disable 문서화 목적
+                .httpBasic(httpBasic -> httpBasic.disable())  // 명시 안하면 disable 문서화 목적
+                .logout(logout -> logout.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))

--- a/Pokade/src/main/java/com/pokade/global/config/SwaggerConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SwaggerConfig.java
@@ -1,12 +1,17 @@
 package com.pokade.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
+    private static final String BEARER = "bearerAuth";
 
     @Bean
     public OpenAPI openAPI() {
@@ -14,6 +19,12 @@ public class SwaggerConfig {
                 .info(new Info()
                     .title("Pokade API")
                     .description("Pokade API 문서")
-                    .version("v0.0.1"));
+                    .version("v0.0.1"))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER, new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+                .addSecurityItem(new SecurityRequirement().addList(BEARER));
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/init/DevUserInit.java
+++ b/Pokade/src/main/java/com/pokade/global/init/DevUserInit.java
@@ -1,0 +1,36 @@
+package com.pokade.global.init;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("dev") // dev 프로파일에서만, 앱 기동 시 테스트 계정을 멱등하게 심는다.
+@RequiredArgsConstructor
+public class DevUserInit implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        seed("test1@pokade.com", "테스터원");
+        seed("test2@pokade.com", "테스터투");
+        seed("test3@pokade.com", "테스터삼");
+    }
+
+    //이미 있으면 건너뛰고, 없으면 ACTIVE 로컬 유저 생성
+    private void seed(String email, String nickname) {
+        if (userRepository.existsByEmail(email)) {
+            return;
+        }
+        User user = User.createLocalUser(email, passwordEncoder.encode("test1234"), nickname);
+        user.verifyEmail();
+        userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #56

## ✨ 작업 내용
- `global/init/DevUserInit` 추가 — dev 프로파일에서 테스트 계정 3개(ACTIVE) 멱등 생성 (createLocalUser + verifyEmail, 비번 BCrypt)
- `SecurityConfig` — 미사용 표준 인증 경로(formLogin/httpBasic/기본 logout) 명시적 비활성화로 공격면 축소
- `SwaggerConfig` — Bearer(JWT) 인증 스킴 추가, 전역 SecurityRequirement로 Swagger UI에서 토큰 첨부 가능

## 📸 스크린샷 / 테스트 결과
- dev 기동 후 `POST /api/auth/login`(test1@pokade.com) → 200 + accessToken
- 인증 가드: `GET /api/listings?cardId=1` → 토큰 없음 401 / 토큰 있음 200
- Postman E2E: 로그인 → 재발급 → 로그아웃 → 로그아웃 후 재발급 401 확인

## 🔍 리뷰 포인트
- 테스트 계정 seeder는 `@Profile("dev")`로 prod 미적용, `existsByEmail` 가드로 멱등
- 타 도메인의 `@RequestHeader("X-USER-ID")` → `@AuthenticationPrincipal` 전환은 별도 이슈로 예정(도메인 담당자 조율)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 문서에 JWT Bearer 인증 스키마와 보안 요구사항을 추가해, 인증이 필요한 요청을 더 쉽게 확인/테스트할 수 있게 했습니다.
  * 개발(profie `dev`) 환경에서 테스트 계정이 시작 시 자동으로 시딩됩니다.
* **개선 사항**
  * 개발용 테스트 계정은 이미 존재하면 중복 생성하지 않으며, 이메일 검증까지 포함해 멱등적으로 동작합니다.
  * JWT REST 전용 보안 구성을 그대로 유지했습니다(기존 폼 로그인/HTTP Basic 비활성화 유지).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->