### PR TITLE
[Feature] #73 카드 검색 성능 점검 및 등급·가격 필터 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -31,9 +31,11 @@ public class CardController {
             @RequestParam(required = false) List<String> rarity,
             @RequestParam(required = false) List<String> grades,
             @RequestParam(required = false) String expansionId,
+            @RequestParam(required = false) Integer minPrice,
+            @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
             @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(cardService.search(types, rarity, grades, expansionId, sort, pageable));
+        return ApiResponse.ok(cardService.search(types, rarity, grades, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")

--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -29,13 +29,12 @@ public class CardController {
     public ApiResponse<Page<CardResponse>> search(
             @RequestParam(required = false) List<String> types,
             @RequestParam(required = false) List<String> rarity,
-            @RequestParam(required = false) List<String> grades,
             @RequestParam(required = false) String expansionId,
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
             @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(cardService.search(types, rarity, grades, expansionId, minPrice, maxPrice, sort, pageable));
+        return ApiResponse.ok(cardService.search(types, rarity, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")

--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -29,10 +29,11 @@ public class CardController {
     public ApiResponse<Page<CardResponse>> search(
             @RequestParam(required = false) List<String> types,
             @RequestParam(required = false) List<String> rarity,
+            @RequestParam(required = false) List<String> grades,
             @RequestParam(required = false) String expansionId,
             @RequestParam(required = false) String sort,
             @PageableDefault(size = 20) Pageable pageable) {
-        return ApiResponse.ok(cardService.search(types, rarity, expansionId, sort, pageable));
+        return ApiResponse.ok(cardService.search(types, rarity, grades, expansionId, sort, pageable));
     }
 
     @GetMapping("/search")

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
@@ -2,6 +2,7 @@ package com.pokade.domain.card.dto;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
@@ -24,7 +25,7 @@ public record CardDetailResponse(
         List<VariantSummary> variants
 ) {
 
-    public static CardDetailResponse of(Card card, List<CardVariant> variants) {
+    public static CardDetailResponse of(Card card, List<CardVariant> variants, Map<Long, List<String>> gradesByVariantId) {
         return new CardDetailResponse(
                 card.getId(),
                 card.getExternalId(),
@@ -39,7 +40,9 @@ public record CardDetailResponse(
                 card.getImageMedium(),
                 card.getImageLarge(),
                 ExpansionSummary.from(card.getExpansion()),
-                variants.stream().map(VariantSummary::from).toList()
+                variants.stream()
+                        .map(variant -> VariantSummary.from(variant, gradesByVariantId.getOrDefault(variant.getId(), List.of())))
+                        .toList()
         );
     }
 
@@ -76,16 +79,18 @@ public record CardDetailResponse(
             String variantName,
             boolean primary,
             String imageSmall,
-            String imageLarge
+            String imageLarge,
+            List<String> grades
     ) {
 
-        public static VariantSummary from(CardVariant variant) {
+        public static VariantSummary from(CardVariant variant, List<String> grades) {
             return new VariantSummary(
                     variant.getId(),
                     variant.getVariantName(),
                     variant.isPrimary(),
                     variant.getImageSmall(),
-                    variant.getImageLarge()
+                    variant.getImageLarge(),
+                    grades
             );
         }
     }

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -14,10 +14,15 @@ public record CardResponse(
         List<String> types,
         String imageSmall,
         String imageMedium,
-        String expansionId
+        String expansionId,
+        List<String> grades
 ) {
 
     public static CardResponse from(Card card) {
+        return from(card, List.of());
+    }
+
+    public static CardResponse from(Card card, List<String> grades) {
         return new CardResponse(
                 card.getId(),
                 card.getExternalId(),
@@ -28,7 +33,8 @@ public record CardResponse(
                 card.getTypes(),
                 card.getImageSmall(),
                 card.getImageMedium(),
-                card.getExpansion() != null ? card.getExpansion().getId() : null
+                card.getExpansion() != null ? card.getExpansion().getId() : null,
+                grades
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -32,8 +32,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.synced_at DESC, c.id DESC
@@ -42,8 +45,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
@@ -54,6 +60,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                     @Param("rarities") List<String> rarities,
                                     @Param("hasGrades") boolean hasGrades,
                                     @Param("grades") List<String> grades,
+                                    @Param("hasPrice") boolean hasPrice,
+                                    @Param("minPrice") Integer minPrice,
+                                    @Param("maxPrice") Integer maxPrice,
                                     @Param("expansionId") String expansionId,
                                     Pageable pageable);
 
@@ -61,8 +70,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.name ASC, c.id ASC
@@ -71,8 +83,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
@@ -83,6 +98,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                   @Param("rarities") List<String> rarities,
                                   @Param("hasGrades") boolean hasGrades,
                                   @Param("grades") List<String> grades,
+                                  @Param("hasPrice") boolean hasPrice,
+                                  @Param("minPrice") Integer minPrice,
+                                  @Param("maxPrice") Integer maxPrice,
                                   @Param("expansionId") String expansionId,
                                   Pageable pageable);
 
@@ -90,8 +108,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.view_count DESC, c.id DESC
@@ -100,8 +121,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            (:hasGrades = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                AND (:hasGrades = false OR l.grade IN (:grades))
+                AND (:minPrice IS NULL OR l.price >= :minPrice)
+                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
@@ -112,6 +136,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                      @Param("rarities") List<String> rarities,
                                      @Param("hasGrades") boolean hasGrades,
                                      @Param("grades") List<String> grades,
+                                     @Param("hasPrice") boolean hasPrice,
+                                     @Param("minPrice") Integer minPrice,
+                                     @Param("maxPrice") Integer maxPrice,
                                      @Param("expansionId") String expansionId,
                                      Pageable pageable);
 
@@ -139,7 +166,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
         String getGrade();
     }
 
-    default Page<Card> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, String sort, Pageable pageable) {
+    default Page<Card> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         // 빈 문자열("")이 섞여 들어오면 실제 필터 조건 없이 IN ('') 비교만 남아 매칭이 전혀 안 되므로
         // hasTypes/hasRarities/hasGrades 판단 전에 제거한다.
         List<String> filteredTypes = types == null ? null
@@ -152,6 +179,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
         boolean hasTypes = filteredTypes != null && !filteredTypes.isEmpty();
         boolean hasRarities = filteredRarities != null && !filteredRarities.isEmpty();
         boolean hasGrades = filteredGrades != null && !filteredGrades.isEmpty();
+        boolean hasPrice = minPrice != null || maxPrice != null;
         // Pageable에 담긴 Sort는 버린다: Spring의 Pageable 리졸버가 우리와 같은 "sort" 파라미터명을
         // 공유하기 때문에(예: ?sort=latest) 정렬 프로퍼티로 오인해 파싱해 넣을 수 있고, 그 값을 그대로
         // 네이티브 쿼리에 넘기면 이미 고정된 ORDER BY와 충돌한다. 정렬은 아래 화이트리스트로만 결정한다.
@@ -163,12 +191,12 @@ public interface CardRepository extends JpaRepository<Card, Long> {
         List<String> safeGrades = hasGrades ? filteredGrades : List.of("");
 
         if (SORT_NAME.equals(resolvedSort)) {
-            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
+            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
         }
         if (SORT_POPULAR.equals(resolvedSort)) {
-            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
+            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
         }
-        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
+        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
     }
 
     Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -36,9 +36,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+            (:hasPrice = false OR EXISTS (
                 SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -50,9 +49,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
+            (:hasPrice = false OR EXISTS (
                 SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -66,8 +64,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                     @Param("types") List<String> types,
                                     @Param("hasRarities") boolean hasRarities,
                                     @Param("rarities") List<String> rarities,
-                                    @Param("hasGrades") boolean hasGrades,
-                                    @Param("grades") List<String> grades,
                                     @Param("hasPrice") boolean hasPrice,
                                     @Param("minPrice") Integer minPrice,
                                     @Param("maxPrice") Integer maxPrice,
@@ -81,8 +77,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                   @Param("types") List<String> types,
                                   @Param("hasRarities") boolean hasRarities,
                                   @Param("rarities") List<String> rarities,
-                                  @Param("hasGrades") boolean hasGrades,
-                                  @Param("grades") List<String> grades,
                                   @Param("hasPrice") boolean hasPrice,
                                   @Param("minPrice") Integer minPrice,
                                   @Param("maxPrice") Integer maxPrice,
@@ -96,8 +90,6 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                      @Param("types") List<String> types,
                                      @Param("hasRarities") boolean hasRarities,
                                      @Param("rarities") List<String> rarities,
-                                     @Param("hasGrades") boolean hasGrades,
-                                     @Param("grades") List<String> grades,
                                      @Param("hasPrice") boolean hasPrice,
                                      @Param("minPrice") Integer minPrice,
                                      @Param("maxPrice") Integer maxPrice,
@@ -128,19 +120,16 @@ public interface CardRepository extends JpaRepository<Card, Long> {
         String getGrade();
     }
 
-    default Page<Card> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
+    default Page<Card> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         // 빈 문자열("")이 섞여 들어오면 실제 필터 조건 없이 IN ('') 비교만 남아 매칭이 전혀 안 되므로
-        // hasTypes/hasRarities/hasGrades 판단 전에 제거한다.
+        // hasTypes/hasRarities 판단 전에 제거한다.
         List<String> filteredTypes = types == null ? null
                 : types.stream().filter(v -> v != null && !v.isBlank()).toList();
         List<String> filteredRarities = rarities == null ? null
                 : rarities.stream().filter(v -> v != null && !v.isBlank()).toList();
-        List<String> filteredGrades = grades == null ? null
-                : grades.stream().filter(v -> v != null && !v.isBlank()).toList();
 
         boolean hasTypes = filteredTypes != null && !filteredTypes.isEmpty();
         boolean hasRarities = filteredRarities != null && !filteredRarities.isEmpty();
-        boolean hasGrades = filteredGrades != null && !filteredGrades.isEmpty();
         boolean hasPrice = minPrice != null || maxPrice != null;
         // Pageable에 담긴 Sort는 버린다: Spring의 Pageable 리졸버가 우리와 같은 "sort" 파라미터명을
         // 공유하기 때문에(예: ?sort=latest) 정렬 프로퍼티로 오인해 파싱해 넣을 수 있고, 그 값을 그대로
@@ -150,15 +139,14 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
         List<String> safeTypes = hasTypes ? filteredTypes : List.of("");
         List<String> safeRarities = hasRarities ? filteredRarities : List.of("");
-        List<String> safeGrades = hasGrades ? filteredGrades : List.of("");
 
         if (SORT_NAME.equals(resolvedSort)) {
-            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
+            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
         }
         if (SORT_POPULAR.equals(resolvedSort)) {
-            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
+            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
         }
-        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
+        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, hasPrice, minPrice, maxPrice, expansionId, unsortedPageable);
     }
 
     Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -32,6 +32,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.synced_at DESC, c.id DESC
             """,
@@ -39,6 +42,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             nativeQuery = true)
@@ -46,6 +52,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                     @Param("types") List<String> types,
                                     @Param("hasRarities") boolean hasRarities,
                                     @Param("rarities") List<String> rarities,
+                                    @Param("hasGrades") boolean hasGrades,
+                                    @Param("grades") List<String> grades,
                                     @Param("expansionId") String expansionId,
                                     Pageable pageable);
 
@@ -53,6 +61,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.name ASC, c.id ASC
             """,
@@ -60,6 +71,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             nativeQuery = true)
@@ -67,6 +81,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                   @Param("types") List<String> types,
                                   @Param("hasRarities") boolean hasRarities,
                                   @Param("rarities") List<String> rarities,
+                                  @Param("hasGrades") boolean hasGrades,
+                                  @Param("grades") List<String> grades,
                                   @Param("expansionId") String expansionId,
                                   Pageable pageable);
 
@@ -74,6 +90,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             ORDER BY c.view_count DESC, c.id DESC
             """,
@@ -81,6 +100,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
+            (:hasGrades = false OR EXISTS (
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE' AND l.grade IN (:grades)
+            )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
             """,
             nativeQuery = true)
@@ -88,6 +110,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                      @Param("types") List<String> types,
                                      @Param("hasRarities") boolean hasRarities,
                                      @Param("rarities") List<String> rarities,
+                                     @Param("hasGrades") boolean hasGrades,
+                                     @Param("grades") List<String> grades,
                                      @Param("expansionId") String expansionId,
                                      Pageable pageable);
 
@@ -96,16 +120,19 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Query(value = "UPDATE cards SET view_count = view_count + 1 WHERE id = :id", nativeQuery = true)
     void incrementViewCount(@Param("id") Long id);
 
-    default Page<Card> search(List<String> types, List<String> rarities, String expansionId, String sort, Pageable pageable) {
+    default Page<Card> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, String sort, Pageable pageable) {
         // 빈 문자열("")이 섞여 들어오면 실제 필터 조건 없이 IN ('') 비교만 남아 매칭이 전혀 안 되므로
-        // hasTypes/hasRarities 판단 전에 제거한다.
+        // hasTypes/hasRarities/hasGrades 판단 전에 제거한다.
         List<String> filteredTypes = types == null ? null
                 : types.stream().filter(v -> v != null && !v.isBlank()).toList();
         List<String> filteredRarities = rarities == null ? null
                 : rarities.stream().filter(v -> v != null && !v.isBlank()).toList();
+        List<String> filteredGrades = grades == null ? null
+                : grades.stream().filter(v -> v != null && !v.isBlank()).toList();
 
         boolean hasTypes = filteredTypes != null && !filteredTypes.isEmpty();
         boolean hasRarities = filteredRarities != null && !filteredRarities.isEmpty();
+        boolean hasGrades = filteredGrades != null && !filteredGrades.isEmpty();
         // Pageable에 담긴 Sort는 버린다: Spring의 Pageable 리졸버가 우리와 같은 "sort" 파라미터명을
         // 공유하기 때문에(예: ?sort=latest) 정렬 프로퍼티로 오인해 파싱해 넣을 수 있고, 그 값을 그대로
         // 네이티브 쿼리에 넘기면 이미 고정된 ORDER BY와 충돌한다. 정렬은 아래 화이트리스트로만 결정한다.
@@ -114,14 +141,15 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
         List<String> safeTypes = hasTypes ? filteredTypes : List.of("");
         List<String> safeRarities = hasRarities ? filteredRarities : List.of("");
+        List<String> safeGrades = hasGrades ? filteredGrades : List.of("");
 
         if (SORT_NAME.equals(resolvedSort)) {
-            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, expansionId, unsortedPageable);
+            return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
         }
         if (SORT_POPULAR.equals(resolvedSort)) {
-            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, expansionId, unsortedPageable);
+            return searchOrderByPopular(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
         }
-        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, expansionId, unsortedPageable);
+        return searchOrderByLatest(hasTypes, safeTypes, hasRarities, safeRarities, hasGrades, safeGrades, expansionId, unsortedPageable);
     }
 
     Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -120,6 +120,25 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Query(value = "UPDATE cards SET view_count = view_count + 1 WHERE id = :id", nativeQuery = true)
     void incrementViewCount(@Param("id") Long id);
 
+    /**
+     * 카드별 ACTIVE 매물에 존재하는 등급(S/A/B) 집합을 배치로 조회한다.
+     * 카드 목록 응답에 등급 정보를 붙일 때 카드 수와 무관하게 쿼리 1회로 처리하기 위해 사용한다.
+     */
+    @Query(value = """
+            SELECT DISTINCT l.card_id AS cardId, l.grade AS grade
+            FROM listings l
+            WHERE l.card_id IN (:cardIds)
+              AND l.status = 'ACTIVE'
+              AND l.grade IN ('S', 'A', 'B')
+            """,
+            nativeQuery = true)
+    List<CardGradeView> findGradesByCardIds(@Param("cardIds") List<Long> cardIds);
+
+    interface CardGradeView {
+        Long getCardId();
+        String getGrade();
+    }
+
     default Page<Card> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, String sort, Pageable pageable) {
         // 빈 문자열("")이 섞여 들어오면 실제 필터 조건 없이 IN ('') 비교만 남아 매칭이 전혀 안 되므로
         // hasTypes/hasRarities/hasGrades 판단 전에 제거한다.

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -1,8 +1,8 @@
 package com.pokade.domain.card.repository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,14 +22,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     String SORT_POPULAR = "popular";
 
     /**
-     * sort 요청 파라미터 화이트리스트. 값은 실제 실행할 SQL을 선택하는 키로만 쓰이고
-     * SQL 문자열에 직접 삽입되지 않으므로(고정된 두 개의 @Query 중 택일), 인젝션 여지가 없다.
+     * sort 요청 파라미터 화이트리스트. 값은 아래 default search()의 if/else 디스패치에서
+     * 어떤 @Query를 실행할지 고르는 키로만 쓰이고 SQL 문자열에 직접 삽입되지 않으므로
+     * (고정된 세 개의 @Query 중 택일), 인젝션 여지가 없다.
      */
-    Map<String, String> SORT_COLUMN_WHITELIST = Map.of(
-            SORT_LATEST, "synced_at",
-            SORT_NAME, "name",
-            SORT_POPULAR, "view_count"
-    );
+    Set<String> SORT_COLUMN_WHITELIST = Set.of(SORT_LATEST, SORT_NAME, SORT_POPULAR);
 
     @Query(value = """
             SELECT c.* FROM cards c WHERE
@@ -100,16 +97,23 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     void incrementViewCount(@Param("id") Long id);
 
     default Page<Card> search(List<String> types, List<String> rarities, String expansionId, String sort, Pageable pageable) {
-        boolean hasTypes = types != null && !types.isEmpty();
-        boolean hasRarities = rarities != null && !rarities.isEmpty();
+        // 빈 문자열("")이 섞여 들어오면 실제 필터 조건 없이 IN ('') 비교만 남아 매칭이 전혀 안 되므로
+        // hasTypes/hasRarities 판단 전에 제거한다.
+        List<String> filteredTypes = types == null ? null
+                : types.stream().filter(v -> v != null && !v.isBlank()).toList();
+        List<String> filteredRarities = rarities == null ? null
+                : rarities.stream().filter(v -> v != null && !v.isBlank()).toList();
+
+        boolean hasTypes = filteredTypes != null && !filteredTypes.isEmpty();
+        boolean hasRarities = filteredRarities != null && !filteredRarities.isEmpty();
         // Pageable에 담긴 Sort는 버린다: Spring의 Pageable 리졸버가 우리와 같은 "sort" 파라미터명을
         // 공유하기 때문에(예: ?sort=latest) 정렬 프로퍼티로 오인해 파싱해 넣을 수 있고, 그 값을 그대로
         // 네이티브 쿼리에 넘기면 이미 고정된 ORDER BY와 충돌한다. 정렬은 아래 화이트리스트로만 결정한다.
         Pageable unsortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
-        String resolvedSort = sort != null && SORT_COLUMN_WHITELIST.containsKey(sort) ? sort : SORT_LATEST;
+        String resolvedSort = sort != null && SORT_COLUMN_WHITELIST.contains(sort) ? sort : SORT_LATEST;
 
-        List<String> safeTypes = hasTypes ? types : List.of("");
-        List<String> safeRarities = hasRarities ? rarities : List.of("");
+        List<String> safeTypes = hasTypes ? filteredTypes : List.of("");
+        List<String> safeRarities = hasRarities ? filteredRarities : List.of("");
 
         if (SORT_NAME.equals(resolvedSort)) {
             return searchOrderByName(hasTypes, safeTypes, hasRarities, safeRarities, expansionId, unsortedPageable);

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -118,10 +118,10 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             FROM listings l
             WHERE l.card_id IN (:cardIds)
               AND l.status = 'ACTIVE'
-              AND l.grade IN ('S', 'A', 'B')
+              AND l.grade IN (:validGrades)
             """,
             nativeQuery = true)
-    List<CardGradeView> findGradesByCardIds(@Param("cardIds") List<Long> cardIds);
+    List<CardGradeView> findGradesByCardIds(@Param("cardIds") List<Long> cardIds, @Param("validGrades") List<String> validGrades);
 
     interface CardGradeView {
         Long getCardId();

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -28,7 +28,11 @@ public interface CardRepository extends JpaRepository<Card, Long> {
      */
     Set<String> SORT_COLUMN_WHITELIST = Set.of(SORT_LATEST, SORT_NAME, SORT_POPULAR);
 
-    @Query(value = """
+    /**
+     * searchOrderBy* 3개 @Query가 공유하는 SELECT ~ WHERE 절 (ORDER BY 제외).
+     * ORDER BY는 인덱스 정렬 최적화를 위해 메서드별로 분리 유지한다.
+     */
+    String CARD_SEARCH_BASE = """
             SELECT c.* FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
@@ -39,9 +43,10 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            ORDER BY c.synced_at DESC, c.id DESC
-            """,
-            countQuery = """
+            """;
+
+    /** searchOrderBy* 3개 @Query가 공유하는 countQuery. ORDER BY가 없어 셋 다 동일하다. */
+    String CARD_SEARCH_COUNT = """
             SELECT COUNT(*) FROM cards c WHERE
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
@@ -52,7 +57,10 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
             (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            """,
+            """;
+
+    @Query(value = CARD_SEARCH_BASE + "ORDER BY c.synced_at DESC, c.id DESC",
+            countQuery = CARD_SEARCH_COUNT,
             nativeQuery = true)
     Page<Card> searchOrderByLatest(@Param("hasTypes") boolean hasTypes,
                                     @Param("types") List<String> types,
@@ -66,31 +74,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                     @Param("expansionId") String expansionId,
                                     Pageable pageable);
 
-    @Query(value = """
-            SELECT c.* FROM cards c WHERE
-            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
-            (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
-                AND (:minPrice IS NULL OR l.price >= :minPrice)
-                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
-            )) AND
-            (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            ORDER BY c.name ASC, c.id ASC
-            """,
-            countQuery = """
-            SELECT COUNT(*) FROM cards c WHERE
-            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
-            (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
-                AND (:minPrice IS NULL OR l.price >= :minPrice)
-                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
-            )) AND
-            (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            """,
+    @Query(value = CARD_SEARCH_BASE + "ORDER BY c.name ASC, c.id ASC",
+            countQuery = CARD_SEARCH_COUNT,
             nativeQuery = true)
     Page<Card> searchOrderByName(@Param("hasTypes") boolean hasTypes,
                                   @Param("types") List<String> types,
@@ -104,31 +89,8 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                   @Param("expansionId") String expansionId,
                                   Pageable pageable);
 
-    @Query(value = """
-            SELECT c.* FROM cards c WHERE
-            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
-            (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
-                AND (:minPrice IS NULL OR l.price >= :minPrice)
-                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
-            )) AND
-            (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            ORDER BY c.view_count DESC, c.id DESC
-            """,
-            countQuery = """
-            SELECT COUNT(*) FROM cards c WHERE
-            (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
-            (:hasRarities = false OR c.rarity IN (:rarities)) AND
-            ((:hasGrades = false AND :hasPrice = false) OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
-                AND (:hasGrades = false OR l.grade IN (:grades))
-                AND (:minPrice IS NULL OR l.price >= :minPrice)
-                AND (:maxPrice IS NULL OR l.price <= :maxPrice)
-            )) AND
-            (:expansionId IS NULL OR c.expansion_id = :expansionId)
-            """,
+    @Query(value = CARD_SEARCH_BASE + "ORDER BY c.view_count DESC, c.id DESC",
+            countQuery = CARD_SEARCH_COUNT,
             nativeQuery = true)
     Page<Card> searchOrderByPopular(@Param("hasTypes") boolean hasTypes,
                                      @Param("types") List<String> types,

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -28,14 +28,17 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
     /**
      * 카드 상세조회용 variant별 등급(S/A/B) 매핑을 쿼리 1회로 조회한다.
      * listings.variant_id가 NULL인 매물은 대표 변형(is_primary) 기준 매물이므로 COALESCE로 합산한다.
+     * 대표 변형이 없는 카드도 매물이 조회되도록 LEFT JOIN을 사용하며, variant_id와 대표 변형이
+     * 둘 다 없는 경우만 COALESCE 결과가 NULL이 되므로 그 경우만 제외한다.
      */
     @Query(value = """
-            SELECT COALESCE(l.variant_id, cv.id) AS variantId, l.grade AS grade
+            SELECT DISTINCT COALESCE(l.variant_id, cv.id) AS variantId, l.grade AS grade
             FROM listings l
-            JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
+            LEFT JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
             WHERE l.card_id = :cardId
               AND l.status = 'ACTIVE'
               AND l.grade IN (:validGrades)
+              AND COALESCE(l.variant_id, cv.id) IS NOT NULL
             """,
             nativeQuery = true)
     List<VariantGradeView> findGradesByCardId(@Param("cardId") Long cardId, @Param("validGrades") List<String> validGrades);

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -24,4 +24,24 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
         Long getCardId();
         Long getVariantId();
     }
+
+    /**
+     * 카드 상세조회용 variant별 등급(S/A/B) 매핑을 쿼리 1회로 조회한다.
+     * listings.variant_id가 NULL인 매물은 대표 변형(is_primary) 기준 매물이므로 COALESCE로 합산한다.
+     */
+    @Query(value = """
+            SELECT COALESCE(l.variant_id, cv.id) AS variantId, l.grade AS grade
+            FROM listings l
+            JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
+            WHERE l.card_id = :cardId
+              AND l.status = 'ACTIVE'
+              AND l.grade IN ('S', 'A', 'B')
+            """,
+            nativeQuery = true)
+    List<VariantGradeView> findGradesByCardId(@Param("cardId") Long cardId);
+
+    interface VariantGradeView {
+        Long getVariantId();
+        String getGrade();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -35,10 +35,10 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
             JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
             WHERE l.card_id = :cardId
               AND l.status = 'ACTIVE'
-              AND l.grade IN ('S', 'A', 'B')
+              AND l.grade IN (:validGrades)
             """,
             nativeQuery = true)
-    List<VariantGradeView> findGradesByCardId(@Param("cardId") Long cardId);
+    List<VariantGradeView> findGradesByCardId(@Param("cardId") Long cardId, @Param("validGrades") List<String> validGrades);
 
     interface VariantGradeView {
         Long getVariantId();

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -35,11 +35,11 @@ public class CardService {
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(List<String> types, List<String> rarity, String expansionId, String sort, Pageable pageable) {
+    public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, String sort, Pageable pageable) {
         validatePageSize(pageable);
         validateFilterSize(types, "types");
-        validateFilterSize(rarity, "rarity");
-        return cardRepository.search(types, rarity, expansionId, sort, pageable)
+        validateFilterSize(rarities, "rarity");
+        return cardRepository.search(types, rarities, expansionId, sort, pageable)
                 .map(CardResponse::from);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -51,11 +51,7 @@ public class CardService {
         validateFilterSize(grades, "grades");
         validateGrades(grades);
         Page<Card> cards = cardRepository.search(types, rarities, grades, expansionId, sort, pageable);
-        List<Long> cardIds = cards.getContent().stream().map(Card::getId).toList();
-        Map<Long, List<String>> gradesByCardId = cardIds.isEmpty()
-                ? Map.of()
-                : groupByKey(cardRepository.findGradesByCardIds(cardIds),
-                        CardRepository.CardGradeView::getCardId, CardRepository.CardGradeView::getGrade);
+        Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
         return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of())));
     }
 
@@ -91,8 +87,9 @@ public class CardService {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "검색어는 최대 " + MAX_KEYWORD_LENGTH + "자까지 입력할 수 있습니다.");
         }
-        return cardRepository.findByNameContainingIgnoreCase(keyword, pageable)
-                .map(CardResponse::from);
+        Page<Card> cards = cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
+        Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of())));
     }
 
     @Transactional(readOnly = true)
@@ -107,9 +104,19 @@ public class CardService {
         } else {
             related = List.of();
         }
+        Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(related);
         return related.stream()
-                .map(CardResponse::from)
+                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of())))
                 .toList();
+    }
+
+    private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {
+        if (cards.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> cardIds = cards.stream().map(Card::getId).toList();
+        return groupByKey(cardRepository.findGradesByCardIds(cardIds),
+                CardRepository.CardGradeView::getCardId, CardRepository.CardGradeView::getGrade);
     }
 
     /**

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -14,9 +14,13 @@ import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,6 +37,8 @@ public class CardService {
     private static final int MAX_KEYWORD_LENGTH = 100;
     // 카드검색 필터로 노출하는 등급 값. PSA10/9/8은 감정 등급이라 필터 대상이 아니다.
     private static final Set<String> GRADE_WHITELIST = Set.of("S", "A", "B");
+    // 응답에 노출하는 등급 표시 순서. 필터 화이트리스트와 동일한 범위로 제한한다.
+    private static final List<String> GRADE_DISPLAY_ORDER = List.of("S", "A", "B");
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
@@ -44,8 +50,13 @@ public class CardService {
         validateFilterSize(rarities, "rarity");
         validateFilterSize(grades, "grades");
         validateGrades(grades);
-        return cardRepository.search(types, rarities, grades, expansionId, sort, pageable)
-                .map(CardResponse::from);
+        Page<Card> cards = cardRepository.search(types, rarities, grades, expansionId, sort, pageable);
+        List<Long> cardIds = cards.getContent().stream().map(Card::getId).toList();
+        Map<Long, List<String>> gradesByCardId = cardIds.isEmpty()
+                ? Map.of()
+                : groupByKey(cardRepository.findGradesByCardIds(cardIds),
+                        CardRepository.CardGradeView::getCardId, CardRepository.CardGradeView::getGrade);
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of())));
     }
 
     @Transactional
@@ -54,7 +65,19 @@ public class CardService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
         cardRepository.incrementViewCount(id);
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
-        return CardDetailResponse.of(card, variants);
+        Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id),
+                CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade);
+        return CardDetailResponse.of(card, variants, gradesByVariantId);
+    }
+
+    private <T, K> Map<K, List<String>> groupByKey(List<T> views, Function<T, K> keyFn, Function<T, String> gradeFn) {
+        Map<K, Set<String>> grouped = new HashMap<>();
+        for (T view : views) {
+            grouped.computeIfAbsent(keyFn.apply(view), k -> new HashSet<>()).add(gradeFn.apply(view));
+        }
+        Map<K, List<String>> result = new HashMap<>();
+        grouped.forEach((key, gradeSet) -> result.put(key, GRADE_DISPLAY_ORDER.stream().filter(gradeSet::contains).toList()));
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -35,25 +35,22 @@ public class CardService {
     private static final int MAX_FILTER_VALUES = 20;
     // 키워드 검색어 상한: cards.name 컬럼 길이(200자)보다 짧게 잡아 과도하게 긴 ILIKE 패턴을 차단.
     private static final int MAX_KEYWORD_LENGTH = 100;
-    // 카드검색 필터로 노출하는 등급 값. PSA10/9/8은 감정 등급이라 필터 대상이 아니다.
-    private static final Set<String> GRADE_WHITELIST = Set.of("S", "A", "B");
-    // 네이티브 쿼리 IN (:validGrades) 바인드 파라미터로 전달하기 위한 리스트 형태. GRADE_WHITELIST와 동일한 값을 유지한다.
-    private static final List<String> GRADE_WHITELIST_LIST = List.copyOf(GRADE_WHITELIST);
-    // 응답에 노출하는 등급 표시 순서. 필터 화이트리스트와 동일한 범위로 제한한다.
+    // 카드 목록/상세 응답에 표시할 등급 값. PSA10/9/8은 감정 등급이라 표시 대상이 아니다.
+    // 네이티브 쿼리 IN (:validGrades) 바인드 파라미터로 전달하기 위한 리스트 형태.
+    private static final List<String> GRADE_WHITELIST_LIST = List.of("S", "A", "B");
+    // 응답에 노출하는 등급 표시 순서. 화이트리스트와 동일한 범위로 제한한다.
     private static final List<String> GRADE_DISPLAY_ORDER = List.of("S", "A", "B");
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
+    public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         validatePageSize(pageable);
         validateFilterSize(types, "types");
         validateFilterSize(rarities, "rarity");
-        validateFilterSize(grades, "grades");
-        validateGrades(grades);
         validatePriceRange(minPrice, maxPrice);
-        Page<Card> cards = cardRepository.search(types, rarities, grades, expansionId, minPrice, maxPrice, sort, pageable);
+        Page<Card> cards = cardRepository.search(types, rarities, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
         return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of())));
     }
@@ -152,18 +149,6 @@ public class CardService {
     private void validatePriceRange(Integer minPrice, Integer maxPrice) {
         if (minPrice != null && maxPrice != null && minPrice > maxPrice) {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "minPrice는 maxPrice보다 클 수 없습니다.");
-        }
-    }
-
-    private void validateGrades(List<String> grades) {
-        if (grades == null) {
-            return;
-        }
-        for (String grade : grades) {
-            if (grade != null && !grade.isBlank() && !GRADE_WHITELIST.contains(grade)) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT,
-                        "grades는 S, A, B 중에서만 지정할 수 있습니다.");
-            }
         }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -37,6 +37,8 @@ public class CardService {
     private static final int MAX_KEYWORD_LENGTH = 100;
     // 카드검색 필터로 노출하는 등급 값. PSA10/9/8은 감정 등급이라 필터 대상이 아니다.
     private static final Set<String> GRADE_WHITELIST = Set.of("S", "A", "B");
+    // 네이티브 쿼리 IN (:validGrades) 바인드 파라미터로 전달하기 위한 리스트 형태. GRADE_WHITELIST와 동일한 값을 유지한다.
+    private static final List<String> GRADE_WHITELIST_LIST = List.copyOf(GRADE_WHITELIST);
     // 응답에 노출하는 등급 표시 순서. 필터 화이트리스트와 동일한 범위로 제한한다.
     private static final List<String> GRADE_DISPLAY_ORDER = List.of("S", "A", "B");
 
@@ -62,7 +64,7 @@ public class CardService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
         cardRepository.incrementViewCount(id);
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
-        Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id),
+        Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id, GRADE_WHITELIST_LIST),
                 CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade);
         return CardDetailResponse.of(card, variants, gradesByVariantId);
     }
@@ -116,7 +118,7 @@ public class CardService {
             return Map.of();
         }
         List<Long> cardIds = cards.stream().map(Card::getId).toList();
-        return groupByKey(cardRepository.findGradesByCardIds(cardIds),
+        return groupByKey(cardRepository.findGradesByCardIds(cardIds, GRADE_WHITELIST_LIST),
                 CardRepository.CardGradeView::getCardId, CardRepository.CardGradeView::getGrade);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -16,6 +16,7 @@ import com.pokade.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,16 +31,20 @@ public class CardService {
     private static final int MAX_FILTER_VALUES = 20;
     // 키워드 검색어 상한: cards.name 컬럼 길이(200자)보다 짧게 잡아 과도하게 긴 ILIKE 패턴을 차단.
     private static final int MAX_KEYWORD_LENGTH = 100;
+    // 카드검색 필터로 노출하는 등급 값. PSA10/9/8은 감정 등급이라 필터 대상이 아니다.
+    private static final Set<String> GRADE_WHITELIST = Set.of("S", "A", "B");
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, String sort, Pageable pageable) {
+    public Page<CardResponse> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, String sort, Pageable pageable) {
         validatePageSize(pageable);
         validateFilterSize(types, "types");
         validateFilterSize(rarities, "rarity");
-        return cardRepository.search(types, rarities, expansionId, sort, pageable)
+        validateFilterSize(grades, "grades");
+        validateGrades(grades);
+        return cardRepository.search(types, rarities, grades, expansionId, sort, pageable)
                 .map(CardResponse::from);
     }
 
@@ -108,6 +113,18 @@ public class CardService {
         if (values != null && values.size() > MAX_FILTER_VALUES) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     fieldName + "는 최대 " + MAX_FILTER_VALUES + "개까지 지정할 수 있습니다.");
+        }
+    }
+
+    private void validateGrades(List<String> grades) {
+        if (grades == null) {
+            return;
+        }
+        for (String grade : grades) {
+            if (grade != null && !grade.isBlank() && !GRADE_WHITELIST.contains(grade)) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT,
+                        "grades는 S, A, B 중에서만 지정할 수 있습니다.");
+            }
         }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -44,13 +44,14 @@ public class CardService {
     private final CardVariantRepository cardVariantRepository;
 
     @Transactional(readOnly = true)
-    public Page<CardResponse> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, String sort, Pageable pageable) {
+    public Page<CardResponse> search(List<String> types, List<String> rarities, List<String> grades, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         validatePageSize(pageable);
         validateFilterSize(types, "types");
         validateFilterSize(rarities, "rarity");
         validateFilterSize(grades, "grades");
         validateGrades(grades);
-        Page<Card> cards = cardRepository.search(types, rarities, grades, expansionId, sort, pageable);
+        validatePriceRange(minPrice, maxPrice);
+        Page<Card> cards = cardRepository.search(types, rarities, grades, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
         return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of())));
     }
@@ -143,6 +144,12 @@ public class CardService {
         if (values != null && values.size() > MAX_FILTER_VALUES) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     fieldName + "는 최대 " + MAX_FILTER_VALUES + "개까지 지정할 수 있습니다.");
+        }
+    }
+
+    private void validatePriceRange(Integer minPrice, Integer maxPrice) {
+        if (minPrice != null && maxPrice != null && minPrice > maxPrice) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "minPrice는 maxPrice보다 클 수 없습니다.");
         }
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -53,7 +53,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1");
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), eq("base1"), isNull(), any(Pageable.class)))
+        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -70,7 +70,7 @@ class CardControllerTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
         given(cardService.search(
-                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), any(Pageable.class)))
+                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -84,7 +84,7 @@ class CardControllerTest {
     void t2() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -100,7 +100,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1");
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -115,7 +115,7 @@ class CardControllerTest {
     @DisplayName("t15 size가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t15() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "size는 최대 100까지 요청할 수 있습니다."))
-                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         mockMvcTester.get()
                 .uri("/api/cards?size=101")
@@ -129,7 +129,7 @@ class CardControllerTest {
     @DisplayName("t16 types 개수가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t16() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "types는 최대 20개까지 지정할 수 있습니다."))
-                .given(cardService).search(any(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(any(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         String query = java.util.stream.IntStream.range(0, 21)
                 .mapToObj(i -> "types=type" + i)
@@ -138,6 +138,38 @@ class CardControllerTest {
 
         mockMvcTester.get()
                 .uri("/api/cards?" + query)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("INVALID_INPUT");
+    }
+
+    @Test
+    @DisplayName("t18 grades 쿼리 파라미터를 서비스에 그대로 위임한다")
+    void t18() {
+        CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), null, null, "base1");
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardService.search(isNull(), isNull(), eq(List.of("S", "A")), isNull(), isNull(), any(Pageable.class)))
+                .willReturn(page);
+
+        mockMvcTester.get()
+                .uri("/api/cards?grades=S&grades=A")
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t19 잘못된 grades 값이면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
+    void t19() {
+        willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "grades는 S, A, B 중에서만 지정할 수 있습니다."))
+                .given(cardService).search(isNull(), isNull(), eq(List.of("PSA10")), isNull(), isNull(), any(Pageable.class));
+
+        mockMvcTester.get()
+                .uri("/api/cards?grades=PSA10")
                 .assertThat()
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .bodyJson()

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -53,7 +53,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), any(Pageable.class)))
+        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         var result = mockMvcTester.get()
@@ -70,7 +70,7 @@ class CardControllerTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
         given(cardService.search(
-                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), isNull(), any(Pageable.class)))
+                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -84,7 +84,7 @@ class CardControllerTest {
     void t2() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -100,7 +100,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -115,7 +115,7 @@ class CardControllerTest {
     @DisplayName("t15 size가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t15() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "size는 최대 100까지 요청할 수 있습니다."))
-                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         mockMvcTester.get()
                 .uri("/api/cards?size=101")
@@ -129,7 +129,7 @@ class CardControllerTest {
     @DisplayName("t16 types 개수가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t16() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "types는 최대 20개까지 지정할 수 있습니다."))
-                .given(cardService).search(any(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(any(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         String query = java.util.stream.IntStream.range(0, 21)
                 .mapToObj(i -> "types=type" + i)
@@ -151,7 +151,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1", List.of("S", "A"));
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), eq(List.of("S", "A")), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), eq(List.of("S", "A")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         var result = mockMvcTester.get()
@@ -166,10 +166,42 @@ class CardControllerTest {
     @DisplayName("t19 잘못된 grades 값이면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t19() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "grades는 S, A, B 중에서만 지정할 수 있습니다."))
-                .given(cardService).search(isNull(), isNull(), eq(List.of("PSA10")), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(isNull(), isNull(), eq(List.of("PSA10")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         mockMvcTester.get()
                 .uri("/api/cards?grades=PSA10")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("INVALID_INPUT");
+    }
+
+    @Test
+    @DisplayName("t20 minPrice/maxPrice 쿼리 파라미터를 서비스에 그대로 위임한다")
+    void t20() {
+        CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
+                List.of("Fire"), null, null, "base1", List.of());
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq(10000), eq(50000), isNull(), any(Pageable.class)))
+                .willReturn(page);
+
+        mockMvcTester.get()
+                .uri("/api/cards?minPrice=10000&maxPrice=50000")
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t21 minPrice가 maxPrice보다 크면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
+    void t21() {
+        willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "minPrice는 maxPrice보다 클 수 없습니다."))
+                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), eq(50000), eq(10000), isNull(), any(Pageable.class));
+
+        mockMvcTester.get()
+                .uri("/api/cards?minPrice=50000&maxPrice=10000")
                 .assertThat()
                 .hasStatus(HttpStatus.BAD_REQUEST)
                 .bodyJson()

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -53,7 +53,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), eq("base1"), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         var result = mockMvcTester.get()
@@ -70,7 +70,7 @@ class CardControllerTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
         given(cardService.search(
-                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
+                eq(List.of("Fire", "Water")), eq(List.of("Common", "Rare Holo")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -84,7 +84,7 @@ class CardControllerTest {
     void t2() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -100,7 +100,7 @@ class CardControllerTest {
                 List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -115,7 +115,7 @@ class CardControllerTest {
     @DisplayName("t15 size가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t15() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "size는 최대 100까지 요청할 수 있습니다."))
-                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         mockMvcTester.get()
                 .uri("/api/cards?size=101")
@@ -129,7 +129,7 @@ class CardControllerTest {
     @DisplayName("t16 types 개수가 상한을 초과하면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t16() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "types는 최대 20개까지 지정할 수 있습니다."))
-                .given(cardService).search(any(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
+                .given(cardService).search(any(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
 
         String query = java.util.stream.IntStream.range(0, 21)
                 .mapToObj(i -> "types=type" + i)
@@ -145,45 +145,13 @@ class CardControllerTest {
     }
 
     @Test
-    @DisplayName("t18 grades 쿼리 파라미터를 서비스에 그대로 위임한다")
-    void t18() {
-        CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1", List.of("S", "A"));
-        Pageable pageable = PageRequest.of(0, 20);
-        Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), eq(List.of("S", "A")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
-                .willReturn(page);
-
-        var result = mockMvcTester.get()
-                .uri("/api/cards?grades=S&grades=A")
-                .assertThat()
-                .hasStatusOk();
-        result.bodyJson().extractingPath("$.data.content[0].name").isEqualTo("Charizard");
-        result.bodyJson().extractingPath("$.data.content[0].grades").asList().containsExactly("S", "A");
-    }
-
-    @Test
-    @DisplayName("t19 잘못된 grades 값이면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
-    void t19() {
-        willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "grades는 S, A, B 중에서만 지정할 수 있습니다."))
-                .given(cardService).search(isNull(), isNull(), eq(List.of("PSA10")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class));
-
-        mockMvcTester.get()
-                .uri("/api/cards?grades=PSA10")
-                .assertThat()
-                .hasStatus(HttpStatus.BAD_REQUEST)
-                .bodyJson()
-                .extractingPath("$.code").isEqualTo("INVALID_INPUT");
-    }
-
-    @Test
     @DisplayName("t20 minPrice/maxPrice 쿼리 파라미터를 서비스에 그대로 위임한다")
     void t20() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
                 List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq(10000), eq(50000), isNull(), any(Pageable.class)))
+        given(cardService.search(isNull(), isNull(), isNull(), eq(10000), eq(50000), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
         mockMvcTester.get()
@@ -198,7 +166,7 @@ class CardControllerTest {
     @DisplayName("t21 minPrice가 maxPrice보다 크면 서비스의 INVALID_INPUT 예외가 400으로 응답된다")
     void t21() {
         willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "minPrice는 maxPrice보다 클 수 없습니다."))
-                .given(cardService).search(isNull(), isNull(), isNull(), isNull(), eq(50000), eq(10000), isNull(), any(Pageable.class));
+                .given(cardService).search(isNull(), isNull(), isNull(), eq(50000), eq(10000), isNull(), any(Pageable.class));
 
         mockMvcTester.get()
                 .uri("/api/cards?minPrice=50000&maxPrice=10000")

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -50,18 +50,18 @@ class CardControllerTest {
     @DisplayName("t1 쿼리 파라미터로 카드를 검색하면 200과 페이지 결과를 반환한다")
     void t1() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1");
+                List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
-        mockMvcTester.get()
+        var result = mockMvcTester.get()
                 .uri("/api/cards?types=Fire&rarity=Rare Holo&expansionId=base1")
                 .assertThat()
-                .hasStatusOk()
-                .bodyJson()
-                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+                .hasStatusOk();
+        result.bodyJson().extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+        result.bodyJson().extractingPath("$.data.content[0].grades").asList().isEmpty();
     }
 
     @Test
@@ -97,7 +97,7 @@ class CardControllerTest {
     @DisplayName("t12 sort 쿼리 파라미터를 서비스에 그대로 위임한다")
     void t12() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1");
+                List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
@@ -148,18 +148,18 @@ class CardControllerTest {
     @DisplayName("t18 grades 쿼리 파라미터를 서비스에 그대로 위임한다")
     void t18() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1");
+                List.of("Fire"), null, null, "base1", List.of("S", "A"));
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(isNull(), isNull(), eq(List.of("S", "A")), isNull(), isNull(), any(Pageable.class)))
                 .willReturn(page);
 
-        mockMvcTester.get()
+        var result = mockMvcTester.get()
                 .uri("/api/cards?grades=S&grades=A")
                 .assertThat()
-                .hasStatusOk()
-                .bodyJson()
-                .extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+                .hasStatusOk();
+        result.bodyJson().extractingPath("$.data.content[0].name").isEqualTo("Charizard");
+        result.bodyJson().extractingPath("$.data.content[0].grades").asList().containsExactly("S", "A");
     }
 
     @Test
@@ -197,7 +197,7 @@ class CardControllerTest {
         CardDetailResponse.ExpansionSummary expansion = new CardDetailResponse.ExpansionSummary(
                 "base1", "Base", "Base", "BS", 102, LocalDate.of(1999, 1, 9), null, null);
         CardDetailResponse.VariantSummary variant = new CardDetailResponse.VariantSummary(
-                1L, "unlimitedHolofoil", true, null, null);
+                1L, "unlimitedHolofoil", true, null, null, List.of("S", "A"));
         CardDetailResponse detail = new CardDetailResponse(
                 1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
                 List.of("Fire"), "Mitsuhiro Arita", "4/102", null, null, null,
@@ -211,6 +211,7 @@ class CardControllerTest {
         result.bodyJson().extractingPath("$.data.name").isEqualTo("Charizard");
         result.bodyJson().extractingPath("$.data.expansion.id").isEqualTo("base1");
         result.bodyJson().extractingPath("$.data.variants[0].variantName").isEqualTo("unlimitedHolofoil");
+        result.bodyJson().extractingPath("$.data.variants[0].grades").asList().containsExactly("S", "A");
     }
 
     @Test
@@ -251,7 +252,7 @@ class CardControllerTest {
     @DisplayName("t6 검색어로 카드 이름 키워드 검색을 하면 200과 페이지 결과를 반환한다")
     void t6() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1");
+                List.of("Fire"), null, null, "base1", List.of());
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.searchByKeyword(eq("char"), any(Pageable.class))).willReturn(page);
@@ -282,7 +283,7 @@ class CardControllerTest {
     @DisplayName("t8 존재하는 카드 id로 유사 카드를 조회하면 200과 목록을 반환한다")
     void t8() {
         CardResponse related = new CardResponse(2L, "sv3pt5-6", "Charizard ex", "151", "Double Rare", "Pokémon",
-                List.of("Fire"), null, null, "sv3pt5");
+                List.of("Fire"), null, null, "sv3pt5", List.of());
         given(cardService.getRelated(1L)).willReturn(List.of(related));
 
         mockMvcTester.get()

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -357,6 +357,34 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("t28 types에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
+    void t28() {
+        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Charizard", "Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t29 rarity에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
+    void t29() {
+        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Pikachu");
+    }
+
+    @Test
+    @DisplayName("t30 types가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
+    void t30() {
+        Page<Card> result = cardRepository.search(List.of(""), null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(6);
+    }
+
+    @Test
     @DisplayName("t7 같은 포켓몬 도감번호를 가진 다른 카드를 유사 카드로 조회한다")
     void t7() {
         List<Card> result = cardRepository.findRelatedByPokedexNumber(charizard.getId());

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -638,7 +638,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         entityManager.flush();
 
         List<CardRepository.CardGradeView> result = cardRepository.findGradesByCardIds(
-                List.of(charizard.getId(), charizardEx.getId(), professorsResearch.getId()));
+                List.of(charizard.getId(), charizardEx.getId(), professorsResearch.getId()), List.of("S", "A", "B"));
 
         assertThat(result)
                 .filteredOn(view -> view.getCardId().equals(charizard.getId()))
@@ -660,7 +660,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.CANCELLED);
         entityManager.flush();
 
-        List<CardRepository.CardGradeView> result = cardRepository.findGradesByCardIds(List.of(charizard.getId()));
+        List<CardRepository.CardGradeView> result = cardRepository.findGradesByCardIds(List.of(charizard.getId()), List.of("S", "A", "B"));
 
         assertThat(result).isEmpty();
     }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -142,7 +142,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -152,7 +152,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t3 rarity가 정확히 일치하는 카드만 조회한다")
     void t3() {
-        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -162,7 +162,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t4 expansionId가 정확히 일치하는 카드만 조회한다")
     void t4() {
-        Page<Card> result = cardRepository.search(null, null, null, "sv3pt5", null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, "sv3pt5", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -172,7 +172,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 여러 조건을 조합하면 AND로 필터링된다")
     void t5() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "base1", null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, "base1", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -182,7 +182,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t6 조건이 없으면 전체 카드를 페이지 크기만큼 반환한다")
     void t6() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, null, null, PageRequest.of(0, 2));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, PageRequest.of(0, 2));
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
@@ -192,7 +192,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t12 타입을 여러 개 선택하면 하나라도 포함된 카드를 OR로 조회한다")
     void t12() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -202,7 +202,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t13 레어도를 여러 개 선택하면 하나라도 일치하는 카드를 OR로 조회한다")
     void t13() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -213,7 +213,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t14 타입·레어도·세트를 동시에 지정하면 AND로 결합되어 모두 만족하는 카드만 조회한다")
     void t14() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, null, PageRequest.of(0, 10));
+                List.of("Fire"), List.of("Rare Holo"), "base1", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -223,7 +223,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t15 조건을 모두 만족하는 카드가 없으면 빈 페이지를 반환한다")
     void t15() {
-        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -232,7 +232,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t16 존재하지 않는 타입 값으로 조회해도 예외 없이 빈 페이지를 반환한다")
     void t16() {
-        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -242,7 +242,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t17 타입을 여러 개, 레어도를 여러 개 동시에 선택하면 각 조건 내부는 OR, 조건 간에는 AND로 결합된다")
     void t17() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, null, null, null, PageRequest.of(0, 10));
+                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -252,7 +252,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t18 sort가 없으면 기본값 latest 기준(synced_at DESC, id DESC)으로 정렬한다")
     void t18() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, PageRequest.of(0, 10));
 
         // id 순서(삽입 순서)와는 다른 synced_at 순서(내림차순: Charizard ex > Charizard > Pikachu
         // > Quick Ball > Professor's Research > Blastoise)로 나와야 synced_at이 실제 1차 정렬
@@ -265,7 +265,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t19 sort=name이면 이름 오름차순으로 정렬한다")
     void t19() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -275,7 +275,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t20 화이트리스트에 없는 sort 값이 들어와도 예외 없이 기본값 latest로 처리한다")
     void t20() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -285,7 +285,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t21 필터와 sort=name을 함께 적용해도 필터링된 결과 안에서 이름순으로 정렬한다")
     void t21() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -300,7 +300,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistCardWithViewCount("Squirtle", popExpansion, 10);
         persistCardWithViewCount("Bulbasaur", popExpansion, 0);
 
-        Page<Card> result = cardRepository.search(null, null, null, "popTest", null, null, "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, "popTest", null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -316,7 +316,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -390,7 +390,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t28 types에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t28() {
-        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -400,7 +400,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t29 rarity에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t29() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -410,7 +410,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t30 types가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
     void t30() {
-        Page<Card> result = cardRepository.search(List.of(""), null, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of(""), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getTotalElements()).isEqualTo(6);
     }
@@ -483,94 +483,14 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("t35 grades=S로 필터링하면 S등급 매물이 있는 카드만 조회된다")
-    void t35() {
-        Long seller = persistSeller("grade-s-seller@test.com");
-        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
-        persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent())
-                .extracting(Card::getName)
-                .containsExactly("Charizard");
-    }
-
-    @Test
-    @DisplayName("t36 grades를 여러 개 선택하면 하나라도 일치하는 매물을 가진 카드를 OR로 조회한다")
-    void t36() {
-        Long seller = persistSeller("grade-multi-seller@test.com");
-        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
-        persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, null, List.of("S", "A"), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent())
-                .extracting(Card::getName)
-                .containsExactlyInAnyOrder("Charizard", "Charizard ex");
-    }
-
-    @Test
-    @DisplayName("t37 ACTIVE가 아닌 매물의 등급은 필터에 반영되지 않는다")
-    void t37() {
-        Long seller = persistSeller("grade-cancelled-seller@test.com");
-        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.CANCELLED);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("t38 등급 필터와 일치하는 매물이 없는 카드는 결과에서 제외된다")
-    void t38() {
-        Long seller = persistSeller("grade-none-seller@test.com");
-        persistListing(charizard.getId(), seller, ListingGrade.PSA10, ListingStatus.ACTIVE);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("t39 rarity와 grades를 함께 적용하면 같은 카드가 두 조건을 모두 만족할 때만 조회된다")
-    void t39() {
-        Long seller = persistSeller("grade-rarity-seller@test.com");
-        // charizard와 blastoise는 둘 다 rarity=Rare Holo. charizard에만 S등급 매물을 붙여
-        // rarity 조건과 grades 조건이 "같은 카드" 기준으로 AND 결합되는지 검증한다.
-        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, List.of("Rare Holo"), List.of("S"), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent())
-                .extracting(Card::getName)
-                .containsExactly("Charizard");
-    }
-
-    @Test
-    @DisplayName("t40 grades가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
-    void t40() {
-        Page<Card> result = cardRepository.search(null, null, List.of(""), null, null, null, null, PageRequest.of(0, 10));
-
-        assertThat(result.getTotalElements()).isEqualTo(6);
-    }
-
-    @Test
-    @DisplayName("t43 등급 미지정 상태에서 가격(minPrice)만 지정해도 매물 가격 기준으로 필터링된다")
+    @DisplayName("t43 가격(minPrice)만 지정해도 매물 가격 기준으로 필터링된다")
     void t43() {
-        // 등급을 지정하지 않고 가격만 지정한 경우에도 바깥 게이트 조건이 EXISTS를 실행해야
-        // 매물 가격 기준 필터링이 실제로 적용되는지 검증한다(게이트 수정의 핵심 케이스).
         Long seller = persistSeller("price-only-seller@test.com");
         persistListing(charizard.getId(), seller, 5000, null, ListingStatus.ACTIVE);
         persistListing(charizardEx.getId(), seller, 20000, null, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, null, null, 10000, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, 10000, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -586,26 +506,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(professorsResearch.getId(), seller, 30000, null, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, null, null, 10000, 20000, null, PageRequest.of(0, 10));
-
-        assertThat(result.getContent())
-                .extracting(Card::getName)
-                .containsExactly("Charizard ex");
-    }
-
-    @Test
-    @DisplayName("t45 등급과 가격을 동시에 지정하면 같은 매물이 두 조건을 모두 만족하는 카드만 조회된다")
-    void t45() {
-        Long seller = persistSeller("grade-price-seller@test.com");
-        // charizard는 두 매물로 조건을 나눠 만족시켜, 같은 매물 하나가 등급·가격을 모두
-        // 만족해야 하는지(카드 단위가 아니라 매물 단위 AND) 검증한다.
-        persistListing(charizard.getId(), seller, 5000, ListingGrade.S, ListingStatus.ACTIVE);
-        persistListing(charizard.getId(), seller, 20000, ListingGrade.A, ListingStatus.ACTIVE);
-        // charizardEx는 단일 매물이 등급·가격 조건을 모두 만족한다.
-        persistListing(charizardEx.getId(), seller, 20000, ListingGrade.S, ListingStatus.ACTIVE);
-        entityManager.flush();
-
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, 10000, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, 10000, 20000, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -620,7 +521,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizardEx.getId(), seller, 20000, null, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, 10000, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, 10000, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -110,10 +110,14 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     private void persistListing(Long cardId, Long sellerId, ListingGrade grade, ListingStatus status) {
+        persistListing(cardId, sellerId, 10000, grade, status);
+    }
+
+    private void persistListing(Long cardId, Long sellerId, int price, ListingGrade grade, ListingStatus status) {
         Listing listing = Listing.builder()
                 .cardId(cardId)
                 .sellerId(sellerId)
-                .price(10000)
+                .price(price)
                 .grade(grade)
                 .build();
         entityManager.persist(listing);
@@ -138,7 +142,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -148,7 +152,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t3 rarity가 정확히 일치하는 카드만 조회한다")
     void t3() {
-        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -158,7 +162,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t4 expansionId가 정확히 일치하는 카드만 조회한다")
     void t4() {
-        Page<Card> result = cardRepository.search(null, null, null, "sv3pt5", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, "sv3pt5", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -168,7 +172,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 여러 조건을 조합하면 AND로 필터링된다")
     void t5() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "base1", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "base1", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -178,7 +182,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t6 조건이 없으면 전체 카드를 페이지 크기만큼 반환한다")
     void t6() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, PageRequest.of(0, 2));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, null, PageRequest.of(0, 2));
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
@@ -188,7 +192,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t12 타입을 여러 개 선택하면 하나라도 포함된 카드를 OR로 조회한다")
     void t12() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -198,7 +202,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t13 레어도를 여러 개 선택하면 하나라도 일치하는 카드를 OR로 조회한다")
     void t13() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -209,7 +213,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t14 타입·레어도·세트를 동시에 지정하면 AND로 결합되어 모두 만족하는 카드만 조회한다")
     void t14() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire"), List.of("Rare Holo"), null, "base1", null, PageRequest.of(0, 10));
+                List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -219,7 +223,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t15 조건을 모두 만족하는 카드가 없으면 빈 페이지를 반환한다")
     void t15() {
-        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -228,7 +232,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t16 존재하지 않는 타입 값으로 조회해도 예외 없이 빈 페이지를 반환한다")
     void t16() {
-        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -238,7 +242,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t17 타입을 여러 개, 레어도를 여러 개 동시에 선택하면 각 조건 내부는 OR, 조건 간에는 AND로 결합된다")
     void t17() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, null, PageRequest.of(0, 10));
+                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -248,7 +252,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t18 sort가 없으면 기본값 latest 기준(synced_at DESC, id DESC)으로 정렬한다")
     void t18() {
-        Page<Card> result = cardRepository.search(null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, null, PageRequest.of(0, 10));
 
         // id 순서(삽입 순서)와는 다른 synced_at 순서(내림차순: Charizard ex > Charizard > Pikachu
         // > Quick Ball > Professor's Research > Blastoise)로 나와야 synced_at이 실제 1차 정렬
@@ -261,7 +265,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t19 sort=name이면 이름 오름차순으로 정렬한다")
     void t19() {
-        Page<Card> result = cardRepository.search(null, null, null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -271,7 +275,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t20 화이트리스트에 없는 sort 값이 들어와도 예외 없이 기본값 latest로 처리한다")
     void t20() {
-        Page<Card> result = cardRepository.search(null, null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -281,7 +285,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t21 필터와 sort=name을 함께 적용해도 필터링된 결과 안에서 이름순으로 정렬한다")
     void t21() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -296,7 +300,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistCardWithViewCount("Squirtle", popExpansion, 10);
         persistCardWithViewCount("Bulbasaur", popExpansion, 0);
 
-        Page<Card> result = cardRepository.search(null, null, null, "popTest", "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, "popTest", null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -312,7 +316,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -386,7 +390,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t28 types에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t28() {
-        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -396,7 +400,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t29 rarity에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t29() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -406,7 +410,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t30 types가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
     void t30() {
-        Page<Card> result = cardRepository.search(List.of(""), null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of(""), null, null, null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getTotalElements()).isEqualTo(6);
     }
@@ -486,7 +490,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -501,7 +505,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, List.of("S", "A"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, List.of("S", "A"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -515,7 +519,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.CANCELLED);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
     }
@@ -527,7 +531,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizard.getId(), seller, ListingGrade.PSA10, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
     }
@@ -541,7 +545,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
         entityManager.flush();
 
-        Page<Card> result = cardRepository.search(null, List.of("Rare Holo"), List.of("S"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Rare Holo"), List.of("S"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -551,9 +555,76 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t40 grades가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
     void t40() {
-        Page<Card> result = cardRepository.search(null, null, List.of(""), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, List.of(""), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getTotalElements()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("t43 등급 미지정 상태에서 가격(minPrice)만 지정해도 매물 가격 기준으로 필터링된다")
+    void t43() {
+        // 등급을 지정하지 않고 가격만 지정한 경우에도 바깥 게이트 조건이 EXISTS를 실행해야
+        // 매물 가격 기준 필터링이 실제로 적용되는지 검증한다(게이트 수정의 핵심 케이스).
+        Long seller = persistSeller("price-only-seller@test.com");
+        persistListing(charizard.getId(), seller, 5000, null, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, 20000, null, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, null, null, 10000, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t44 minPrice와 maxPrice를 함께 지정하면 범위 안의 매물이 있는 카드만 조회된다")
+    void t44() {
+        Long seller = persistSeller("price-range-seller@test.com");
+        persistListing(charizard.getId(), seller, 5000, null, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, 15000, null, ListingStatus.ACTIVE);
+        persistListing(professorsResearch.getId(), seller, 30000, null, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, null, null, 10000, 20000, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t45 등급과 가격을 동시에 지정하면 같은 매물이 두 조건을 모두 만족하는 카드만 조회된다")
+    void t45() {
+        Long seller = persistSeller("grade-price-seller@test.com");
+        // charizard는 두 매물로 조건을 나눠 만족시켜, 같은 매물 하나가 등급·가격을 모두
+        // 만족해야 하는지(카드 단위가 아니라 매물 단위 AND) 검증한다.
+        persistListing(charizard.getId(), seller, 5000, ListingGrade.S, ListingStatus.ACTIVE);
+        persistListing(charizard.getId(), seller, 20000, ListingGrade.A, ListingStatus.ACTIVE);
+        // charizardEx는 단일 매물이 등급·가격 조건을 모두 만족한다.
+        persistListing(charizardEx.getId(), seller, 20000, ListingGrade.S, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, 10000, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t46 가격 필터를 기존 타입 필터와 함께 적용해도 두 조건이 AND로 결합된다")
+    void t46() {
+        Long seller = persistSeller("price-type-seller@test.com");
+        persistListing(charizard.getId(), seller, 5000, null, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, 20000, null, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, 10000, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard ex");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -52,12 +52,15 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         Expansion sv3pt5 = persistExpansion("sv3pt5", "151");
         Expansion swsh1 = persistExpansion("swsh1", "Sword & Shield");
 
-        charizard = persistCard("Charizard", "Rare Holo", base1, "Fire", List.of(6));
-        persistCard("Blastoise", "Rare Holo", base1, "Water", List.of(9));
-        persistCard("Pikachu", "Common", base1, "Lightning", List.of(25));
-        charizardEx = persistCard("Charizard ex", "Double Rare", sv3pt5, "Fire", List.of(6));
-        professorsResearch = persistTrainerCard("Professor's Research", base1);
-        quickBall = persistTrainerCard("Quick Ball", swsh1);
+        // synced_at을 삽입 순서(id)와 일부러 어긋나게 부여해, DESC 정렬이 id가 아닌
+        // synced_at 자체를 1차 키로 쓰는지 구분해서 검증할 수 있게 한다.
+        LocalDateTime baseTime = LocalDateTime.now();
+        charizard = persistCard("Charizard", "Rare Holo", base1, "Fire", List.of(6), baseTime.plusMinutes(5));
+        persistCard("Blastoise", "Rare Holo", base1, "Water", List.of(9), baseTime.plusMinutes(1));
+        persistCard("Pikachu", "Common", base1, "Lightning", List.of(25), baseTime.plusMinutes(4));
+        charizardEx = persistCard("Charizard ex", "Double Rare", sv3pt5, "Fire", List.of(6), baseTime.plusMinutes(6));
+        professorsResearch = persistTrainerCard("Professor's Research", base1, baseTime.plusMinutes(2));
+        quickBall = persistTrainerCard("Quick Ball", swsh1, baseTime.plusMinutes(3));
     }
 
     private Expansion persistExpansion(String id, String name) {
@@ -70,7 +73,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         return expansion;
     }
 
-    private Card persistCard(String name, String rarity, Expansion expansion, String type, List<Integer> pokedexNumbers) {
+    private Card persistCard(String name, String rarity, Expansion expansion, String type, List<Integer> pokedexNumbers, LocalDateTime syncedAt) {
         Card card = Card.builder()
                 .name(name)
                 .rarity(rarity)
@@ -78,16 +81,18 @@ class CardRepositoryTest extends AbstractIntegrationTest {
                 .expansion(expansion)
                 .types(type != null ? List.of(type) : null)
                 .nationalPokedexNumbers(pokedexNumbers)
+                .syncedAt(syncedAt)
                 .build();
         entityManager.persist(card);
         return card;
     }
 
-    private Card persistTrainerCard(String name, Expansion expansion) {
+    private Card persistTrainerCard(String name, Expansion expansion, LocalDateTime syncedAt) {
         Card card = Card.builder()
                 .name(name)
                 .supertype("Trainer")
                 .expansion(expansion)
+                .syncedAt(syncedAt)
                 .build();
         entityManager.persist(card);
         return card;
@@ -218,9 +223,12 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     void t18() {
         Page<Card> result = cardRepository.search(null, null, null, null, PageRequest.of(0, 10));
 
+        // id 순서(삽입 순서)와는 다른 synced_at 순서(내림차순: Charizard ex > Charizard > Pikachu
+        // > Quick Ball > Professor's Research > Blastoise)로 나와야 synced_at이 실제 1차 정렬
+        // 키임이 증명된다.
         assertThat(result.getContent())
                 .extracting(Card::getName)
-                .containsExactly("Quick Ball", "Professor's Research", "Charizard ex", "Pikachu", "Blastoise", "Charizard");
+                .containsExactly("Charizard ex", "Charizard", "Pikachu", "Quick Ball", "Professor's Research", "Blastoise");
     }
 
     @Test
@@ -240,7 +248,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
-                .containsExactly("Quick Ball", "Professor's Research", "Charizard ex", "Pikachu", "Blastoise", "Charizard");
+                .containsExactly("Charizard ex", "Charizard", "Pikachu", "Quick Ball", "Professor's Research", "Blastoise");
     }
 
     @Test
@@ -271,11 +279,17 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t23 필터와 sort=popular를 함께 적용해도 필터링된 결과 안에서 조회수순으로 정렬한다")
     void t23() {
+        cardRepository.incrementViewCount(charizard.getId());
+        cardRepository.incrementViewCount(charizard.getId());
+        cardRepository.incrementViewCount(charizardEx.getId());
+        entityManager.flush();
+        entityManager.clear();
+
         Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
-                .containsExactlyInAnyOrder("Charizard", "Charizard ex");
+                .containsExactly("Charizard", "Charizard ex");
     }
 
     @Test
@@ -304,21 +318,26 @@ class CardRepositoryTest extends AbstractIntegrationTest {
             return card.getId();
         });
 
-        int threadCount = 20;
-        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-        List<Future<?>> futures = new ArrayList<>();
-        for (int i = 0; i < threadCount; i++) {
-            futures.add(executor.submit(() -> cardRepository.incrementViewCount(cardId)));
-        }
-        executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-        // future.get()으로 각 스레드의 예외를 즉시 드러낸다. submit()만 하고 get()을 부르지 않으면
-        // TransactionRequiredException 등이 조용히 삼켜져 view_count가 증가하지 않은 원인을 놓치게 된다.
-        for (Future<?> future : futures) {
-            assertThatCode(future::get).doesNotThrowAnyException();
-        }
-
+        // 카드 커밋 직후부터 finally로 정리를 보장한다: 스레드 실행/검증 중 어디서 실패하더라도
+        // 커밋된 테스트 카드가 DB에 남지 않도록 try 범위를 넓혔다.
         try {
+            int threadCount = 20;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            List<Future<?>> futures = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(() -> cardRepository.incrementViewCount(cardId)));
+            }
+            executor.shutdown();
+            boolean terminated = executor.awaitTermination(10, TimeUnit.SECONDS);
+            // awaitTermination의 반환값을 무시하면 타임아웃으로 일부 스레드가 아직 실행 중이어도
+            // 조용히 다음 단계로 넘어가 원인 파악이 어려운 실패로 이어질 수 있다.
+            assertThat(terminated).as("20개 스레드가 타임아웃 전에 모두 종료되어야 한다").isTrue();
+            // future.get()으로 각 스레드의 예외를 즉시 드러낸다. submit()만 하고 get()을 부르지 않으면
+            // TransactionRequiredException 등이 조용히 삼켜져 view_count가 증가하지 않은 원인을 놓치게 된다.
+            for (Future<?> future : futures) {
+                assertThatCode(future::get).doesNotThrowAnyException();
+            }
+
             Integer finalViewCount = requiresNew.execute(status ->
                     cardRepository.findById(cardId).orElseThrow().getViewCount());
             assertThat(finalViewCount).isEqualTo(threadCount);

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -25,6 +25,9 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.Expansion;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.support.AbstractIntegrationTest;
 
 import jakarta.persistence.EntityManager;
@@ -98,6 +101,30 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         return card;
     }
 
+    private Long persistSeller(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .getSingleResult()).longValue();
+    }
+
+    private void persistListing(Long cardId, Long sellerId, ListingGrade grade, ListingStatus status) {
+        Listing listing = Listing.builder()
+                .cardId(cardId)
+                .sellerId(sellerId)
+                .price(10000)
+                .grade(grade)
+                .build();
+        entityManager.persist(listing);
+        if (status != ListingStatus.ACTIVE) {
+            entityManager.createNativeQuery("UPDATE listings SET status = :status WHERE id = :id")
+                    .setParameter("status", status.name())
+                    .setParameter("id", listing.getId())
+                    .executeUpdate();
+        }
+    }
+
     @Test
     @DisplayName("t1 이름 키워드에 부분 일치하는 카드를 대소문자 구분 없이 조회한다")
     void t1() {
@@ -111,7 +138,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -121,7 +148,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t3 rarity가 정확히 일치하는 카드만 조회한다")
     void t3() {
-        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common"), null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -131,7 +158,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t4 expansionId가 정확히 일치하는 카드만 조회한다")
     void t4() {
-        Page<Card> result = cardRepository.search(null, null, "sv3pt5", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, "sv3pt5", null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -141,7 +168,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 여러 조건을 조합하면 AND로 필터링된다")
     void t5() {
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, "base1", null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "base1", null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -151,7 +178,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t6 조건이 없으면 전체 카드를 페이지 크기만큼 반환한다")
     void t6() {
-        Page<Card> result = cardRepository.search(null, null, null, null, PageRequest.of(0, 2));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, PageRequest.of(0, 2));
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(6);
@@ -161,7 +188,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t12 타입을 여러 개 선택하면 하나라도 포함된 카드를 OR로 조회한다")
     void t12() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -171,7 +198,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t13 레어도를 여러 개 선택하면 하나라도 일치하는 카드를 OR로 조회한다")
     void t13() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", "Double Rare"), null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -182,7 +209,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t14 타입·레어도·세트를 동시에 지정하면 AND로 결합되어 모두 만족하는 카드만 조회한다")
     void t14() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire"), List.of("Rare Holo"), "base1", null, PageRequest.of(0, 10));
+                List.of("Fire"), List.of("Rare Holo"), null, "base1", null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -192,7 +219,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t15 조건을 모두 만족하는 카드가 없으면 빈 페이지를 반환한다")
     void t15() {
-        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Water"), List.of("Common"), null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -201,7 +228,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t16 존재하지 않는 타입 값으로 조회해도 예외 없이 빈 페이지를 반환한다")
     void t16() {
-        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("NonExistentType"), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
@@ -211,7 +238,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @DisplayName("t17 타입을 여러 개, 레어도를 여러 개 동시에 선택하면 각 조건 내부는 OR, 조건 간에는 AND로 결합된다")
     void t17() {
         Page<Card> result = cardRepository.search(
-                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, PageRequest.of(0, 10));
+                List.of("Fire", "Water"), List.of("Rare Holo", "Double Rare"), null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -221,7 +248,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t18 sort가 없으면 기본값 latest 기준(synced_at DESC, id DESC)으로 정렬한다")
     void t18() {
-        Page<Card> result = cardRepository.search(null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, null, PageRequest.of(0, 10));
 
         // id 순서(삽입 순서)와는 다른 synced_at 순서(내림차순: Charizard ex > Charizard > Pikachu
         // > Quick Ball > Professor's Research > Blastoise)로 나와야 synced_at이 실제 1차 정렬
@@ -234,7 +261,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t19 sort=name이면 이름 오름차순으로 정렬한다")
     void t19() {
-        Page<Card> result = cardRepository.search(null, null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -244,7 +271,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t20 화이트리스트에 없는 sort 값이 들어와도 예외 없이 기본값 latest로 처리한다")
     void t20() {
-        Page<Card> result = cardRepository.search(null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, null, "id; DROP TABLE cards;--", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -254,7 +281,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t21 필터와 sort=name을 함께 적용해도 필터링된 결과 안에서 이름순으로 정렬한다")
     void t21() {
-        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, "name", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", "Water"), null, null, null, "name", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -269,7 +296,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         persistCardWithViewCount("Squirtle", popExpansion, 10);
         persistCardWithViewCount("Bulbasaur", popExpansion, 0);
 
-        Page<Card> result = cardRepository.search(null, null, "popTest", "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, null, null, "popTest", "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -285,7 +312,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, "popular", PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, "popular", PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -359,7 +386,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t28 types에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t28() {
-        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of("Fire", ""), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -369,7 +396,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t29 rarity에 빈 문자열이 섞여 있으면 제거하고 나머지 값으로만 필터링한다")
     void t29() {
-        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(null, List.of("Common", ""), null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getContent())
                 .extracting(Card::getName)
@@ -379,7 +406,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t30 types가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
     void t30() {
-        Page<Card> result = cardRepository.search(List.of(""), null, null, null, PageRequest.of(0, 10));
+        Page<Card> result = cardRepository.search(List.of(""), null, null, null, null, PageRequest.of(0, 10));
 
         assertThat(result.getTotalElements()).isEqualTo(6);
     }
@@ -449,5 +476,83 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         Optional<Card> result = cardRepository.findByExternalId("does-not-exist");
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t35 grades=S로 필터링하면 S등급 매물이 있는 카드만 조회된다")
+    void t35() {
+        Long seller = persistSeller("grade-s-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard");
+    }
+
+    @Test
+    @DisplayName("t36 grades를 여러 개 선택하면 하나라도 일치하는 매물을 가진 카드를 OR로 조회한다")
+    void t36() {
+        Long seller = persistSeller("grade-multi-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, List.of("S", "A"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Charizard", "Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t37 ACTIVE가 아닌 매물의 등급은 필터에 반영되지 않는다")
+    void t37() {
+        Long seller = persistSeller("grade-cancelled-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.CANCELLED);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t38 등급 필터와 일치하는 매물이 없는 카드는 결과에서 제외된다")
+    void t38() {
+        Long seller = persistSeller("grade-none-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.PSA10, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, null, List.of("S"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t39 rarity와 grades를 함께 적용하면 같은 카드가 두 조건을 모두 만족할 때만 조회된다")
+    void t39() {
+        Long seller = persistSeller("grade-rarity-seller@test.com");
+        // charizard와 blastoise는 둘 다 rarity=Rare Holo. charizard에만 S등급 매물을 붙여
+        // rarity 조건과 grades 조건이 "같은 카드" 기준으로 AND 결합되는지 검증한다.
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        Page<Card> result = cardRepository.search(null, List.of("Rare Holo"), List.of("S"), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard");
+    }
+
+    @Test
+    @DisplayName("t40 grades가 빈 문자열로만 채워져 있으면 필터 없이 전체 카드를 반환한다")
+    void t40() {
+        Page<Card> result = cardRepository.search(null, null, List.of(""), null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getTotalElements()).isEqualTo(6);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -555,4 +555,42 @@ class CardRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(result.getTotalElements()).isEqualTo(6);
     }
+
+    @Test
+    @DisplayName("t41 카드별 ACTIVE 매물에 존재하는 등급을 배치로 조회하면 카드마다 중복 없는 등급 목록을 얻는다")
+    void t41() {
+        Long seller = persistSeller("grade-batch-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.ACTIVE);
+        persistListing(charizard.getId(), seller, ListingGrade.A, ListingStatus.ACTIVE);
+        persistListing(charizardEx.getId(), seller, ListingGrade.B, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        List<CardRepository.CardGradeView> result = cardRepository.findGradesByCardIds(
+                List.of(charizard.getId(), charizardEx.getId(), professorsResearch.getId()));
+
+        assertThat(result)
+                .filteredOn(view -> view.getCardId().equals(charizard.getId()))
+                .extracting(CardRepository.CardGradeView::getGrade)
+                .containsExactlyInAnyOrder("S", "A");
+        assertThat(result)
+                .filteredOn(view -> view.getCardId().equals(charizardEx.getId()))
+                .extracting(CardRepository.CardGradeView::getGrade)
+                .containsExactly("B");
+        assertThat(result)
+                .noneMatch(view -> view.getCardId().equals(professorsResearch.getId()));
+    }
+
+    @Test
+    @DisplayName("t42 ACTIVE가 아니거나 S/A/B가 아닌 등급은 배치 조회에서 제외된다")
+    void t42() {
+        Long seller = persistSeller("grade-batch-exclude-seller@test.com");
+        persistListing(charizard.getId(), seller, ListingGrade.PSA10, ListingStatus.ACTIVE);
+        persistListing(charizard.getId(), seller, ListingGrade.S, ListingStatus.CANCELLED);
+        entityManager.flush();
+
+        List<CardRepository.CardGradeView> result = cardRepository.findGradesByCardIds(List.of(charizard.getId()));
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
@@ -113,7 +113,7 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
         persistListing(multiVariantCard.getId(), seller, firstEdition.getId(), "A", "ACTIVE");
         entityManager.flush();
 
-        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId(), List.of("S", "A", "B"));
 
         assertThat(result)
                 .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
@@ -130,7 +130,7 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
         persistListing(multiVariantCard.getId(), seller, null, "S", "ACTIVE");
         entityManager.flush();
 
-        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId(), List.of("S", "A", "B"));
 
         assertThat(result)
                 .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
@@ -140,7 +140,7 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
     @Test
     @DisplayName("t5 매물이 없는 카드는 등급 조회 결과가 빈 목록이다")
     void t5() {
-        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId(), List.of("S", "A", "B"));
 
         assertThat(result).isEmpty();
     }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
@@ -144,4 +144,49 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("t6 대표 변형(is_primary)이 없는 카드도 variant_id가 명시된 ACTIVE 매물의 등급이 조회된다")
+    void t6() {
+        Card noPrimaryCard = Card.builder()
+                .name("Blastoise")
+                .rarity("Rare Holo")
+                .expansion(multiVariantCard.getExpansion())
+                .build();
+        entityManager.persist(noPrimaryCard);
+        CardVariant onlyVariant = CardVariant.builder()
+                .card(noPrimaryCard)
+                .variantName("holofoil")
+                .primary(false)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(onlyVariant);
+        Long seller = persistSeller("no-primary-variant-seller@test.com");
+        persistListing(noPrimaryCard.getId(), seller, onlyVariant.getId(), "B", "ACTIVE");
+        entityManager.flush();
+
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(noPrimaryCard.getId(), List.of("S", "A", "B"));
+
+        assertThat(result)
+                .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(onlyVariant.getId(), "B"));
+    }
+
+    @Test
+    @DisplayName("t7 동일 variant에 같은 등급의 ACTIVE 매물이 여러 건이어도 중복 없이 한 건으로 조회된다")
+    void t7() {
+        Long seller = persistSeller("duplicate-grade-seller@test.com");
+        CardVariant firstEdition = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(multiVariantCard.getId())
+                .stream().filter(v -> v.getVariantName().equals("firstEditionHolofoil")).findFirst().orElseThrow();
+        persistListing(multiVariantCard.getId(), seller, firstEdition.getId(), "A", "ACTIVE");
+        persistListing(multiVariantCard.getId(), seller, firstEdition.getId(), "A", "ACTIVE");
+        entityManager.flush();
+
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId(), List.of("S", "A", "B"));
+
+        assertThat(result)
+                .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(firstEdition.getId(), "A"));
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
@@ -82,4 +82,66 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(result).isEmpty();
     }
+
+    private Long persistSeller(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .getSingleResult()).longValue();
+    }
+
+    private Long persistListing(Long cardId, Long sellerId, Long variantId, String grade, String status) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status) "
+                                + "VALUES (:cardId, :sellerId, :variantId, 10000, :grade, :status) RETURNING id")
+                .setParameter("cardId", cardId)
+                .setParameter("sellerId", sellerId)
+                .setParameter("variantId", variantId)
+                .setParameter("grade", grade)
+                .setParameter("status", status)
+                .getSingleResult()).longValue();
+    }
+
+    @Test
+    @DisplayName("t3 variant_id가 채워진 매물은 해당 variant의 등급으로 매핑된다")
+    void t3() {
+        Long seller = persistSeller("variant-grade-seller@test.com");
+        CardVariant firstEdition = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(multiVariantCard.getId())
+                .stream().filter(v -> v.getVariantName().equals("firstEditionHolofoil")).findFirst().orElseThrow();
+        persistListing(multiVariantCard.getId(), seller, firstEdition.getId(), "A", "ACTIVE");
+        entityManager.flush();
+
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+
+        assertThat(result)
+                .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(firstEdition.getId(), "A"));
+    }
+
+    @Test
+    @DisplayName("t4 variant_id가 NULL인 매물은 대표 변형(primary) 등급으로 합산된다")
+    void t4() {
+        Long seller = persistSeller("variant-grade-null-seller@test.com");
+        CardVariant primary = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(multiVariantCard.getId())
+                .stream().filter(CardVariant::isPrimary).findFirst().orElseThrow();
+        persistListing(multiVariantCard.getId(), seller, null, "S", "ACTIVE");
+        entityManager.flush();
+
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+
+        assertThat(result)
+                .extracting(CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(primary.getId(), "S"));
+    }
+
+    @Test
+    @DisplayName("t5 매물이 없는 카드는 등급 조회 결과가 빈 목록이다")
+    void t5() {
+        List<CardVariantRepository.VariantGradeView> result = cardVariantRepository.findGradesByCardId(multiVariantCard.getId());
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -54,9 +54,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), "base1", "name", pageable)).willReturn(page);
+        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", "name", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), "base1", "name", pageable);
+        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", "name", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -72,11 +72,11 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, pageable))
+        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, pageable))
                 .willReturn(page);
 
         Page<CardResponse> result = cardService.search(
-                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, pageable);
+                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Blastoise");
@@ -92,9 +92,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, null, "latest", pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, "latest", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, "latest", pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, "latest", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -105,9 +105,9 @@ class CardServiceTest {
     void t17() {
         Pageable pageable = PageRequest.of(0, 100);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
@@ -117,7 +117,7 @@ class CardServiceTest {
     void t18() {
         Pageable pageable = PageRequest.of(0, 101);
 
-        assertThatThrownBy(() -> cardService.search(null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -131,7 +131,7 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -145,7 +145,7 @@ class CardServiceTest {
                 .mapToObj(i -> "rarity" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -159,11 +159,65 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(exactlyTwenty, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(exactlyTwenty, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("t31 grades가 20개를 초과하면 INVALID_INPUT 예외가 발생한다")
+    void t31() {
+        Pageable pageable = PageRequest.of(0, 20);
+        List<String> tooManyGrades = java.util.stream.IntStream.range(0, 21)
+                .mapToObj(i -> "S")
+                .toList();
+
+        assertThatThrownBy(() -> cardService.search(null, null, tooManyGrades, null, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t32 grades에 S/A/B 화이트리스트 외 값이 오면 INVALID_INPUT 예외가 발생한다")
+    void t32() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        assertThatThrownBy(() -> cardService.search(null, null, List.of("PSA10"), null, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t33 grades에 임의 문자열이 오면 INVALID_INPUT 예외가 발생한다")
+    void t33() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        assertThatThrownBy(() -> cardService.search(null, null, List.of("아무값"), null, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t34 grades가 S/A/B로만 구성되면 리포지토리에 그대로 위임한다")
+    void t34() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("Charizard")
+                .types(List.of("Fire"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.search(null, null, List.of("S", "A", "B"), null, null, pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.search(null, null, List.of("S", "A", "B"), null, null, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -421,6 +421,39 @@ class CardServiceTest {
     }
 
     @Test
+    @DisplayName("t37 키워드 검색 결과 카드들의 id를 모아 등급을 배치 조회하고 카드별 등급 배열로 매핑한다")
+    void t37() {
+        Card charizard = Card.builder().id(1L).name("Charizard").types(List.of("Fire")).build();
+        Card blastoise = Card.builder().id(2L).name("Blastoise").types(List.of("Water")).build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
+        given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
+        given(cardRepository.findGradesByCardIds(List.of(1L, 2L))).willReturn(List.of(
+                gradeView(1L, "B"),
+                gradeView(1L, "S")
+        ));
+
+        Page<CardResponse> result = cardService.searchByKeyword("char", pageable);
+
+        assertThat(result.getContent().get(0).grades()).containsExactly("S", "B");
+        assertThat(result.getContent().get(1).grades()).isEmpty();
+        verify(cardRepository, times(1)).findGradesByCardIds(any());
+    }
+
+    @Test
+    @DisplayName("t38 키워드 검색 결과가 비어 있으면 등급 배치 조회를 호출하지 않는다")
+    void t38() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
+        given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.searchByKeyword("char", pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(cardRepository, never()).findGradesByCardIds(any());
+    }
+
+    @Test
     @DisplayName("t7 포켓몬 카드(도감번호 있음)는 도감번호 겹침 기준으로 유사 카드를 조회한다")
     void t7() {
         Card card = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
@@ -487,6 +520,38 @@ class CardServiceTest {
         assertThat(result).isEmpty();
         verify(cardRepository, never()).findRelatedByPokedexNumber(any());
         verify(cardRepository, never()).findRelatedByExpansion(any(), any());
+    }
+
+    @Test
+    @DisplayName("t39 유사 카드 결과들의 id를 모아 등급을 배치 조회하고 카드별 등급 배열로 매핑한다")
+    void t39() {
+        Card card = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
+        Card related1 = Card.builder().id(2L).name("Charizard ex").build();
+        Card related2 = Card.builder().id(3L).name("Charizard V").build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByPokedexNumber(1L)).willReturn(List.of(related1, related2));
+        given(cardRepository.findGradesByCardIds(List.of(2L, 3L))).willReturn(List.of(
+                gradeView(2L, "A")
+        ));
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result.get(0).grades()).containsExactly("A");
+        assertThat(result.get(1).grades()).isEmpty();
+        verify(cardRepository, times(1)).findGradesByCardIds(any());
+    }
+
+    @Test
+    @DisplayName("t40 유사 카드 결과가 비어 있으면 등급 배치 조회를 호출하지 않는다")
+    void t40() {
+        Card card = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardRepository.findRelatedByPokedexNumber(1L)).willReturn(List.of());
+
+        List<CardResponse> result = cardService.getRelated(1L);
+
+        assertThat(result).isEmpty();
+        verify(cardRepository, never()).findGradesByCardIds(any());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -56,9 +56,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, "name", pageable)).willReturn(page);
+        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), "base1", null, null, "name", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, "name", pageable);
+        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), "base1", null, null, "name", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -74,11 +74,11 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, null, pageable))
+        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, pageable))
                 .willReturn(page);
 
         Page<CardResponse> result = cardService.search(
-                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, null, pageable);
+                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Blastoise");
@@ -94,9 +94,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, null, null, null, null, "latest", pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, "latest", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, "latest", pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, "latest", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -107,9 +107,9 @@ class CardServiceTest {
     void t17() {
         Pageable pageable = PageRequest.of(0, 100);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
@@ -119,7 +119,7 @@ class CardServiceTest {
     void t18() {
         Pageable pageable = PageRequest.of(0, 101);
 
-        assertThatThrownBy(() -> cardService.search(null, null, null, null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -133,7 +133,7 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -147,7 +147,7 @@ class CardServiceTest {
                 .mapToObj(i -> "rarity" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -161,65 +161,11 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(exactlyTwenty, null, null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(exactlyTwenty, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("t31 grades가 20개를 초과하면 INVALID_INPUT 예외가 발생한다")
-    void t31() {
-        Pageable pageable = PageRequest.of(0, 20);
-        List<String> tooManyGrades = java.util.stream.IntStream.range(0, 21)
-                .mapToObj(i -> "S")
-                .toList();
-
-        assertThatThrownBy(() -> cardService.search(null, null, tooManyGrades, null, null, null, null, pageable))
-                .isInstanceOf(BusinessException.class)
-                .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.INVALID_INPUT);
-    }
-
-    @Test
-    @DisplayName("t32 grades에 S/A/B 화이트리스트 외 값이 오면 INVALID_INPUT 예외가 발생한다")
-    void t32() {
-        Pageable pageable = PageRequest.of(0, 20);
-
-        assertThatThrownBy(() -> cardService.search(null, null, List.of("PSA10"), null, null, null, null, pageable))
-                .isInstanceOf(BusinessException.class)
-                .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.INVALID_INPUT);
-    }
-
-    @Test
-    @DisplayName("t33 grades에 임의 문자열이 오면 INVALID_INPUT 예외가 발생한다")
-    void t33() {
-        Pageable pageable = PageRequest.of(0, 20);
-
-        assertThatThrownBy(() -> cardService.search(null, null, List.of("아무값"), null, null, null, null, pageable))
-                .isInstanceOf(BusinessException.class)
-                .extracting(e -> ((BusinessException) e).getErrorCode())
-                .isEqualTo(ErrorCode.INVALID_INPUT);
-    }
-
-    @Test
-    @DisplayName("t34 grades가 S/A/B로만 구성되면 리포지토리에 그대로 위임한다")
-    void t34() {
-        Card card = Card.builder()
-                .id(1L)
-                .name("Charizard")
-                .types(List.of("Fire"))
-                .build();
-        Pageable pageable = PageRequest.of(0, 20);
-        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, List.of("S", "A", "B"), null, null, null, null, pageable)).willReturn(page);
-
-        Page<CardResponse> result = cardService.search(null, null, List.of("S", "A", "B"), null, null, null, null, pageable);
-
-        assertThat(result.getTotalElements()).isEqualTo(1);
-        assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
     }
 
     @Test
@@ -227,7 +173,7 @@ class CardServiceTest {
     void t41() {
         Pageable pageable = PageRequest.of(0, 20);
 
-        assertThatThrownBy(() -> cardService.search(null, null, null, null, 20000, 10000, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, null, 20000, 10000, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -243,9 +189,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, null, null, 10000, 50000, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, 10000, 50000, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, 10000, 50000, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, 10000, 50000, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -258,14 +204,14 @@ class CardServiceTest {
         Card blastoise = Card.builder().id(2L).name("Blastoise").types(List.of("Water")).build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
-        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, pageable)).willReturn(page);
         given(cardRepository.findGradesByCardIds(eq(List.of(1L, 2L)), any())).willReturn(List.of(
                 gradeView(1L, "B"),
                 gradeView(1L, "S"),
                 gradeView(1L, "A")
         ));
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, pageable);
 
         assertThat(result.getContent().get(0).grades()).containsExactly("S", "A", "B");
         assertThat(result.getContent().get(1).grades()).isEmpty();
@@ -277,9 +223,9 @@ class CardServiceTest {
     void t36() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, pageable);
 
         assertThat(result.getContent()).isEmpty();
         verify(cardRepository, never()).findGradesByCardIds(any(), any());

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.card.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -258,7 +259,7 @@ class CardServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
         given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
-        given(cardRepository.findGradesByCardIds(List.of(1L, 2L))).willReturn(List.of(
+        given(cardRepository.findGradesByCardIds(eq(List.of(1L, 2L)), any())).willReturn(List.of(
                 gradeView(1L, "B"),
                 gradeView(1L, "S"),
                 gradeView(1L, "A")
@@ -268,7 +269,7 @@ class CardServiceTest {
 
         assertThat(result.getContent().get(0).grades()).containsExactly("S", "A", "B");
         assertThat(result.getContent().get(1).grades()).isEmpty();
-        verify(cardRepository, times(1)).findGradesByCardIds(any());
+        verify(cardRepository, times(1)).findGradesByCardIds(any(), any());
     }
 
     @Test
@@ -281,7 +282,7 @@ class CardServiceTest {
         Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
 
         assertThat(result.getContent()).isEmpty();
-        verify(cardRepository, never()).findGradesByCardIds(any());
+        verify(cardRepository, never()).findGradesByCardIds(any(), any());
     }
 
     private CardRepository.CardGradeView gradeView(Long cardId, String grade) {
@@ -344,7 +345,7 @@ class CardServiceTest {
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(1L))
                 .willReturn(List.of(primaryVariant, secondaryVariant));
-        given(cardVariantRepository.findGradesByCardId(1L)).willReturn(List.of(
+        given(cardVariantRepository.findGradesByCardId(eq(1L), any())).willReturn(List.of(
                 variantGradeView(1L, "A"),
                 variantGradeView(2L, "B")
         ));
@@ -457,7 +458,7 @@ class CardServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
         given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
-        given(cardRepository.findGradesByCardIds(List.of(1L, 2L))).willReturn(List.of(
+        given(cardRepository.findGradesByCardIds(eq(List.of(1L, 2L)), any())).willReturn(List.of(
                 gradeView(1L, "B"),
                 gradeView(1L, "S")
         ));
@@ -466,7 +467,7 @@ class CardServiceTest {
 
         assertThat(result.getContent().get(0).grades()).containsExactly("S", "B");
         assertThat(result.getContent().get(1).grades()).isEmpty();
-        verify(cardRepository, times(1)).findGradesByCardIds(any());
+        verify(cardRepository, times(1)).findGradesByCardIds(any(), any());
     }
 
     @Test
@@ -479,7 +480,7 @@ class CardServiceTest {
         Page<CardResponse> result = cardService.searchByKeyword("char", pageable);
 
         assertThat(result.getContent()).isEmpty();
-        verify(cardRepository, never()).findGradesByCardIds(any());
+        verify(cardRepository, never()).findGradesByCardIds(any(), any());
     }
 
     @Test
@@ -559,7 +560,7 @@ class CardServiceTest {
         Card related2 = Card.builder().id(3L).name("Charizard V").build();
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardRepository.findRelatedByPokedexNumber(1L)).willReturn(List.of(related1, related2));
-        given(cardRepository.findGradesByCardIds(List.of(2L, 3L))).willReturn(List.of(
+        given(cardRepository.findGradesByCardIds(eq(List.of(2L, 3L)), any())).willReturn(List.of(
                 gradeView(2L, "A")
         ));
 
@@ -567,7 +568,7 @@ class CardServiceTest {
 
         assertThat(result.get(0).grades()).containsExactly("A");
         assertThat(result.get(1).grades()).isEmpty();
-        verify(cardRepository, times(1)).findGradesByCardIds(any());
+        verify(cardRepository, times(1)).findGradesByCardIds(any(), any());
     }
 
     @Test
@@ -580,7 +581,7 @@ class CardServiceTest {
         List<CardResponse> result = cardService.getRelated(1L);
 
         assertThat(result).isEmpty();
-        verify(cardRepository, never()).findGradesByCardIds(any());
+        verify(cardRepository, never()).findGradesByCardIds(any(), any());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -55,9 +55,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", "name", pageable)).willReturn(page);
+        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, "name", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", "name", pageable);
+        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), null, "base1", null, null, "name", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -73,11 +73,11 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, pageable))
+        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, null, pageable))
                 .willReturn(page);
 
         Page<CardResponse> result = cardService.search(
-                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, pageable);
+                List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Blastoise");
@@ -93,9 +93,9 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, null, null, "latest", pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, "latest", pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, "latest", pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, "latest", pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -106,9 +106,9 @@ class CardServiceTest {
     void t17() {
         Pageable pageable = PageRequest.of(0, 100);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
@@ -118,7 +118,7 @@ class CardServiceTest {
     void t18() {
         Pageable pageable = PageRequest.of(0, 101);
 
-        assertThatThrownBy(() -> cardService.search(null, null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -132,7 +132,7 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(tooManyTypes, null, null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -146,7 +146,7 @@ class CardServiceTest {
                 .mapToObj(i -> "rarity" + i)
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, tooManyRarities, null, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -160,9 +160,9 @@ class CardServiceTest {
                 .mapToObj(i -> "type" + i)
                 .toList();
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(exactlyTwenty, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(exactlyTwenty, null, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(exactlyTwenty, null, null, null, null, null, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
@@ -175,7 +175,7 @@ class CardServiceTest {
                 .mapToObj(i -> "S")
                 .toList();
 
-        assertThatThrownBy(() -> cardService.search(null, null, tooManyGrades, null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, tooManyGrades, null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -186,7 +186,7 @@ class CardServiceTest {
     void t32() {
         Pageable pageable = PageRequest.of(0, 20);
 
-        assertThatThrownBy(() -> cardService.search(null, null, List.of("PSA10"), null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, List.of("PSA10"), null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -197,7 +197,7 @@ class CardServiceTest {
     void t33() {
         Pageable pageable = PageRequest.of(0, 20);
 
-        assertThatThrownBy(() -> cardService.search(null, null, List.of("아무값"), null, null, pageable))
+        assertThatThrownBy(() -> cardService.search(null, null, List.of("아무값"), null, null, null, null, pageable))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
@@ -213,9 +213,38 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(null, null, List.of("S", "A", "B"), null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, List.of("S", "A", "B"), null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, List.of("S", "A", "B"), null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, List.of("S", "A", "B"), null, null, null, null, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
+    }
+
+    @Test
+    @DisplayName("t41 minPrice가 maxPrice보다 크면 INVALID_INPUT 예외가 발생한다")
+    void t41() {
+        Pageable pageable = PageRequest.of(0, 20);
+
+        assertThatThrownBy(() -> cardService.search(null, null, null, null, 20000, 10000, null, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t42 minPrice/maxPrice를 리포지토리에 그대로 위임한다")
+    void t42() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("Charizard")
+                .types(List.of("Fire"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.search(null, null, null, null, 10000, 50000, null, pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.search(null, null, null, null, 10000, 50000, null, pageable);
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
@@ -228,14 +257,14 @@ class CardServiceTest {
         Card blastoise = Card.builder().id(2L).name("Blastoise").types(List.of("Water")).build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
-        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
         given(cardRepository.findGradesByCardIds(List.of(1L, 2L))).willReturn(List.of(
                 gradeView(1L, "B"),
                 gradeView(1L, "S"),
                 gradeView(1L, "A")
         ));
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
 
         assertThat(result.getContent().get(0).grades()).containsExactly("S", "A", "B");
         assertThat(result.getContent().get(1).grades()).isEmpty();
@@ -247,9 +276,9 @@ class CardServiceTest {
     void t36() {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.search(null, null, null, null, null, null, null, pageable)).willReturn(page);
 
-        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, null, pageable);
 
         assertThat(result.getContent()).isEmpty();
         verify(cardRepository, never()).findGradesByCardIds(any());

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDateTime;
@@ -221,6 +222,68 @@ class CardServiceTest {
     }
 
     @Test
+    @DisplayName("t35 검색 결과 카드들의 id를 모아 등급을 배치 조회하고 카드별 등급 배열로 매핑한다")
+    void t35() {
+        Card charizard = Card.builder().id(1L).name("Charizard").types(List.of("Fire")).build();
+        Card blastoise = Card.builder().id(2L).name("Blastoise").types(List.of("Water")).build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(charizard, blastoise), pageable, 2);
+        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
+        given(cardRepository.findGradesByCardIds(List.of(1L, 2L))).willReturn(List.of(
+                gradeView(1L, "B"),
+                gradeView(1L, "S"),
+                gradeView(1L, "A")
+        ));
+
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
+
+        assertThat(result.getContent().get(0).grades()).containsExactly("S", "A", "B");
+        assertThat(result.getContent().get(1).grades()).isEmpty();
+        verify(cardRepository, times(1)).findGradesByCardIds(any());
+    }
+
+    @Test
+    @DisplayName("t36 검색 결과가 비어 있으면 등급 배치 조회를 호출하지 않는다")
+    void t36() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
+        given(cardRepository.search(null, null, null, null, null, pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(cardRepository, never()).findGradesByCardIds(any());
+    }
+
+    private CardRepository.CardGradeView gradeView(Long cardId, String grade) {
+        return new CardRepository.CardGradeView() {
+            @Override
+            public Long getCardId() {
+                return cardId;
+            }
+
+            @Override
+            public String getGrade() {
+                return grade;
+            }
+        };
+    }
+
+    private CardVariantRepository.VariantGradeView variantGradeView(Long variantId, String grade) {
+        return new CardVariantRepository.VariantGradeView() {
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+
+            @Override
+            public String getGrade() {
+                return grade;
+            }
+        };
+    }
+
+    @Test
     @DisplayName("t2 존재하는 id로 상세조회하면 확장팩과 변형 목록을 포함한 상세 응답을 반환한다")
     void t2() {
         Expansion expansion = Expansion.builder()
@@ -252,6 +315,10 @@ class CardServiceTest {
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(1L))
                 .willReturn(List.of(primaryVariant, secondaryVariant));
+        given(cardVariantRepository.findGradesByCardId(1L)).willReturn(List.of(
+                variantGradeView(1L, "A"),
+                variantGradeView(2L, "B")
+        ));
 
         CardDetailResponse result = cardService.getDetail(1L);
 
@@ -259,6 +326,8 @@ class CardServiceTest {
         assertThat(result.expansion().id()).isEqualTo("base1");
         assertThat(result.variants()).hasSize(2);
         assertThat(result.variants().get(0).variantName()).isEqualTo("unlimitedHolofoil");
+        assertThat(result.variants().get(0).grades()).containsExactly("A");
+        assertThat(result.variants().get(1).grades()).containsExactly("B");
         verify(cardRepository).incrementViewCount(1L);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #73 

## ✨ 작업 내용
- 카드 검색 정렬 테스트 보강
- rarity 파라미터 이름 통일 (내부 코드만, API는 그대로)
- 가격대로 카드 검색 필터링 기능 추가
- 카드 목록/상세에 매물 등급(S/A/B) 정보 표시 추가
- 카드 API 요청 횟수 제한 추가 (분당 60회, 임시)
- 카드 검색 쿼리 중복 코드 정리

## 📸 스크린샷 / 테스트 결과
- 카드 도메인 테스트 108개 전체 통과 (Controller/Repository/Service)
- 등급+가격 동시 필터링 시 같은 매물 기준으로 정확히 결합되는지 검증 (서로 다른 매물끼리 조건이 섞이지 않음을 별도 테스트로 확인)
- Rate Limit: 분당 60회 제한 실제 서버 기동 상태로 확인
- 다른 도메인(시세, 매물) API 비영향 확인

## 🔍 리뷰 포인트
- 정렬/성능점검 + 등급필터 + 가격필터 + 리팩터링 
  (등급 필터가 만든 조건 구조를 가격 필터가 그대로 확장했고, 리팩터링은 그 과정에서 커진 중복을 정리한 것입니다)
- CardRateLimitFilter는 카드 도메인 한정 임시 조치입니다. 
   전체 서비스 공통 Rate Limiter 정책이 팀 논의로 확정되면 이 필터는 제거되고 공통 필터로 대체될 예정입니다.
- findByExternalId는 현재 호출하는 곳이 없는 재사용 대비용 메서드입니다 
  (AI 등급진단 연결 시 활용 제안)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (API 명세서 반영 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카드 검색 시 최소 가격과 최대 가격으로 결과를 필터링할 수 있습니다.
  * 카드 및 카드 변형 정보에 등급 목록이 표시됩니다.
  * 가격 범위가 올바르지 않은 경우 안내 오류가 제공됩니다.

* **버그 수정**
  * 검색 결과와 관련 카드의 등급 정보가 누락 없이 매핑됩니다.
  * 판매 중인 상품이 없는 카드 변형도 올바른 등급으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->