### PR TITLE
[Feature]#75 내 정보 조회 API (GET /api/users/me)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -1,0 +1,23 @@
+package com.pokade.domain.user.controller;
+
+import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.service.UserService;
+import com.pokade.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok("내 정보 조회 성공", userService.getMyInfo(userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,27 @@
+package com.pokade.domain.user.dto.response;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+
+public record UserResponse(
+        Long userId,
+        String email,
+        String nickname,
+        Role role,
+        UserStatus status,
+        String profileImageUrl,
+        Integer pointBalance
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole(),
+                user.getStatus(),
+                user.getProfileImageUrl(),
+                user.getPointBalance()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
@@ -1,0 +1,23 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponse getMyInfo(Long userId) {
+        return userRepository.findById(userId)
+                .map(UserResponse::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,82 @@
+package com.pokade.domain.user.controller;
+
+import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.service.UserService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;                 // 실제 JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // SecurityConfig가 요구
+
+    private RequestPostProcessor userId(Long userId) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    @Test
+    @DisplayName("인증된 사용자가 내 정보를 조회하면 200과 프로필을 반환한다")
+    void getMyInfo_success() throws Exception {
+        UserResponse res = new UserResponse(
+                1L, "user@pokade.com", "트레이너김",
+                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30);
+        given(userService.getMyInfo(1L)).willReturn(res);
+
+        mockMvc.perform(get("/api/users/me").with(userId(1L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.email").value("user@pokade.com"))
+                .andExpect(jsonPath("$.data.nickname").value("트레이너김"))
+                .andExpect(jsonPath("$.data.role").value("USER"))
+                .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.pointBalance").value(30));
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않으면 404와 USER_NOT_FOUND를 반환한다")
+    void getMyInfo_userNotFound() throws Exception {
+        given(userService.getMyInfo(1L))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(get("/api/users/me").with(userId(1L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
@@ -1,0 +1,69 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+    @InjectMocks
+    UserService userService;
+
+    private User user() {
+        return User.builder()
+                .id(1L)
+                .email("user@pokade.com")
+                .password("ENCODED_PW")
+                .nickname("지우")
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .profileImageUrl("https://img/x.png")
+                .pointBalance(30)
+                .build();
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 시 프로필 필드를 담은 UserResponse를 반환한다")
+    void getMyInfo_success() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(user()));
+
+        UserResponse res = userService.getMyInfo(1L);
+
+        assertThat(res.userId()).isEqualTo(1L);
+        assertThat(res.email()).isEqualTo("user@pokade.com");
+        assertThat(res.nickname()).isEqualTo("지우");
+        assertThat(res.role()).isEqualTo(Role.USER);
+        assertThat(res.status()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(res.profileImageUrl()).isEqualTo("https://img/x.png");
+        assertThat(res.pointBalance()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않으면 USER_NOT_FOUND 예외를 던진다")
+    void getMyInfo_userNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.getMyInfo(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
# 📌 관련 이슈
- #75

## ✨ 작업 내용
- 로그인 사용자 프로필 조회 `GET /api/users/me` 구현 (FR-AUTH-10)
- `UserController`(`@AuthenticationPrincipal Long userId`, ApiResponse 래핑) · `UserService.getMyInfo`(findById→UserResponse, 없으면 USER_NOT_FOUND 404) · `UserResponse`(record)
- 우리 시스템의 첫 **보호된 엔드포인트** — 화이트리스트 미포함이라 인증 필수(SecurityConfig 변경 없음)
- 목적: 로그인/재발급 응답은 accessToken만 주므로, FE의 **닉네임 표시·세션 복원**을 위한 프로필 조회 경로 제공

## 📸 스크린샷 / 테스트 결과
- 서비스 단위 + 컨트롤러 슬라이스 테스트 GREEN (4)
<img width="1440" height="900" alt="스크린샷 2026-07-31 오후 3 21 06" src="https://github.com/user-attachments/assets/d55a13a7-3ca8-4210-b83d-c24923112c44" />


## 🔍 리뷰 포인트
- 인증 사용자 식별을 `@AuthenticationPrincipal Long`으로 (Trade·Listing 관례와 동일)
- 응답 필드 범위: userId·email·nickname·role·status·profileImageUrl·pointBalance (비번 등 민감/내부 필드 제외)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? <!-- user 테스트 GREEN / TradeControllerTest 5건은 무관·선재 -->
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자가 자신의 프로필 정보(이메일, 닉네임, 역할, 상태, 프로필 이미지, 포인트)를 조회할 수 있습니다.
  * 등록되지 않은 사용자 조회 시 적절한 오류 응답을 제공합니다.

* **테스트**
  * 내 정보 조회 성공 및 사용자 미존재 상황을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->