### PR TITLE
[Feature] #63 거래 확정 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,5 +38,13 @@ public class TradeController {
             @PathVariable Long id
     ) {
         return ResponseEntity.ok(tradeService.getTrade(userId, id));
+    }
+
+    @PatchMapping("/{id}/confirm")
+    public ResponseEntity<TradeResponse> confirmTrade(
+            @AuthenticationPrincipal Long buyerId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(tradeService.confirmTrade(buyerId, id));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -71,4 +71,18 @@ public class TradeService {
 
         return TradeResponse.of(trade);
     }
+
+    @Transactional
+    public TradeResponse confirmTrade(Long buyerId, Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        if (!trade.getBuyerId().equals(buyerId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        trade.complete();
+
+        return TradeResponse.of(trade);
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -173,5 +174,52 @@ class TradeControllerTest {
                         .with(userId(200L)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
+    }
+
+    @Test
+    void 구매자가_확정하면_200과_COMPLETED_상태를_반환한다() throws Exception {
+        TradeResponse response = new TradeResponse(
+                1L, 1L, 200L, 10000, TradeStatus.COMPLETED,
+                null, LocalDateTime.now(), LocalDateTime.now(), LocalDateTime.now());
+
+        given(tradeService.confirmTrade(200L, 1L)).willReturn(response);
+
+        mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
+                        .with(userId(200L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+    }
+
+    @Test
+    void 구매자가_아니면_확정시_403을_반환한다() throws Exception {
+        given(tradeService.confirmTrade(100L, 1L))
+                .willThrow(new BusinessException(ErrorCode.ACCESS_DENIED));
+
+        mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
+                        .with(userId(100L)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void 존재하지_않는_거래를_확정하면_404를_반환한다() throws Exception {
+        given(tradeService.confirmTrade(200L, 999L))
+                .willThrow(new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/trades/{id}/confirm", 999L)
+                        .with(userId(200L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
+    }
+
+    @Test
+    void 이미_완료된_거래를_확정하면_400을_반환한다() throws Exception {
+        given(tradeService.confirmTrade(200L, 1L))
+                .willThrow(new BusinessException(ErrorCode.INVALID_TRADE_STATUS));
+
+        mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
+                        .with(userId(200L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_TRADE_STATUS"));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -4,6 +4,7 @@ import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.trade.repository.PaymentRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.exception.BusinessException;
@@ -86,5 +87,45 @@ class TradeServiceTest {
         assertThatThrownBy(() -> tradeService.getTrade(200L, 999L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TRADE_NOT_FOUND);
+    }
+
+    @Test
+    void 구매자가_확정하면_거래상태가_COMPLETED로_바뀐다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        TradeResponse response = tradeService.confirmTrade(200L, 1L);
+
+        assertThat(response.status()).isEqualTo(TradeStatus.COMPLETED);
+    }
+
+    @Test
+    void 구매자가_아니면_확정시_ACCESS_DENIED_예외가_발생한다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        assertThatThrownBy(() -> tradeService.confirmTrade(100L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    void 존재하지_않는_거래를_확정하면_TRADE_NOT_FOUND_예외가_발생한다() {
+        given(tradeRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tradeService.confirmTrade(200L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TRADE_NOT_FOUND);
+    }
+
+    @Test
+    void 이미_완료된_거래를_다시_확정하면_INVALID_TRADE_STATUS_예외가_발생한다() {
+        Trade trade = tradeOf(100L, 200L);
+        trade.complete();
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        assertThatThrownBy(() -> tradeService.confirmTrade(200L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TRADE_STATUS);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #63 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
  - FR-TRADE-08 거래 확정 API 구현 (PATCH /api/trades/{id}/confirm)                                                                                                     
  - TradeService.confirmTrade(buyerId, tradeId) 추가 — 구매자 본인만 확정 가능
  - 예외 처리: 거래 없음 → 404(TRADE_NOT_FOUND), 본인 아님 → 403(ACCESS_DENIED), 이미 완료·취소된 거래 → 400(INVALID_TRADE_STATUS)

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 구매자가 거래를 확정할 수 있는 기능을 추가했습니다.
  * 거래 확정 시 상태가 완료로 변경됩니다.

* **버그 수정 및 예외 처리**
  * 구매자가 아닌 사용자의 확정 요청을 차단합니다.
  * 존재하지 않거나 이미 완료된 거래의 잘못된 요청을 처리합니다.

* **테스트**
  * 거래 확정 성공 및 권한·상태·존재 여부에 따른 응답을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->