### PR TITLE
[Feature] #74 카드 목록 일괄 조회 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -15,4 +15,14 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
 
     @Query("SELECT cv.id FROM CardVariant cv WHERE cv.card.id = :cardId AND cv.primary = true")
     Optional<Long> findPrimaryVariantId(@Param("cardId") Long cardId);
+
+    // 카드 목록(예: /search 20개)의 대표 판본을 한 번에 조회하기 위한 배치 버전 — N+1 방지용.
+    @Query("SELECT cv.card.id AS cardId, cv.id AS variantId FROM CardVariant cv "
+            + "WHERE cv.card.id IN :cardIds AND cv.primary = true")
+    List<PrimaryVariantIdView> findPrimaryVariantIdsByCardIds(@Param("cardIds") List<Long> cardIds);
+
+    interface PrimaryVariantIdView {
+        Long getCardId();
+        Long getVariantId();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -15,8 +15,7 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
 
     @Query("SELECT cv.id FROM CardVariant cv WHERE cv.card.id = :cardId AND cv.primary = true")
     Optional<Long> findPrimaryVariantId(@Param("cardId") Long cardId);
-
-    // 카드 목록(예: /search 20개)의 대표 판본을 한 번에 조회하기 위한 배치 버전 — N+1 방지용.
+    
     @Query("SELECT cv.card.id AS cardId, cv.id AS variantId FROM CardVariant cv "
             + "WHERE cv.card.id IN :cardIds AND cv.primary = true")
     List<PrimaryVariantIdView> findPrimaryVariantIdsByCardIds(@Param("cardIds") List<Long> cardIds);

--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -36,9 +36,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
     Optional<Integer> findLowestActivePrice(@Param("cardId") Long cardId,
                                              @Param("variantId") Long variantId,
                                              @Param("status") ListingStatus status);
-
-    // 여러 판본의 최저 매물가를 한 번에 조회하기 위한 배치 버전(가격 요약 배치 조회용) — variantId가
-    // card_variants.id 그 자체라 카드별로 별도 필터링 없이 variantId만으로 그룹핑해도 충분하다.
+    
     @Query("SELECT l.variantId AS variantId, MIN(l.price) AS price FROM Listing l "
             + "WHERE l.variantId IN :variantIds AND l.status = :status GROUP BY l.variantId")
     List<VariantPriceView> findLowestActivePricesByVariantIds(@Param("variantIds") List<Long> variantIds,

--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -37,6 +37,18 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
                                              @Param("variantId") Long variantId,
                                              @Param("status") ListingStatus status);
 
+    // 여러 판본의 최저 매물가를 한 번에 조회하기 위한 배치 버전(가격 요약 배치 조회용) — variantId가
+    // card_variants.id 그 자체라 카드별로 별도 필터링 없이 variantId만으로 그룹핑해도 충분하다.
+    @Query("SELECT l.variantId AS variantId, MIN(l.price) AS price FROM Listing l "
+            + "WHERE l.variantId IN :variantIds AND l.status = :status GROUP BY l.variantId")
+    List<VariantPriceView> findLowestActivePricesByVariantIds(@Param("variantIds") List<Long> variantIds,
+                                                               @Param("status") ListingStatus status);
+
+    interface VariantPriceView {
+        Long getVariantId();
+        Integer getPrice();
+    }
+
     // ACTIVE 상태인 매물만 원자적으로 TRADING으로 전환. 반환값 0 = 이미 팔렸거나 존재하지 않음(동시 구매 충돌)
     @Modifying
     @Query("UPDATE Listing l SET l.status = com.pokade.domain.listing.entity.ListingStatus.TRADING "

--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -29,8 +29,6 @@ public class PriceController {
         return ApiResponse.ok(priceService.getSummary(cardId, variantId));
     }
 
-    // /search 카드 그리드처럼 여러 카드의 즉시구매가/판매가를 한 번에 조회하기 위한 배치 버전.
-    // 예: /api/prices/summaries?cardIds=1,2,3 — 항상 각 카드의 대표 판본 기준(variantId 지정 불가).
     @GetMapping("/summaries")
     public ApiResponse<List<CardPriceSummaryResponse>> getSummaries(@RequestParam List<Long> cardIds) {
         return ApiResponse.ok(priceService.getSummaries(cardIds));

--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.price.controller;
 
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
@@ -26,6 +27,13 @@ public class PriceController {
             @RequestParam(required = false) Long variantId
     ) {
         return ApiResponse.ok(priceService.getSummary(cardId, variantId));
+    }
+
+    // /search 카드 그리드처럼 여러 카드의 즉시구매가/판매가를 한 번에 조회하기 위한 배치 버전.
+    // 예: /api/prices/summaries?cardIds=1,2,3 — 항상 각 카드의 대표 판본 기준(variantId 지정 불가).
+    @GetMapping("/summaries")
+    public ApiResponse<List<CardPriceSummaryResponse>> getSummaries(@RequestParam List<Long> cardIds) {
+        return ApiResponse.ok(priceService.getSummaries(cardIds));
     }
 
     @GetMapping("/{cardId}/trades")

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/CardPriceSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/CardPriceSummaryResponse.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.price.dto;
+
+public record CardPriceSummaryResponse(
+        Long cardId,
+        Integer buyPrice,
+        Integer sellPrice,
+        String currency
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/BuyOfferRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/BuyOfferRepository.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.repository;
 
 import com.pokade.domain.price.entity.BuyOffer;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,14 @@ public interface BuyOfferRepository extends JpaRepository<BuyOffer, Long> {
     @Query("SELECT MAX(b.price) FROM BuyOffer b "
             + "WHERE b.cardId = :cardId AND b.variantId = :variantId AND b.status = 'ACTIVE'")
     Optional<Integer> findHighestActivePrice(@Param("cardId") Long cardId, @Param("variantId") Long variantId);
+
+    // 여러 판본의 최고 구매호가를 한 번에 조회하기 위한 배치 버전(가격 요약 배치 조회용).
+    @Query("SELECT b.variantId AS variantId, MAX(b.price) AS price FROM BuyOffer b "
+            + "WHERE b.variantId IN :variantIds AND b.status = 'ACTIVE' GROUP BY b.variantId")
+    List<VariantPriceView> findHighestActivePricesByVariantIds(@Param("variantIds") List<Long> variantIds);
+
+    interface VariantPriceView {
+        Long getVariantId();
+        Integer getPrice();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -5,6 +5,7 @@ import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.price.ChartPeriod;
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
@@ -19,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +30,8 @@ public class PriceService {
 
     private static final String CURRENCY = "KRW";
     private static final int RECENT_TRADES_LIMIT = 20;
+    // /search 한 페이지(20개) 조회 기준보다 넉넉한 상한 — CardService의 MAX_PAGE_SIZE(100)와 동일한 취지.
+    private static final int MAX_SUMMARIES_BATCH_SIZE = 100;
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
@@ -50,6 +55,54 @@ public class PriceService {
         Integer sellPrice = buyOfferRepository.findHighestActivePrice(cardId, resolvedVariantId).orElse(null);
 
         return new PriceSummaryResponse(buyPrice, sellPrice, CURRENCY);
+    }
+
+    // /search 등에서 카드 여러 장을 한 번에 그릴 때 getSummary()를 카드 수만큼 호출하는 N+1을 피하기
+    // 위한 배치 버전. 항상 대표 판본(primary variant) 기준이라 카드별 variantId 지정은 지원하지 않는다.
+    // 존재하지 않는 카드/대표 판본이 없는 카드는 요청 자체를 실패시키지 않고 buyPrice/sellPrice를
+    // null로 채워 응답한다 — 응답 배열은 항상 distinct한 요청 cardId 개수만큼 나온다(FE가 배열 길이나
+    // 순서에 의존하지 않고 cardId로 매칭할 수 있게).
+    public List<CardPriceSummaryResponse> getSummaries(List<Long> cardIds) {
+        if (cardIds == null || cardIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최소 1개 이상 필요합니다.");
+        }
+        if (cardIds.size() > MAX_SUMMARIES_BATCH_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "cardIds는 최대 " + MAX_SUMMARIES_BATCH_SIZE + "개까지 조회할 수 있습니다.");
+        }
+
+        List<Long> distinctCardIds = cardIds.stream().distinct().toList();
+
+        Map<Long, Long> primaryVariantByCard = cardVariantRepository
+                .findPrimaryVariantIdsByCardIds(distinctCardIds).stream()
+                .collect(Collectors.toMap(
+                        CardVariantRepository.PrimaryVariantIdView::getCardId,
+                        CardVariantRepository.PrimaryVariantIdView::getVariantId));
+
+        List<Long> variantIds = primaryVariantByCard.values().stream().distinct().toList();
+
+        Map<Long, Integer> buyPriceByVariant = variantIds.isEmpty()
+                ? Map.of()
+                : listingRepository.findLowestActivePricesByVariantIds(variantIds, ListingStatus.ACTIVE).stream()
+                        .collect(Collectors.toMap(
+                                ListingRepository.VariantPriceView::getVariantId,
+                                ListingRepository.VariantPriceView::getPrice));
+
+        Map<Long, Integer> sellPriceByVariant = variantIds.isEmpty()
+                ? Map.of()
+                : buyOfferRepository.findHighestActivePricesByVariantIds(variantIds).stream()
+                        .collect(Collectors.toMap(
+                                BuyOfferRepository.VariantPriceView::getVariantId,
+                                BuyOfferRepository.VariantPriceView::getPrice));
+
+        return distinctCardIds.stream()
+                .map(cardId -> {
+                    Long variantId = primaryVariantByCard.get(cardId);
+                    Integer buyPrice = variantId != null ? buyPriceByVariant.get(variantId) : null;
+                    Integer sellPrice = variantId != null ? sellPriceByVariant.get(variantId) : null;
+                    return new CardPriceSummaryResponse(cardId, buyPrice, sellPrice, CURRENCY);
+                })
+                .toList();
     }
 
     public List<TradeSummaryResponse> getRecentTrades(Long cardId) {

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -30,7 +30,6 @@ public class PriceService {
 
     private static final String CURRENCY = "KRW";
     private static final int RECENT_TRADES_LIMIT = 20;
-    // /search 한 페이지(20개) 조회 기준보다 넉넉한 상한 — CardService의 MAX_PAGE_SIZE(100)와 동일한 취지.
     private static final int MAX_SUMMARIES_BATCH_SIZE = 100;
 
     private final CardRepository cardRepository;
@@ -57,11 +56,7 @@ public class PriceService {
         return new PriceSummaryResponse(buyPrice, sellPrice, CURRENCY);
     }
 
-    // /search 등에서 카드 여러 장을 한 번에 그릴 때 getSummary()를 카드 수만큼 호출하는 N+1을 피하기
-    // 위한 배치 버전. 항상 대표 판본(primary variant) 기준이라 카드별 variantId 지정은 지원하지 않는다.
-    // 존재하지 않는 카드/대표 판본이 없는 카드는 요청 자체를 실패시키지 않고 buyPrice/sellPrice를
-    // null로 채워 응답한다 — 응답 배열은 항상 distinct한 요청 cardId 개수만큼 나온다(FE가 배열 길이나
-    // 순서에 의존하지 않고 cardId로 매칭할 수 있게).
+    // N+1을 피하기 위한 배치 버전.
     public List<CardPriceSummaryResponse> getSummaries(List<Long> cardIds) {
         if (cardIds == null || cardIds.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최소 1개 이상 필요합니다.");

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -87,6 +87,20 @@ INSERT INTO card_variants (card_id, variant_name, is_primary, synced_at) VALUES 
 INSERT INTO card_prices (variant_id, price_type, grade, company, low, mid, high, market, currency, change_1d_pct, change_7d_pct, change_14d_pct, change_30d_pct, change_90d_pct, change_180d_pct, change_7d_amount, updated_at) VALUES ((SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'sv10_ja-1') AND variant_name = 'normal'), 'graded', '10', 'PSA', 5.0, 5.6, 6.2, 5.7, 'JPY', NULL, 0.0, NULL, 1.79, 3.64, NULL, 0.0, now()) ON CONFLICT (variant_id, price_type, grade, company) DO NOTHING;
 INSERT INTO card_prices (variant_id, price_type, grade, company, low, mid, high, market, currency, change_1d_pct, change_7d_pct, change_14d_pct, change_30d_pct, change_90d_pct, change_180d_pct, change_7d_amount, updated_at) VALUES ((SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'sv10_ja-1') AND variant_name = 'normal'), 'graded', '9', 'PSA', 2.0, 2.3, 2.6, 2.35, 'JPY', NULL, 0.0, NULL, 2.22, 4.44, NULL, 0.0, now()) ON CONFLICT (variant_id, price_type, grade, company) DO NOTHING;
 
+-- GET /api/cards?sort=popular 테스트용 view_count 더미 값 (신규 카드는 위 INSERT가 0으로 넣으므로 매 재기동 시 덮어써서 편차를 유지)
+UPDATE cards SET view_count = 15000 WHERE external_id = 'base1-4';
+UPDATE cards SET view_count = 12000 WHERE external_id = 'sv3pt5-6';
+UPDATE cards SET view_count = 9000 WHERE external_id = 'sm3-20';
+UPDATE cards SET view_count = 7000 WHERE external_id = 'base1-2';
+UPDATE cards SET view_count = 6000 WHERE external_id = 'base1-58';
+UPDATE cards SET view_count = 5500 WHERE external_id = 'sv3pt5-25';
+UPDATE cards SET view_count = 4000 WHERE external_id = 'sv3pt5-54';
+UPDATE cards SET view_count = 3000 WHERE external_id = 'zsv10pt5-105';
+UPDATE cards SET view_count = 2500 WHERE external_id = 'me1-12';
+UPDATE cards SET view_count = 1800 WHERE external_id = 'xy7-54';
+UPDATE cards SET view_count = 1200 WHERE external_id = 'sm11-95';
+UPDATE cards SET view_count = 300 WHERE external_id = 'sv10_ja-1';
+
 
 -- =========================================================
 -- FR-PRICE-01 검증용 시드 (users / listings / buy_offers)

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.global.exception.BusinessException;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -122,6 +124,41 @@ class PriceControllerTest {
     @Test
     void period_파라미터가_없으면_400을_반환한다() throws Exception {
         mockMvc.perform(get("/api/prices/1/chart"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 배치_요약_조회시_cardIds에_해당하는_요약_목록을_반환한다() throws Exception {
+        List<CardPriceSummaryResponse> summaries = List.of(
+                new CardPriceSummaryResponse(1L, 3000000, null, "KRW"),
+                new CardPriceSummaryResponse(2L, null, 2000000, "KRW")
+        );
+        given(priceService.getSummaries(List.of(1L, 2L))).willReturn(summaries);
+
+        mockMvc.perform(get("/api/prices/summaries").param("cardIds", "1,2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].cardId").value(1))
+                .andExpect(jsonPath("$.data[0].buyPrice").value(3000000))
+                .andExpect(jsonPath("$.data[0].sellPrice").value(nullValue()))
+                .andExpect(jsonPath("$.data[1].cardId").value(2))
+                .andExpect(jsonPath("$.data[1].sellPrice").value(2000000));
+    }
+
+    @Test
+    void 배치_요약_조회시_cardIds가_없으면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/prices/summaries"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 배치_요약_조회시_상한을_넘으면_400을_반환한다() throws Exception {
+        given(priceService.getSummaries(any()))
+                .willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최대 100개까지 조회할 수 있습니다."));
+
+        mockMvc.perform(get("/api/prices/summaries").param("cardIds", "1,2,3"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -4,7 +4,9 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
 import com.pokade.domain.trade.entity.Trade;
@@ -101,5 +103,90 @@ class PriceServiceTest {
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_PERIOD);
         verify(tradeRepository, never()).findCompletedTradesSince(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("t5 여러 카드를 배치 조회하면 카드별 대표 판본 기준 가격을 반환하고, "
+            + "대표 판본이 없는 카드는 가격을 null로 채운다")
+    void t5() {
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(
+                        primaryVariantIdView(1L, 10L),
+                        primaryVariantIdView(2L, 20L)
+                        // 3L은 대표 판본이 없는 카드로 취급(응답에서 variantId 없음)
+                ));
+        given(listingRepository.findLowestActivePricesByVariantIds(List.of(10L, 20L), ListingStatus.ACTIVE))
+                .willReturn(List.of(listingPriceView(10L, 3000000)));
+        given(buyOfferRepository.findHighestActivePricesByVariantIds(List.of(10L, 20L)))
+                .willReturn(List.of(buyOfferPriceView(20L, 2000000)));
+
+        List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L, 2L, 3L));
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0)).isEqualTo(new CardPriceSummaryResponse(1L, 3000000, null, "KRW"));
+        assertThat(result.get(1)).isEqualTo(new CardPriceSummaryResponse(2L, null, 2000000, "KRW"));
+        assertThat(result.get(2)).isEqualTo(new CardPriceSummaryResponse(3L, null, null, "KRW"));
+    }
+
+    @Test
+    @DisplayName("t6 cardIds가 비어 있으면 INVALID_INPUT 예외가 발생한다")
+    void t6() {
+        assertThatThrownBy(() -> priceService.getSummaries(List.of()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t7 cardIds가 상한(100개)을 넘으면 INVALID_INPUT 예외가 발생한다")
+    void t7() {
+        List<Long> tooMany = java.util.stream.LongStream.rangeClosed(1, 101).boxed().toList();
+
+        assertThatThrownBy(() -> priceService.getSummaries(tooMany))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    private CardVariantRepository.PrimaryVariantIdView primaryVariantIdView(Long cardId, Long variantId) {
+        return new CardVariantRepository.PrimaryVariantIdView() {
+            @Override
+            public Long getCardId() {
+                return cardId;
+            }
+
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+        };
+    }
+
+    private ListingRepository.VariantPriceView listingPriceView(Long variantId, Integer price) {
+        return new ListingRepository.VariantPriceView() {
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+
+            @Override
+            public Integer getPrice() {
+                return price;
+            }
+        };
+    }
+
+    private BuyOfferRepository.VariantPriceView buyOfferPriceView(Long variantId, Integer price) {
+        return new BuyOfferRepository.VariantPriceView() {
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+
+            @Override
+            public Integer getPrice() {
+                return price;
+            }
+        };
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -72,7 +72,7 @@ class TradeControllerTest {
                 .willReturn(response);
 
         mockMvc.perform(post("/api/trades")
-                        .with(userId(200L))
+                        .header("X-USER-ID", 200L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -86,7 +86,7 @@ class TradeControllerTest {
         TradeCreateRequest invalidRequest = new TradeCreateRequest(null);
 
         mockMvc.perform(post("/api/trades")
-                        .with(userId(200L))
+                        .header("X-USER-ID", 200L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest())
@@ -101,7 +101,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED));
 
         mockMvc.perform(post("/api/trades")
-                        .with(userId(100L))
+                        .header("X-USER-ID", 100L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -116,7 +116,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));
 
         mockMvc.perform(post("/api/trades")
-                        .with(userId(200L))
+                        .header("X-USER-ID", 200L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -131,7 +131,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.TRADE_CONFLICT));
 
         mockMvc.perform(post("/api/trades")
-                        .with(userId(200L))
+                        .header("X-USER-ID", 200L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -72,7 +72,7 @@ class TradeControllerTest {
                 .willReturn(response);
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -86,7 +86,7 @@ class TradeControllerTest {
         TradeCreateRequest invalidRequest = new TradeCreateRequest(null);
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest())
@@ -101,7 +101,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 100L)
+                        .with(userId(100L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -116,7 +116,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -131,7 +131,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.TRADE_CONFLICT));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())


### PR DESCRIPTION
## 📌 관련 이슈
- #74 

## ✨ 작업 내용
- 여러 카드의 시세 요약을 한 번에 조회하는 벌크 API 추가
  - `GET /api/prices/summaries?cardIds=1,2,3,4`
  - 카드 검색 목록에서 카드별 개별 호출 없이 1회 호출로 시세 표시 가능
- 응답 DTO `CardPriceSummaryResponse` 추가 (cardId별 buyPrice / sellPrice / currency)
- listings 최저가 / buy_offers 최고가를 IN 절 기반으로 일괄 조회하여 N+1 방지
- 벌크 조회 검증용 시드 데이터 보강 (data.sql)

## 📸 스크린샷 / 테스트 결과
- 로컬 `./gradlew compileJava` 성공
- 단위/컨트롤러 테스트 통과 (PriceServiceTest / PriceControllerTest)

## 🔍 리뷰 포인트
- **N+1 방지 쿼리** — 카드별 반복 조회가 아니라 IN 절 기반 일괄 조회로 쿼리 수를 최소화했습니다. 쿼리 방식이 적절한지 봐주세요.
- **응답 형식** — `List<CardPriceSummaryResponse>` 배열로 반환합니다. FE 검색 목록에서 cardId로 매핑해 쓰기 편한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 여러 카드의 가격 요약을 한 번에 조회할 수 있는 API가 추가되었습니다.
  - 카드별 매입가, 판매가, 통화 정보를 제공합니다.
  - 대표 판본이 없거나 가격 정보가 없는 경우 해당 값은 비어 있는 상태로 반환됩니다.
  - 중복 카드 ID는 자동으로 정리됩니다.
- **개선 사항**
  - 한 번에 최대 100개의 카드만 조회할 수 있으며, 잘못된 요청은 안내된 오류로 처리됩니다.
- **테스트**
  - 정상 조회, 누락된 요청값, 조회 한도 초과 및 가격 정보 누락 상황을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->