### PR TITLE
[Feature]#69 refresh 토큰 해시 저장 + grace 재설계(Option Y) + 카운터 원자화 정리

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
@@ -49,8 +49,10 @@ public class AuthController {
             HttpServletResponse response
     ) {
         TokenPair tokens = authService.reissue(refreshToken);
-        response.addHeader(HttpHeaders.SET_COOKIE,
-                refreshTokenCookieFactory.create(tokens.refreshToken()).toString());
+        if (tokens.refreshToken() != null) { // grace 수렴이면 refresh 없음 -> 기존 쿠키 유지, 재세팅 스킵
+            response.addHeader(HttpHeaders.SET_COOKIE,
+                    refreshTokenCookieFactory.create(tokens.refreshToken()).toString());
+        }
         return ApiResponse.ok("토큰 재발급 성공", LoginResponse.of(tokens.accessToken()));
     }
 
@@ -58,7 +60,7 @@ public class AuthController {
     public ApiResponse<Void> logout(
             @CookieValue(value = "refreshToken", required = false) String refreshToken,
             HttpServletResponse response
-    ){
+    ) {
         authService.logout(refreshToken);
         response.addHeader(HttpHeaders.SET_COOKIE,
                 refreshTokenCookieFactory.expired().toString());

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -93,29 +93,28 @@ public class AuthService {
         }
 
         Long userId = jwtTokenProvider.getUserId(refreshToken);
-        String stored = refreshTokenStore.find(userId);
 
-        if (stored == null) {
+        if (!refreshTokenStore.exists(userId)) { // 저장 키 자체가 없음 -> 미로그인/로그아웃/만료
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        if (!stored.equals(refreshToken)) {
-            String grace = refreshTokenStore.findGrace(userId);
+        if (refreshTokenStore.matches(userId, refreshToken)) { // 현재 refresh와 일치 -> 정상 회전
+            String newAccessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
+            String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-            if (refreshToken.equals(grace)) {
-                String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-                return new TokenPair(accessToken, stored);
-            }
-            refreshTokenStore.delete(userId);
-            throw new BusinessException(ErrorCode.TOKEN_STOLEN);
+            refreshTokenStore.saveGrace(userId, refreshToken);
+            refreshTokenStore.save(userId, newRefreshToken);
+
+            return new TokenPair(newAccessToken, newRefreshToken);
         }
-        String newAccessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        refreshTokenStore.saveGrace(userId, refreshToken);
-        refreshTokenStore.save(userId, newRefreshToken);
+       if (refreshTokenStore.matchesGrace(userId, refreshToken)) { // 직전 refresh(동시요청) -> 새 access만
+           String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
+           return new TokenPair(accessToken, null); // Option Y: refresh 재발급,재세팅 안 함
+       }
 
-        return new TokenPair(newAccessToken, newRefreshToken);
+       refreshTokenStore.delete(userId); // 키는 있는데 어느 것과도 불일치 -> 탈취 의심, 전면 폐기
+       throw new BusinessException(ErrorCode.TOKEN_STOLEN);
     }
 
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -98,14 +98,11 @@ public class AuthService {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        if (refreshTokenStore.matches(userId, refreshToken)) { // 현재 refresh와 일치 -> 정상 회전
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        if (refreshTokenStore.compareAndRotate(userId, refreshToken, newRefreshToken)) {
             String newAccessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-            String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
-
-            refreshTokenStore.saveGrace(userId, refreshToken);
-            refreshTokenStore.save(userId, newRefreshToken);
-
-            return new TokenPair(newAccessToken, newRefreshToken);
+            return new TokenPair(newAccessToken, newRefreshToken); // Option X: refresh 재
         }
 
        if (refreshTokenStore.matchesGrace(userId, refreshToken)) { // 직전 refresh(동시요청) -> 새 access만

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisLoginAttemptStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisLoginAttemptStore.java
@@ -18,7 +18,7 @@ public class RedisLoginAttemptStore implements LoginAttemptStore {
     // 로그인 실패 카운트 +1, 첫 실패에만 TTL — 원자 실행(2단계면 크래시 시 TTL 없는 키가 남아 영구 잠금)
     private static final RedisScript<Long> INCR_WITH_TTL = RedisScript.of(
             "local c = redis.call('INCR', KEYS[1]) " +
-                    "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
+                    "if c == 1 or redis.call('TTL', KEYS[1]) == -1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
                     "return c", Long.class);
 
     private final StringRedisTemplate redisTemplate;

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisLoginAttemptStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisLoginAttemptStore.java
@@ -25,10 +25,9 @@ public class RedisLoginAttemptStore implements LoginAttemptStore {
 
     @Override
     public void recordFailure(String email) {
-        Long count = redisTemplate.execute(INCR_WITH_TTL, List.of(KEY_PREFIX + email), String.valueOf(BLOCK_TTL.getSeconds()));
-        if (count != null && count == 1) {
-            redisTemplate.expire(KEY_PREFIX + email, BLOCK_TTL);
-        }
+        redisTemplate.execute(INCR_WITH_TTL,
+                List.of(KEY_PREFIX + email),
+                String.valueOf(BLOCK_TTL.getSeconds()));
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
@@ -5,7 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.util.HexFormat;
 
 @Repository
 @RequiredArgsConstructor
@@ -13,20 +17,29 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String REFRESH_KEY_PREFIX = "auth:refresh:";
     private static final String GRACE_KEY_PREFIX = "auth:refresh:grace:";
-    private static final Duration GRACE_TTL = Duration.ofSeconds(60);
+    private static final Duration GRACE_TTL = Duration.ofSeconds(5);
     private final StringRedisTemplate redisTemplate;
     private final JwtProperties jwtProperties;
 
+    // refresh 토큰을 해시로 저장 (원문 미보관)
     @Override
     public void save(Long userId, String refreshToken) {
         redisTemplate.opsForValue().set(
-                REFRESH_KEY_PREFIX + userId, refreshToken, jwtProperties.refreshExpiration()
+                REFRESH_KEY_PREFIX + userId, hash(refreshToken), jwtProperties.refreshExpiration()
         );
     }
 
+    //refresh 키 존재 여부
     @Override
-    public String find(Long userId) {
-        return redisTemplate.opsForValue().get(REFRESH_KEY_PREFIX + userId);
+    public boolean exists(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(REFRESH_KEY_PREFIX + userId));
+    }
+
+    // 제시된 토큰의 해시가 저장된 refresh 해시와 일치하는지
+    @Override
+    public boolean matches(Long userId, String refreshToken) {
+        String stored = redisTemplate.opsForValue().get(REFRESH_KEY_PREFIX + userId);
+        return stored != null && stored.equals(hash(refreshToken));
     }
 
     @Override
@@ -35,14 +48,28 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
         redisTemplate.delete(GRACE_KEY_PREFIX + userId);
     }
 
+    // 직전 refresh를 grace 창(5초) 동안 해시로 보관
     @Override
     public void saveGrace(Long userId, String refreshToken) {
-        redisTemplate.opsForValue().set(GRACE_KEY_PREFIX + userId, refreshToken, GRACE_TTL);
+        redisTemplate.opsForValue().set(GRACE_KEY_PREFIX + userId, hash(refreshToken), GRACE_TTL);
     }
 
+    // 제시된 토큰의 해시가 grace 해시와 일치하는지
     @Override
-    public String findGrace(Long userId) {
-        return redisTemplate.opsForValue().get(GRACE_KEY_PREFIX + userId);
+    public boolean matchesGrace(Long userId, String refreshToken) {
+        String stored = redisTemplate.opsForValue().get(GRACE_KEY_PREFIX + userId);
+        return stored != null && stored.equals(hash(refreshToken));
+    }
+
+    // SHA-256 해시 -> 16진 문자열 (외부 의존성 없이 JDK만)
+    private String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisRefreshTokenStore.java
@@ -3,6 +3,7 @@ package com.pokade.domain.auth.service;
 import com.pokade.global.security.JwtProperties;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 
 import java.nio.charset.StandardCharsets;
@@ -10,6 +11,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.HexFormat;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,6 +20,17 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     private static final String REFRESH_KEY_PREFIX = "auth:refresh:";
     private static final String GRACE_KEY_PREFIX = "auth:refresh:grace:";
     private static final Duration GRACE_TTL = Duration.ofSeconds(5);
+
+    // 현재 refresh와 일치할 때만 원자적으로 회전: 옛 current→grace, 새 refresh→current (동시요청 double-rotate 차단)
+    private static final RedisScript<Long> COMPARE_AND_ROTATE = RedisScript.of(
+            "local cur = redis.call('GET', KEYS[1]) " +
+                    "if cur == ARGV[1] then " +
+                    "  redis.call('SET', KEYS[2], cur, 'EX', ARGV[3]) " +
+                    "  redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[4]) " +
+                    "  return 1 " +
+                    "end " +
+                    "return 0", Long.class);
+
     private final StringRedisTemplate redisTemplate;
     private final JwtProperties jwtProperties;
 
@@ -37,21 +50,14 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     // 제시된 토큰의 해시가 저장된 refresh 해시와 일치하는지
     @Override
-    public boolean matches(Long userId, String refreshToken) {
-        String stored = redisTemplate.opsForValue().get(REFRESH_KEY_PREFIX + userId);
-        return stored != null && stored.equals(hash(refreshToken));
-    }
-
-    @Override
-    public void delete(Long userId) {
-        redisTemplate.delete(REFRESH_KEY_PREFIX + userId);
-        redisTemplate.delete(GRACE_KEY_PREFIX + userId);
-    }
-
-    // 직전 refresh를 grace 창(5초) 동안 해시로 보관
-    @Override
-    public void saveGrace(Long userId, String refreshToken) {
-        redisTemplate.opsForValue().set(GRACE_KEY_PREFIX + userId, hash(refreshToken), GRACE_TTL);
+    public boolean compareAndRotate(Long userId, String presentedToken, String newRefreshToken) {
+        Long rotated = redisTemplate.execute(COMPARE_AND_ROTATE,
+                List.of(REFRESH_KEY_PREFIX + userId, GRACE_KEY_PREFIX + userId),
+                hash(presentedToken),
+                hash(newRefreshToken),
+                String.valueOf(GRACE_TTL.getSeconds()),
+                String.valueOf(jwtProperties.refreshExpiration().getSeconds()));
+        return Long.valueOf(1L).equals(rotated);
     }
 
     // 제시된 토큰의 해시가 grace 해시와 일치하는지
@@ -59,6 +65,12 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
     public boolean matchesGrace(Long userId, String refreshToken) {
         String stored = redisTemplate.opsForValue().get(GRACE_KEY_PREFIX + userId);
         return stored != null && stored.equals(hash(refreshToken));
+    }
+
+    @Override
+    public void delete(Long userId) {
+        redisTemplate.delete(REFRESH_KEY_PREFIX + userId);
+        redisTemplate.delete(GRACE_KEY_PREFIX + userId);
     }
 
     // SHA-256 해시 -> 16진 문자열 (외부 의존성 없이 JDK만)
@@ -71,5 +83,4 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
             throw new IllegalStateException("SHA-256 not available", e);
         }
     }
-
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -20,7 +20,7 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     private static final String ATTEMPT_KEY_PREFIX = "auth:verify:attempt:";
     private static final RedisScript<Long> INCR_WITH_TTL = RedisScript.of(
             "local c = redis.call('INCR', KEYS[1]) " +
-                    "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
+                    "if c == 1 or redis.call('TTL', KEYS[1]) == -1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
                     "return c", Long.class);
     private final StringRedisTemplate redisTemplate;
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -2,9 +2,11 @@ package com.pokade.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,7 +18,10 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     private static final String CODE_KEY_PREFIX = "auth:verify:code:";
     private static final String COOLDOWN_KEY_PREFIX = "auth:verify:cooldown:";
     private static final String ATTEMPT_KEY_PREFIX = "auth:verify:attempt:";
-
+    private static final RedisScript<Long> INCR_WITH_TTL = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1]) " +
+                    "if c == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
+                    "return c", Long.class);
     private final StringRedisTemplate redisTemplate;
 
     @Override
@@ -43,10 +48,9 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
 
     @Override
     public void incrementAttempt(String email) {
-        Long count = redisTemplate.opsForValue().increment(ATTEMPT_KEY_PREFIX + email);
-        if (count != null && count == 1) {
-            redisTemplate.expire(ATTEMPT_KEY_PREFIX + email, CODE_TTL);
-        }
+        redisTemplate.execute(INCR_WITH_TTL,
+                List.of(ATTEMPT_KEY_PREFIX + email),
+                String.valueOf(CODE_TTL.getSeconds()));
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
@@ -3,8 +3,7 @@ package com.pokade.domain.auth.service;
 public interface RefreshTokenStore {
     void save(Long userId, String refreshToken);
     boolean exists(Long userId);
-    boolean matches(Long userId, String refreshToken);
-    void delete(Long userId);
-    void saveGrace(Long userId, String refreshToken);
+    boolean compareAndRotate(Long userId, String presentedToken, String newRefreshToken);
     boolean matchesGrace(Long userId, String refreshToken);
+    void delete(Long userId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RefreshTokenStore.java
@@ -2,8 +2,9 @@ package com.pokade.domain.auth.service;
 
 public interface RefreshTokenStore {
     void save(Long userId, String refreshToken);
-    String find(Long userId);
+    boolean exists(Long userId);
+    boolean matches(Long userId, String refreshToken);
     void delete(Long userId);
     void saveGrace(Long userId, String refreshToken);
-    String findGrace(Long userId);
+    boolean matchesGrace(Long userId, String refreshToken);
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
@@ -126,4 +126,19 @@ class AuthControllerTest {
         assertThat(result).hasStatusOk();
         then(authService).should().logout(null);
     }
+
+    @Test
+    @DisplayName("grace 수렴 재발급이면 refresh 쿠키를 세팅하지 않고 새 access만 반환한다")
+    void reissue_graceConverges_noCookie() {
+        given(authService.reissue("old-refresh")).willReturn(new TokenPair("new-access", null));
+
+        MvcTestResult result = mockMvcTester.post()
+                .uri("/api/auth/reissue")
+                .cookie(new Cookie("refreshToken", "old-refresh"))
+                .exchange();
+
+        assertThat(result).hasStatusOk();
+        assertThat(result.getResponse().getHeader(HttpHeaders.SET_COOKIE)).isNull(); // 쿠키 미세팅
+        then(authService).should().reissue("old-refresh");
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -171,23 +171,22 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("저장된 refresh와 일치하면 회전(새 access+새 refresh)하고 직전 refresh를 grace에 보관한다")
+    @DisplayName("저장된 refresh와 일치하면 원자 회전(compareAndRotate)하고 새 access+새 refresh를 반환한다")
     void reissue_success() {
         String oldRefresh = "old-refresh";
         given(jwtTokenProvider.isValid(oldRefresh)).willReturn(true);
         given(jwtTokenProvider.getUserId(oldRefresh)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
-        given(refreshTokenStore.matches(1L, oldRefresh)).willReturn(true);
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
+        given(refreshTokenStore.compareAndRotate(1L, oldRefresh, "new-refresh")).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
         given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
-        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
 
         TokenPair result = authService.reissue(oldRefresh);
 
         assertThat(result.accessToken()).isEqualTo("new-access");
         assertThat(result.refreshToken()).isEqualTo("new-refresh");
-        then(refreshTokenStore).should().saveGrace(1L, oldRefresh);
-        then(refreshTokenStore).should().save(1L, "new-refresh");
+        then(refreshTokenStore).should().compareAndRotate(1L, oldRefresh, "new-refresh");
     }
 
     @Test
@@ -219,7 +218,8 @@ class AuthServiceTest {
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
-        given(refreshTokenStore.matches(1L, presented)).willReturn(false);
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("unused-new");
+        given(refreshTokenStore.compareAndRotate(1L, presented, "unused-new")).willReturn(false);
         given(refreshTokenStore.matchesGrace(1L, presented)).willReturn(false);
 
         assertThatThrownBy(() -> authService.reissue(presented))
@@ -236,7 +236,8 @@ class AuthServiceTest {
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
-        given(refreshTokenStore.matches(1L, presented)).willReturn(false);
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("unused-new");
+        given(refreshTokenStore.compareAndRotate(1L, presented, "unused-new")).willReturn(false);
         given(refreshTokenStore.matchesGrace(1L, presented)).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
         given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
@@ -255,7 +256,8 @@ class AuthServiceTest {
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
-        given(refreshTokenStore.matches(1L, presented)).willReturn(true);
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
+        given(refreshTokenStore.compareAndRotate(1L, presented, "new-refresh")).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> authService.reissue(presented))

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -176,7 +176,8 @@ class AuthServiceTest {
         String oldRefresh = "old-refresh";
         given(jwtTokenProvider.isValid(oldRefresh)).willReturn(true);
         given(jwtTokenProvider.getUserId(oldRefresh)).willReturn(1L);
-        given(refreshTokenStore.find(1L)).willReturn(oldRefresh);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(refreshTokenStore.matches(1L, oldRefresh)).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
         given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
         given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
@@ -204,7 +205,7 @@ class AuthServiceTest {
     void reissue_noStoredToken() {
         given(jwtTokenProvider.isValid("r")).willReturn(true);
         given(jwtTokenProvider.getUserId("r")).willReturn(1L);
-        given(refreshTokenStore.find(1L)).willReturn(null);
+        given(refreshTokenStore.exists(1L)).willReturn(false);
 
         assertThatThrownBy(() -> authService.reissue("r"))
                 .isInstanceOf(BusinessException.class)
@@ -212,13 +213,14 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("저장값과 불일치하고 grace도 아니면 TOKEN_STOLEN 예외를 던지고 저장 토큰을 삭제한다")
+    @DisplayName("저장값·grace 모두와 불일치하면 TOKEN_STOLEN을 던지고 저장 토큰을 삭제한다")
     void reissue_stolen() {
         String presented = "stale-refresh";
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
-        given(refreshTokenStore.find(1L)).willReturn("current-refresh");
-        given(refreshTokenStore.findGrace(1L)).willReturn(null);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(refreshTokenStore.matches(1L, presented)).willReturn(false);
+        given(refreshTokenStore.matchesGrace(1L, presented)).willReturn(false);
 
         assertThatThrownBy(() -> authService.reissue(presented))
                 .isInstanceOf(BusinessException.class)
@@ -228,20 +230,21 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("저장값과 불일치해도 grace와 일치하면 재회전 없이 새 access만 발급하고 현재 refresh로 수렴한다")
+    @DisplayName("저장값과 불일치해도 grace와 일치하면 재회전 없이 새 access만 발급하고 refresh는 재세팅하지 않는다")
     void reissue_graceConverges() {
         String presented = "old-refresh";
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
-        given(refreshTokenStore.find(1L)).willReturn("current-refresh");
-        given(refreshTokenStore.findGrace(1L)).willReturn(presented);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(refreshTokenStore.matches(1L, presented)).willReturn(false);
+        given(refreshTokenStore.matchesGrace(1L, presented)).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
         given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
 
         TokenPair result = authService.reissue(presented);
 
         assertThat(result.accessToken()).isEqualTo("new-access");
-        assertThat(result.refreshToken()).isEqualTo("current-refresh");
+        assertThat(result.refreshToken()).isNull(); // Option Y: grace 수렴은 새 access만, refresh 없음
         then(refreshTokenStore).should(never()).save(any(), any());
     }
 
@@ -251,7 +254,8 @@ class AuthServiceTest {
         String presented = "current-refresh";
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
-        given(refreshTokenStore.find(1L)).willReturn(presented);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(refreshTokenStore.matches(1L, presented)).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> authService.reissue(presented))

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
@@ -63,7 +63,7 @@ class RedisRefreshTokenStoreTest {
         store.save(1L, "refresh-token");
 
         String raw = redisTemplate.opsForValue().get("auth:refresh:1");
-        assertThat(raw).isNotNull().isNotEqualTo("refresh-token"); // 원문이 아니라 해시
+        assertThat(raw).isNotNull().isNotEqualTo("refresh-token");
         Long ttl = redisTemplate.getExpire("auth:refresh:1");
         assertThat(ttl).isNotNull().isGreaterThan(0);
     }
@@ -77,57 +77,69 @@ class RedisRefreshTokenStoreTest {
     }
 
     @Test
-    @DisplayName("matches는 동일 원문 토큰이면 true를 반환한다")
-    void matches_trueForSameToken() {
-        store.save(1L, "refresh-token");
+    @DisplayName("compareAndRotate는 현재 refresh와 일치하면 회전하고 옛 토큰을 grace로 옮긴다")
+    void compareAndRotate_rotatesAndMovesOldToGrace() {
+        store.save(1L, "R0");
 
-        assertThat(store.matches(1L, "refresh-token")).isTrue();
+        assertThat(store.compareAndRotate(1L, "R0", "R1")).isTrue();
+        assertThat(store.matchesGrace(1L, "R0")).isTrue();           // 옛 current -> grace
+        assertThat(store.compareAndRotate(1L, "R1", "R2")).isTrue(); // 새 current는 R1
     }
 
     @Test
-    @DisplayName("matches는 다른 토큰이면 false를 반환한다")
-    void matches_falseForDifferentToken() {
-        store.save(1L, "refresh-token");
+    @DisplayName("compareAndRotate는 현재 refresh와 다르면 회전하지 않고 false")
+    void compareAndRotate_falseWhenNotCurrent() {
+        store.save(1L, "R0");
 
-        assertThat(store.matches(1L, "other-token")).isFalse();
+        assertThat(store.compareAndRotate(1L, "WRONG", "R1")).isFalse();
+        assertThat(store.compareAndRotate(1L, "R0", "R1")).isTrue(); // current는 그대로 R0였음
     }
 
     @Test
-    @DisplayName("matches는 저장된 값이 없으면 false를 반환한다")
-    void matches_falseWhenAbsent() {
-        assertThat(store.matches(999L, "refresh-token")).isFalse();
+    @DisplayName("compareAndRotate는 저장이 없으면 false")
+    void compareAndRotate_falseWhenAbsent() {
+        assertThat(store.compareAndRotate(999L, "R0", "R1")).isFalse();
     }
 
     @Test
-    @DisplayName("saveGrace하면 해시가 저장되고 TTL이 5초 이하로 설정된다")
-    void saveGrace_storesHashedWithShortTtl() {
-        store.saveGrace(1L, "old-refresh");
+    @DisplayName("같은 현재 refresh로 두 번째 회전은 실패하고 grace로 수렴한다 (동시요청 double-rotate 방지)")
+    void compareAndRotate_secondCallWithSameCurrentHitsGrace() {
+        store.save(1L, "R0");
 
-        String raw = redisTemplate.opsForValue().get("auth:refresh:grace:1");
-        assertThat(raw).isNotNull().isNotEqualTo("old-refresh");
+        assertThat(store.compareAndRotate(1L, "R0", "R1a")).isTrue();  // A: 회전 성공
+        assertThat(store.compareAndRotate(1L, "R0", "R1b")).isFalse(); // B: 같은 R0 -> 재회전 차단
+        assertThat(store.matchesGrace(1L, "R0")).isTrue();            // B는 grace로 수렴
+    }
+
+    @Test
+    @DisplayName("compareAndRotate 시 grace TTL이 5초 이하로 설정된다")
+    void compareAndRotate_graceTtlIsShort() {
+        store.save(1L, "R0");
+        store.compareAndRotate(1L, "R0", "R1");
+
         Long ttl = redisTemplate.getExpire("auth:refresh:grace:1");
         assertThat(ttl).isNotNull().isGreaterThan(0).isLessThanOrEqualTo(5);
     }
 
     @Test
-    @DisplayName("matchesGrace는 동일 원문 토큰이면 true, 다르면 false")
-    void matchesGrace_matchesOnlySameToken() {
-        store.saveGrace(1L, "old-refresh");
+    @DisplayName("matchesGrace는 grace로 옮겨진 옛 토큰이면 true, 아니면 false")
+    void matchesGrace_reflectsGraceContent() {
+        store.save(1L, "R0");
+        store.compareAndRotate(1L, "R0", "R1");
 
-        assertThat(store.matchesGrace(1L, "old-refresh")).isTrue();
+        assertThat(store.matchesGrace(1L, "R0")).isTrue();
         assertThat(store.matchesGrace(1L, "other")).isFalse();
     }
 
     @Test
     @DisplayName("delete하면 refresh와 grace가 모두 제거된다")
     void delete_removesBoth() {
-        store.save(1L, "refresh-token");
-        store.saveGrace(1L, "old-refresh");
+        store.save(1L, "R0");
+        store.compareAndRotate(1L, "R0", "R1"); // current=R1, grace=R0
 
         store.delete(1L);
 
         assertThat(store.exists(1L)).isFalse();
-        assertThat(store.matches(1L, "refresh-token")).isFalse();
-        assertThat(store.matchesGrace(1L, "old-refresh")).isFalse();
+        assertThat(store.matchesGrace(1L, "R0")).isFalse();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.auth.service;
 
 import com.pokade.global.security.JwtProperties;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,62 +47,87 @@ class RedisRefreshTokenStoreTest {
         }
     }
 
+    @BeforeEach
+    void flush() {
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushDb();
+    }
+
     @Autowired
     RedisRefreshTokenStore store;
     @Autowired
     StringRedisTemplate redisTemplate;
 
     @Test
-    @DisplayName("save하면 auth:refresh:<userId> 키에 토큰이 저장되고 TTL이 설정된다")
-    void save_storesTokenWithTtl() {
+    @DisplayName("save하면 원문이 아닌 해시가 저장되고 TTL이 설정된다")
+    void save_storesHashedTokenWithTtl() {
         store.save(1L, "refresh-token");
 
-        assertThat(redisTemplate.opsForValue().get("auth:refresh:1")).isEqualTo("refresh-token");
+        String raw = redisTemplate.opsForValue().get("auth:refresh:1");
+        assertThat(raw).isNotNull().isNotEqualTo("refresh-token"); // 원문이 아니라 해시
         Long ttl = redisTemplate.getExpire("auth:refresh:1");
         assertThat(ttl).isNotNull().isGreaterThan(0);
     }
 
     @Test
-    @DisplayName("find는 저장된 refresh 토큰을 반환한다")
-    void find_returnsStoredToken() {
+    @DisplayName("exists는 save 후 true, 저장이 없으면 false")
+    void exists_reflectsPresence() {
+        assertThat(store.exists(1L)).isFalse();
+        store.save(1L, "refresh-token");
+        assertThat(store.exists(1L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("matches는 동일 원문 토큰이면 true를 반환한다")
+    void matches_trueForSameToken() {
         store.save(1L, "refresh-token");
 
-        assertThat(store.find(1L)).isEqualTo("refresh-token");
+        assertThat(store.matches(1L, "refresh-token")).isTrue();
     }
 
     @Test
-    @DisplayName("find는 저장된 값이 없으면 null을 반환한다")
-    void find_returnsNullWhenAbsent() {
-        assertThat(store.find(999L)).isNull();
+    @DisplayName("matches는 다른 토큰이면 false를 반환한다")
+    void matches_falseForDifferentToken() {
+        store.save(1L, "refresh-token");
+
+        assertThat(store.matches(1L, "other-token")).isFalse();
     }
 
     @Test
-    @DisplayName("saveGrace하면 auth:refresh:grace:<userId>에 저장되고 TTL이 60초 이하로 설정된다")
-    void saveGrace_storesGraceTokenWithShortTtl() {
+    @DisplayName("matches는 저장된 값이 없으면 false를 반환한다")
+    void matches_falseWhenAbsent() {
+        assertThat(store.matches(999L, "refresh-token")).isFalse();
+    }
+
+    @Test
+    @DisplayName("saveGrace하면 해시가 저장되고 TTL이 5초 이하로 설정된다")
+    void saveGrace_storesHashedWithShortTtl() {
         store.saveGrace(1L, "old-refresh");
 
-        assertThat(redisTemplate.opsForValue().get("auth:refresh:grace:1")).isEqualTo("old-refresh");
+        String raw = redisTemplate.opsForValue().get("auth:refresh:grace:1");
+        assertThat(raw).isNotNull().isNotEqualTo("old-refresh");
         Long ttl = redisTemplate.getExpire("auth:refresh:grace:1");
-        assertThat(ttl).isNotNull().isGreaterThan(0).isLessThanOrEqualTo(60);
+        assertThat(ttl).isNotNull().isGreaterThan(0).isLessThanOrEqualTo(5);
     }
 
     @Test
-    @DisplayName("findGrace는 저장된 grace 토큰을 반환한다")
-    void findGrace_returnsStoredGraceToken() {
+    @DisplayName("matchesGrace는 동일 원문 토큰이면 true, 다르면 false")
+    void matchesGrace_matchesOnlySameToken() {
         store.saveGrace(1L, "old-refresh");
 
-        assertThat(store.findGrace(1L)).isEqualTo("old-refresh");
+        assertThat(store.matchesGrace(1L, "old-refresh")).isTrue();
+        assertThat(store.matchesGrace(1L, "other")).isFalse();
     }
 
     @Test
-    @DisplayName("delete하면 refresh와 grace 토큰이 함께 제거된다")
-    void delete_removesBothRefreshAndGrace() {
+    @DisplayName("delete하면 refresh와 grace가 모두 제거된다")
+    void delete_removesBoth() {
         store.save(1L, "refresh-token");
         store.saveGrace(1L, "old-refresh");
 
         store.delete(1L);
 
-        assertThat(store.find(1L)).isNull();
-        assertThat(store.findGrace(1L)).isNull();
+        assertThat(store.exists(1L)).isFalse();
+        assertThat(store.matches(1L, "refresh-token")).isFalse();
+        assertThat(store.matchesGrace(1L, "old-refresh")).isFalse();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1,16 +1,17 @@
 package com.pokade.domain.price.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.price.dto.TradeSummaryResponse;
+import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,18 +19,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.pokade.domain.card.repository.CardRepository;
-import com.pokade.domain.card.repository.CardVariantRepository;
-import com.pokade.domain.listing.Listing;
-import com.pokade.domain.listing.ListingGrade;
-import com.pokade.domain.listing.ListingRepository;
-import com.pokade.domain.price.dto.TradeSummaryResponse;
-import com.pokade.domain.price.repository.BuyOfferRepository;
-import com.pokade.domain.trade.Trade;
-import com.pokade.domain.trade.TradeRepository;
-import com.pokade.domain.trade.TradeStatus;
-import com.pokade.global.exception.BusinessException;
-import com.pokade.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class PriceServiceTest {

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.trade;
+package com.pokade.domain.trade.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.trade.dto.TradeCreateRequest;


### PR DESCRIPTION
## 📌 관련 이슈
- #69

## ✨ 작업 내용
**1. grace 수렴 재설계 (리뷰 Critical 대응)** — `54e4999`
- 기존 grace 분기가 현재 유효한 refresh(R2)를 쿠키로 재노출 → 공격자가 grace 창에 탈취한 옛 refresh를 replay하면 세션 탈취 가능했음
- grace 수렴 시 **새 access만 발급**, refresh 재발급·쿠키 재세팅 제거(Option Y). refresh가 없으면 `Set-Cookie` 스킵
- grace TTL 60s → 5s

**2. refresh 토큰 SHA-256 해시 저장** — `54e4999` (1과 커플링)
- Redis에 원문 대신 해시 저장·대조 → 저장소 유출 시 replay 차단
- `RefreshTokenStore`를 조회(`find`/`findGrace`) → 대조(`exists`/`matches`/`matchesGrace`)로 전환. 해시만 저장하면 grace가 원문을 못 돌려줘 Option Y가 구조적으로 강제됨

**3. Redis 카운터 원자화 정리**
- `RedisVerificationCodeStore.incrementAttempt`: increment→expire 비원자 → Lua로 원자화 (`ccb5c52`)
- `RedisLoginAttemptStore.recordFailure`: Lua가 이미 TTL 원자 처리하는데 남아있던 `if(count==1) expire` 중복 블록 제거 (`fa52a99`)

## 📸 스크린샷 / 테스트 결과
- auth 관련 테스트(store/service/controller) **전부 통과**
  - `reissue_graceConverges` 단언 refresh=null로 수정, grace 쿠키 스킵 컨트롤러 테스트 추가, `RedisRefreshTokenStore` 테스트 재작성 + `@BeforeEach flushDb` 격리
- ⚠️ 전체 스위트 중 `TradeControllerTest` 5건 실패는 이 PR의 auth 로직과 **무관한 거래 도메인 이슈**(상태코드 AssertionError)

## 🔍 리뷰 포인트
- grace 수렴이 새 access만 반환하고 refresh 쿠키를 건드리지 않는지 (`AuthService.reissue` / `AuthController`)
- 해시 대조 전환(`exists`/`matches`/`matchesGrace`)의 분기 정확성 (INVALID vs TOKEN_STOLEN 구분)
- (후속·별도 이슈) reissue 회전 비원자성, aud 검증(ASVS 9.2.3), 토큰 타입 클레임(9.2.2)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? <!-- auth 전부 통과 / Trade 5건은 무관·별도 -->
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 리프레시 토큰 재발급 과정의 보안이 강화되었습니다.
  * 토큰 원문 대신 안전한 방식으로 검증하며, 의심스러운 토큰 사용 시 즉시 무효화됩니다.
  * 정상적인 동시 재발급 요청은 불필요한 리프레시 토큰 재발급 없이 처리됩니다.
  * 새 리프레시 토큰이 발급되지 않는 경우 기존 쿠키를 유지합니다.
  * 로그인 및 인증 코드 시도 횟수와 만료 시간이 더욱 안정적으로 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->