### PR TITLE
[Feature] #64 AI 등급 진단 결과 조회 API 추가 및 서비스 계층 예외 처리 AOP 도입

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -100,8 +100,9 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    # 이미 리뷰가 진행된 PR에 새 커밋이 추가되면 변경분만 자동으로 다시 리뷰합니다.
-    auto_incremental_review: true
+    # 커밋 추가 시마다 재리뷰하면 개발자별 리뷰 한도(rate limit)를 빨리 소진하므로 끕니다.
+    # 재리뷰가 필요하면 PR 코멘트에 "@coderabbitai review"를 직접 입력하세요.
+    auto_incremental_review: false
     base_branches:
       - "main"
       - "develop"

--- a/Pokade/build.gradle.kts
+++ b/Pokade/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-aspectj")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-mail")

--- a/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
@@ -3,6 +3,8 @@ package com.pokade.domain.ai.controller;
 import com.pokade.domain.ai.dto.GradeRequest;
 import com.pokade.domain.ai.dto.GradeResponse;
 import com.pokade.domain.ai.service.AiGradeService;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -77,7 +79,7 @@ public class AiGradeController {
 
             @AuthenticationPrincipal Long principalUserId
     ) {
-        Long userId = resolveUserId(principalUserId);
+        Long userId = requireUserId(principalUserId);
         GradeResponse response = aiGradeService.getGradeResult(userId, resultId);
         return ResponseEntity.ok(response);
     }
@@ -85,5 +87,13 @@ public class AiGradeController {
     // TODO: 프론트 로그인 연동 완료 후 permitAll·기본값 제거하고 @AuthenticationPrincipal 값을 그대로 사용할 것
     private Long resolveUserId(Long principalUserId) {
         return principalUserId != null ? principalUserId : 1L;
+    }
+
+    // 결과/이력 조회는 타인 데이터 노출 위험이 있어 인증 없는 접근을 허용하지 않는다
+    private Long requireUserId(Long principalUserId) {
+        if (principalUserId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return principalUserId;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
@@ -9,10 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.security.Principal;
 
 @Tag(name = "AI 등급 진단", description = "포켓몬 카드 AI 예비 등급 진단 API")
 @RestController
@@ -58,27 +57,33 @@ public class AiGradeController {
             @Parameter(description = "무료 재업로드 시 원본 grade_result_id")
             @RequestParam(required = false) Long retryOfId,
 
-            Principal principal
+            @AuthenticationPrincipal Long principalUserId
     ) {
-        // TODO: OAuth2 연동 완료 후 principal에서 실제 userId 추출
-        Long userId = extractUserId(principal);
+        Long userId = resolveUserId(principalUserId);
 
         GradeRequest request = new GradeRequest(front, back, cornerTl, cornerTr, cornerBl, cornerBr, retryOfId);
         GradeResponse response = aiGradeService.grade(userId, request);
         return ResponseEntity.ok(response);
     }
 
-    private Long extractUserId(Principal principal) {
-        // TODO: OAuth2 UserDetails에서 userId 추출로 교체
-        if (principal == null) {
-            // TODO: 로컬 테스트용 임시 고정 userId — 인증 연동 후 제거할 것
-            return 1L;
-        }
-        // 임시: principal.getName()이 userId인 경우 (개발 단계)
-        try {
-            return Long.parseLong(principal.getName());
-        } catch (NumberFormatException e) {
-            throw new IllegalStateException("유효하지 않은 사용자 정보입니다.");
-        }
+    @Operation(
+            summary = "AI 등급 진단 결과 조회",
+            description = "진단 요청(POST /api/ai/grade) 응답으로 받은 resultId로 상세 결과를 조회합니다. 본인이 요청한 결과만 조회 가능합니다."
+    )
+    @GetMapping("/grade/{resultId}")
+    public ResponseEntity<GradeResponse> getGradeResult(
+            @Parameter(description = "조회할 진단 결과 ID", required = true)
+            @PathVariable Long resultId,
+
+            @AuthenticationPrincipal Long principalUserId
+    ) {
+        Long userId = resolveUserId(principalUserId);
+        GradeResponse response = aiGradeService.getGradeResult(userId, resultId);
+        return ResponseEntity.ok(response);
+    }
+
+    // TODO: 프론트 로그인 연동 완료 후 permitAll·기본값 제거하고 @AuthenticationPrincipal 값을 그대로 사용할 것
+    private Long resolveUserId(Long principalUserId) {
+        return principalUserId != null ? principalUserId : 1L;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -22,6 +22,7 @@ import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -199,7 +200,7 @@ public class AiGradeService {
         try {
             return new InputStreamResource(file.getInputStream());
         } catch (IOException e) {
-            throw new RuntimeException("이미지를 읽을 수 없습니다: " + file.getOriginalFilename(), e);
+            throw new UncheckedIOException("이미지를 읽을 수 없습니다: " + file.getOriginalFilename(), e);
         }
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -7,6 +7,8 @@ import com.pokade.domain.ai.dto.VisionResult;
 import com.pokade.domain.ai.entity.*;
 import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -112,6 +114,17 @@ public class AiGradeService {
                         .photoType(type)
                         .imageUrl(key)
                         .build()));
+
+        return GradeResponse.from(gradeResult);
+    }
+
+    public GradeResponse getGradeResult(Long userId, Long resultId) {
+        GradeResult gradeResult = gradeResultRepository.findById(resultId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GRADE_RESULT_NOT_FOUND));
+
+        if (!gradeResult.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
 
         return GradeResponse.from(gradeResult);
     }

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/S3UploadService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/S3UploadService.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.UUID;
 
@@ -42,7 +43,7 @@ public class S3UploadService {
                     .build();
             s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
         } catch (IOException e) {
-            throw new RuntimeException("S3 업로드 실패: " + file.getOriginalFilename(), e);
+            throw new UncheckedIOException("S3 업로드 실패: " + file.getOriginalFilename(), e);
         }
         return key;
     }

--- a/Pokade/src/main/java/com/pokade/global/aop/ExceptionLoggingAspect.java
+++ b/Pokade/src/main/java/com/pokade/global/aop/ExceptionLoggingAspect.java
@@ -7,8 +7,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
-
 /**
  * 서비스 계층에서 발생하는 모든 예외를 자동으로 로깅한다.
  * ExceptionTranslationAspect보다 높은 Order 값(더 안쪽)으로 두어, 이 Aspect가
@@ -22,10 +20,10 @@ public class ExceptionLoggingAspect {
 
     @AfterThrowing(pointcut = "execution(* com.pokade.domain..service..*.*(..))", throwing = "ex")
     public void logException(JoinPoint joinPoint, Throwable ex) {
-        log.error("{}.{}() 예외 발생 - args={}",
+        // 서비스 인자에는 비밀번호/토큰 등 민감정보가 포함될 수 있어 로그에 남기지 않는다
+        log.error("{}.{}() 예외 발생",
                 joinPoint.getSignature().getDeclaringTypeName(),
                 joinPoint.getSignature().getName(),
-                Arrays.toString(joinPoint.getArgs()),
                 ex);
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/aop/ExceptionLoggingAspect.java
+++ b/Pokade/src/main/java/com/pokade/global/aop/ExceptionLoggingAspect.java
@@ -1,0 +1,31 @@
+package com.pokade.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+/**
+ * 서비스 계층에서 발생하는 모든 예외를 자동으로 로깅한다.
+ * ExceptionTranslationAspect보다 높은 Order 값(더 안쪽)으로 두어, 이 Aspect가
+ * 먼저 원본(변환 전) 예외를 스택트레이스와 함께 기록한다.
+ */
+@Aspect
+@Component
+@Order(2)
+@Slf4j
+public class ExceptionLoggingAspect {
+
+    @AfterThrowing(pointcut = "execution(* com.pokade.domain..service..*.*(..))", throwing = "ex")
+    public void logException(JoinPoint joinPoint, Throwable ex) {
+        log.error("{}.{}() 예외 발생 - args={}",
+                joinPoint.getSignature().getDeclaringTypeName(),
+                joinPoint.getSignature().getName(),
+                Arrays.toString(joinPoint.getArgs()),
+                ex);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/aop/ExceptionTranslationAspect.java
+++ b/Pokade/src/main/java/com/pokade/global/aop/ExceptionTranslationAspect.java
@@ -1,0 +1,36 @@
+package com.pokade.global.aop;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+import java.io.UncheckedIOException;
+
+/**
+ * 서비스 계층에서 발생하는 저수준 인프라 예외(IO, DB)를 BusinessException으로 변환한다.
+ * ExceptionLoggingAspect보다 낮은 Order 값(더 바깥쪽)으로 두어, 로깅 Aspect가 먼저
+ * 원본 예외를 기록한 뒤 이 Aspect가 최종적으로 변환하도록 한다.
+ */
+@Aspect
+@Component
+@Order(1)
+public class ExceptionTranslationAspect {
+
+    @Around("execution(* com.pokade.domain..service..*.*(..))")
+    public Object translate(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (UncheckedIOException e) {
+            throw new BusinessException(ErrorCode.FILE_IO_ERROR, e.getMessage());
+        } catch (DataAccessException e) {
+            throw new BusinessException(ErrorCode.DATABASE_ERROR, e.getMessage());
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/aop/ExceptionTranslationAspect.java
+++ b/Pokade/src/main/java/com/pokade/global/aop/ExceptionTranslationAspect.java
@@ -8,11 +8,12 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.core.annotation.Order;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
 
 import java.io.UncheckedIOException;
 
 /**
- * 서비스 계층에서 발생하는 저수준 인프라 예외(IO, DB)를 BusinessException으로 변환한다.
+ * 서비스 계층에서 발생하는 저수준 인프라 예외(IO, DB, S3)를 BusinessException으로 변환한다.
  * ExceptionLoggingAspect보다 낮은 Order 값(더 바깥쪽)으로 두어, 로깅 Aspect가 먼저
  * 원본 예외를 기록한 뒤 이 Aspect가 최종적으로 변환하도록 한다.
  */
@@ -28,6 +29,8 @@ public class ExceptionTranslationAspect {
         } catch (BusinessException e) {
             throw e;
         } catch (UncheckedIOException e) {
+            throw new BusinessException(ErrorCode.FILE_IO_ERROR, e.getMessage());
+        } catch (SdkException e) {
             throw new BusinessException(ErrorCode.FILE_IO_ERROR, e.getMessage());
         } catch (DataAccessException e) {
             throw new BusinessException(ErrorCode.DATABASE_ERROR, e.getMessage());

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/actuator/health",
             "/actuator/prometheus",
-            "/api/ai/grade" // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
+            "/api/ai/grade", // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
+            "/api/ai/grade/*" // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
     };
 
     // 보안 필터체인 — CSRF/CORS 설정과 경로별 인가 규칙을 정의

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -37,8 +37,7 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/actuator/health",
             "/actuator/prometheus",
-            "/api/ai/grade", // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
-            "/api/ai/grade/*" // TODO: 로컬 테스트용 임시 permitAll — 인증 연동 후 제거할 것
+            "/api/ai/grade" // TODO: 로컬 테스트용 임시 permitAll(진단 요청만) — 인증 연동 후 제거할 것. 결과/이력 조회는 본인 데이터 노출 위험이 있어 인증 필수로 유지
     };
 
     // 보안 필터체인 — CSRF/CORS 설정과 경로별 인가 규칙을 정의

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -42,7 +42,11 @@ public enum ErrorCode {
     EMAIL_VERIFY_ATTEMPT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과했습니다."),
 
     // ===== AI 등급 진단 =====
-    AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다.");
+    AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),
+
+    // ===== 인프라 (AOP 자동 변환) =====
+    FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 처리 중 오류가 발생했습니다."),
+    DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     LISTING_NOT_FOUND(HttpStatus.NOT_FOUND, "매물을 찾을 수 없습니다."),
     TRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "거래를 찾을 수 없습니다."),
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
+    GRADE_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "진단 결과를 찾을 수 없습니다."),
     PRIMARY_VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 변형이 지정되지 않은 카드입니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),

--- a/Pokade/src/test/java/com/pokade/domain/fixture/service/ExceptionTranslationAspectTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/fixture/service/ExceptionTranslationAspectTest.java
@@ -1,0 +1,92 @@
+package com.pokade.domain.fixture.service;
+
+import com.pokade.global.aop.ExceptionTranslationAspect;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+import java.io.UncheckedIOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ExceptionTranslationAspect의 pointcut(com.pokade.domain..service..*.*)이 실제로
+ * 매칭되는 패키지 구조(domain 하위의 service 패키지)에 더미 서비스를 두고 검증한다.
+ */
+class ExceptionTranslationAspectTest {
+
+    interface FakeService {
+        void throwIo();
+
+        void throwDataAccess();
+
+        void throwBusiness();
+
+        void succeed();
+    }
+
+    static class FakeServiceImpl implements FakeService {
+        @Override
+        public void throwIo() {
+            throw new UncheckedIOException("파일 읽기 실패", new java.io.IOException("boom"));
+        }
+
+        @Override
+        public void throwDataAccess() {
+            throw new DataAccessResourceFailureException("DB 연결 실패");
+        }
+
+        @Override
+        public void throwBusiness() {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
+        @Override
+        public void succeed() {
+        }
+    }
+
+    private FakeService proxy() {
+        AspectJProxyFactory factory = new AspectJProxyFactory(new FakeServiceImpl());
+        factory.addAspect(new ExceptionTranslationAspect());
+        return factory.getProxy();
+    }
+
+    @Test
+    @DisplayName("UncheckedIOException은 BusinessException(FILE_IO_ERROR)로 변환된다")
+    void translatesUncheckedIOException() {
+        assertThatThrownBy(() -> proxy().throwIo())
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FILE_IO_ERROR);
+    }
+
+    @Test
+    @DisplayName("DataAccessException은 BusinessException(DATABASE_ERROR)로 변환된다")
+    void translatesDataAccessException() {
+        assertThatThrownBy(() -> proxy().throwDataAccess())
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DATABASE_ERROR);
+    }
+
+    @Test
+    @DisplayName("이미 BusinessException이면 그대로 통과한다")
+    void passesThroughExistingBusinessException() {
+        assertThatThrownBy(() -> proxy().throwBusiness())
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("예외가 없으면 정상 동작한다")
+    void passesThroughOnSuccess() {
+        assertThat(proxy()).isNotNull();
+        proxy().succeed();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/fixture/service/ExceptionTranslationAspectTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/fixture/service/ExceptionTranslationAspectTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 import org.springframework.dao.DataAccessResourceFailureException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 import java.io.UncheckedIOException;
 
@@ -24,6 +25,8 @@ class ExceptionTranslationAspectTest {
 
         void throwDataAccess();
 
+        void throwSdkException();
+
         void throwBusiness();
 
         void succeed();
@@ -38,6 +41,11 @@ class ExceptionTranslationAspectTest {
         @Override
         public void throwDataAccess() {
             throw new DataAccessResourceFailureException("DB 연결 실패");
+        }
+
+        @Override
+        public void throwSdkException() {
+            throw SdkClientException.create("S3 업로드 실패");
         }
 
         @Override
@@ -72,6 +80,15 @@ class ExceptionTranslationAspectTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.DATABASE_ERROR);
+    }
+
+    @Test
+    @DisplayName("SdkException(AWS SDK)은 BusinessException(FILE_IO_ERROR)로 변환된다")
+    void translatesSdkException() {
+        assertThatThrownBy(() -> proxy().throwSdkException())
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FILE_IO_ERROR);
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #64

## ✨ 작업 내용
- AI 등급 진단 결과 조회 API 구현 (`GET /api/ai/grade/{resultId}`)
  - 진단 요청 응답의 resultId로 상세 결과 조회
  - 본인이 요청한 결과가 아닌 경우 접근 차단, 존재하지 않는 resultId 조회 시 404 처리 (`GRADE_RESULT_NOT_FOUND` 에러코드 추가)
- 서비스 계층 저수준 예외 자동 변환/로깅 AOP 도입
  - `ExceptionTranslationAspect` — `domain..service` 전 계층에 적용, `UncheckedIOException`/`DataAccessException` 등 저수준 인프라 예외를 `BusinessException`으로 자동 변환 (`FILE_IO_ERROR`, `DATABASE_ERROR` 에러코드 추가)
  - `ExceptionLoggingAspect` — 변환 전 원본 예외를 스택트레이스와 함께 로깅 (`@Order`로 로깅이 변환보다 먼저 실행되도록 순서 보장)
- `AiGradeController`의 임시 `Principal` 기반 userId 추출 로직을 `@AuthenticationPrincipal` 방식으로 정리 (프론트 로그인 연동 전까지는 기본값 fallback 유지, `SecurityConfig`에 `/api/ai/grade/*` permitAll 임시 추가)

## 🔍 리뷰 포인트
- AOP 적용 범위(`domain..service..*`)가 다른 도메인 서비스에도 넓게 걸리는데, 예상치 못한 예외 변환이 발생하지 않는지
- `SecurityConfig`의 `/api/ai/grade/*` permitAll이 임시 조치인데, 인증 연동 전까지 리스크가 없는지

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - AI 등급 진단 결과를 결과 ID로 다시 조회할 수 있습니다.
  - 진단 결과는 요청한 사용자에게만 제공되어 개인정보를 보호합니다.
  - 인증 사용자 정보가 더욱 안정적으로 처리됩니다.

- **개선 사항**
  - 파일 처리 및 데이터베이스 오류가 일관된 오류 응답으로 안내됩니다.
  - 서비스 오류 발생 시 원인 파악을 위한 기록이 강화되었습니다.
  - AI 등급 결과 조회 경로를 인증 없이 접근할 수 있도록 허용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->