### PR TITLE
[Feature] #71 거래 취소 API 구현 

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
@@ -47,4 +47,12 @@ public class TradeController {
     ) {
         return ResponseEntity.ok(tradeService.confirmTrade(buyerId, id));
     }
+
+    @PatchMapping("/{id}/cancel")
+    public ResponseEntity<TradeResponse> cancelTrade(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(tradeService.cancelTrade(userId, id));
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -85,4 +85,20 @@ public class TradeService {
 
         return TradeResponse.of(trade);
     }
+
+    @Transactional
+    public TradeResponse cancelTrade(Long userId, Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        boolean isParticipant = trade.getBuyerId().equals(userId)
+                || trade.getListing().getSellerId().equals(userId);
+        if (!isParticipant) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        trade.cancel();
+
+        return TradeResponse.of(trade);
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -20,14 +20,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
-import com.pokade.domain.listing.entity.Listing;
-import com.pokade.domain.listing.entity.ListingGrade;
-import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.listing.Listing;
+import com.pokade.domain.listing.ListingGrade;
+import com.pokade.domain.listing.ListingRepository;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
-import com.pokade.domain.trade.entity.Trade;
-import com.pokade.domain.trade.entity.TradeStatus;
-import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.domain.trade.Trade;
+import com.pokade.domain.trade.TradeRepository;
+import com.pokade.domain.trade.TradeStatus;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -20,14 +20,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
-import com.pokade.domain.listing.Listing;
-import com.pokade.domain.listing.ListingGrade;
-import com.pokade.domain.listing.ListingRepository;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
-import com.pokade.domain.trade.Trade;
-import com.pokade.domain.trade.TradeRepository;
-import com.pokade.domain.trade.TradeStatus;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.trade;
+package com.pokade.domain.trade.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
@@ -72,7 +72,7 @@ class TradeControllerTest {
                 .willReturn(response);
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -86,7 +86,7 @@ class TradeControllerTest {
         TradeCreateRequest invalidRequest = new TradeCreateRequest(null);
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest())
@@ -101,7 +101,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 100L)
+                        .with(userId(100L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -116,7 +116,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
@@ -131,7 +131,7 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.TRADE_CONFLICT));
 
         mockMvc.perform(post("/api/trades")
-                        .header("X-USER-ID", 200L)
+                        .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isConflict())
@@ -218,6 +218,67 @@ class TradeControllerTest {
                 .willThrow(new BusinessException(ErrorCode.INVALID_TRADE_STATUS));
 
         mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
+                        .with(userId(200L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_TRADE_STATUS"));
+    }
+
+    @Test
+    void 구매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
+        TradeResponse response = new TradeResponse(
+                1L, 1L, 200L, 10000, TradeStatus.CANCELLED,
+                null, null, null, LocalDateTime.now());
+
+        given(tradeService.cancelTrade(200L, 1L)).willReturn(response);
+
+        mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
+                        .with(userId(200L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    @Test
+    void 판매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
+        TradeResponse response = new TradeResponse(
+                1L, 1L, 200L, 10000, TradeStatus.CANCELLED,
+                null, null, null, LocalDateTime.now());
+
+        given(tradeService.cancelTrade(100L, 1L)).willReturn(response);
+
+        mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
+                        .with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    @Test
+    void 본인_거래가_아니면_취소시_403을_반환한다() throws Exception {
+        given(tradeService.cancelTrade(999L, 1L))
+                .willThrow(new BusinessException(ErrorCode.ACCESS_DENIED));
+
+        mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
+                        .with(userId(999L)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void 존재하지_않는_거래를_취소하면_404를_반환한다() throws Exception {
+        given(tradeService.cancelTrade(200L, 999L))
+                .willThrow(new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/trades/{id}/cancel", 999L)
+                        .with(userId(200L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
+    }
+
+    @Test
+    void 이미_완료된_거래를_취소하면_400을_반환한다() throws Exception {
+        given(tradeService.cancelTrade(200L, 1L))
+                .willThrow(new BusinessException(ErrorCode.INVALID_TRADE_STATUS));
+
+        mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_TRADE_STATUS"));

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -128,4 +128,54 @@ class TradeServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TRADE_STATUS);
     }
+
+    @Test
+    void 구매자가_취소하면_거래상태가_CANCELLED로_바뀐다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        TradeResponse response = tradeService.cancelTrade(200L, 1L);
+
+        assertThat(response.status()).isEqualTo(TradeStatus.CANCELLED);
+    }
+
+    @Test
+    void 판매자가_취소하면_거래상태가_CANCELLED로_바뀐다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        TradeResponse response = tradeService.cancelTrade(100L, 1L);
+
+        assertThat(response.status()).isEqualTo(TradeStatus.CANCELLED);
+    }
+
+    @Test
+    void 구매자도_판매자도_아니면_취소시_ACCESS_DENIED_예외가_발생한다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        assertThatThrownBy(() -> tradeService.cancelTrade(999L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    void 존재하지_않는_거래를_취소하면_TRADE_NOT_FOUND_예외가_발생한다() {
+        given(tradeRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> tradeService.cancelTrade(200L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TRADE_NOT_FOUND);
+    }
+
+    @Test
+    void 이미_완료된_거래를_취소하면_INVALID_TRADE_STATUS_예외가_발생한다() {
+        Trade trade = tradeOf(100L, 200L);
+        trade.complete();
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+
+        assertThatThrownBy(() -> tradeService.cancelTrade(200L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TRADE_STATUS);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #71 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
  - FR-TRADE-09 거래 취소 API 구현 (PATCH /api/trades/{id}/cancel)                                                                                                      
  - TradeService.cancelTrade(userId, tradeId) 추가 — 구매자 또는 판매자 본인이면 취소 가능(FR-TRADE-08 확정과 달리 양쪽 다 허용), Trade.cancel() 가드로 상태 전이 검증  
  - 예외 처리: 거래 없음 → 404, 본인 아님 → 403, 취소 불가 상태(이미 완료/취소) → 400 — 전부 기존 ErrorCode 재사용

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [ ] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 거래 참여자(구매자 또는 판매자)가 거래를 취소할 수 있는 기능을 추가했습니다.
  * 거래 취소 요청에 대한 권한 및 거래 상태를 검증합니다.

* **버그 수정**
  * 존재하지 않거나 완료된 거래, 권한이 없는 사용자의 취소 요청을 적절히 처리합니다.

* **테스트**
  * 거래 취소 성공 및 예외 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->