### PR TITLE
[Feature] #80 FR-TRADE-10 미체결 매물 알림

### DIFF
--- a/Pokade/src/main/java/com/pokade/PokadeApplication.java
+++ b/Pokade/src/main/java/com/pokade/PokadeApplication.java
@@ -3,9 +3,11 @@ package com.pokade;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 public class PokadeApplication {
 
     public static void main(String[] args) {

--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,4 +43,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
     @Query("UPDATE Listing l SET l.status = com.pokade.domain.listing.entity.ListingStatus.TRADING "
             + "WHERE l.id = :id AND l.status = com.pokade.domain.listing.entity.ListingStatus.ACTIVE")
     int markAsTrading(@Param("id") Long listingId);
+
+    // FR-TRADE-10: cutoff(등록 후 30일) 이전에 등록되었고 아직 알림을 안 보낸 ACTIVE 매물 조회
+    List<Listing> findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(ListingStatus status, LocalDateTime cutoff);
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingStaleNoticeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingStaleNoticeService.java
@@ -1,0 +1,54 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.infra.mail.MailSender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ListingStaleNoticeService {
+
+    private static final int STALE_DAYS = 30;
+
+    private final ListingRepository listingRepository;
+    private final UserRepository userRepository;
+    private final MailSender mailSender;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void sendStaleNotices() {
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(STALE_DAYS);
+        List<Listing> staleListings = listingRepository
+                .findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(ListingStatus.ACTIVE, cutoff);
+
+        for (Listing listing : staleListings) {
+            userRepository.findById(listing.getSellerId())
+                    .ifPresent(seller -> notify(listing, seller));
+        }
+    }
+
+    private void notify(Listing listing, User seller) {
+        try {
+            mailSender.send(
+                    seller.getEmail(),
+                    "[Pokade] 등록하신 매물이 30일간 판매되지 않았습니다",
+                    "매물 #" + listing.getId() + "가 30일이 지나도록 판매되지 않았습니다. 가격을 확인해보세요."
+            );
+            listing.markStaleNoticeSent();
+        } catch (Exception e) {
+            log.warn("미체결 매물 알림 발송 실패: listingId={}, sellerId={}", listing.getId(), seller.getId(), e);
+        }
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/ListingStaleNoticeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/ListingStaleNoticeServiceTest.java
@@ -1,0 +1,117 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.infra.mail.MailSender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ListingStaleNoticeServiceTest {
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MailSender mailSender;
+
+    @InjectMocks
+    private ListingStaleNoticeService listingStaleNoticeService;
+
+    private Listing listingOf(Long sellerId) {
+        return Listing.builder()
+                .cardId(1L)
+                .sellerId(sellerId)
+                .price(10000)
+                .build();
+    }
+
+    @Test
+    void ACTIVE_상태와_30일_이전_cutoff로_대상을_조회한다() {
+        given(listingRepository.findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(any(), any()))
+                .willReturn(List.of());
+
+        listingStaleNoticeService.sendStaleNotices();
+
+        ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(listingRepository).findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(
+                eq(ListingStatus.ACTIVE), cutoffCaptor.capture());
+
+        LocalDateTime expectedCutoff = LocalDateTime.now().minusDays(30);
+        assertThat(cutoffCaptor.getValue()).isCloseTo(expectedCutoff,
+                org.assertj.core.api.Assertions.within(1, java.time.temporal.ChronoUnit.MINUTES));
+    }
+
+    @Test
+    void 판매자를_찾으면_메일을_보내고_알림_발송_플래그를_갱신한다() {
+        Listing listing = listingOf(1L);
+        User seller = User.createLocalUser("seller@test.com", "hashed", "seller");
+
+        given(listingRepository.findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(any(), any()))
+                .willReturn(List.of(listing));
+        given(userRepository.findById(1L)).willReturn(Optional.of(seller));
+
+        listingStaleNoticeService.sendStaleNotices();
+
+        verify(mailSender).send(eq("seller@test.com"), anyString(), anyString());
+        assertThat(listing.isStaleNoticeSent()).isTrue();
+    }
+
+    @Test
+    void 판매자를_찾을_수_없으면_알림을_보내지_않는다() {
+        Listing listing = listingOf(999L);
+
+        given(listingRepository.findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(any(), any()))
+                .willReturn(List.of(listing));
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        listingStaleNoticeService.sendStaleNotices();
+
+        verify(mailSender, never()).send(any(), any(), any());
+        assertThat(listing.isStaleNoticeSent()).isFalse();
+    }
+
+    @Test
+    void 메일_발송이_실패해도_나머지_매물은_계속_처리된다() {
+        Listing failing = listingOf(1L);
+        Listing succeeding = listingOf(2L);
+        User seller1 = User.createLocalUser("seller1@test.com", "hashed", "seller1");
+        User seller2 = User.createLocalUser("seller2@test.com", "hashed", "seller2");
+
+        given(listingRepository.findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore(any(), any()))
+                .willReturn(List.of(failing, succeeding));
+        given(userRepository.findById(1L)).willReturn(Optional.of(seller1));
+        given(userRepository.findById(2L)).willReturn(Optional.of(seller2));
+        doThrow(new RuntimeException("mail server down"))
+                .when(mailSender).send(eq("seller1@test.com"), anyString(), anyString());
+
+        listingStaleNoticeService.sendStaleNotices();
+
+        assertThat(failing.isStaleNoticeSent()).isFalse();
+        assertThat(succeeding.isStaleNoticeSent()).isTrue();
+        verify(mailSender).send(eq("seller2@test.com"), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #80 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
  - FR-TRADE-10 미체결 매물 알림 배치 구현 — 등록 후 30일 지나도 판매되지 않은 ACTIVE 매물의 판매자에게 1차 알림 메일 발송                                              
  - ListingRepository.findByStatusAndStaleNoticeSentFalseAndCreatedAtBefore 조회 쿼리 추가                                                                              
  - ListingStaleNoticeService 신규 — @Scheduled(cron = "0 0 3 * * *")로 매일 새벽 3시 실행, 기존 MailSender(auth 도메인 이메일 인증에서 쓰던 인터페이스) 재사용해 발송, 
  발송 성공 시 markStaleNoticeSent()로 중복 발송 방지                                                                                                                   
  - PokadeApplication에 @EnableScheduling 추가                                                                                                                          
  - 개별 매물 발송 실패는 로그만 남기고 나머지 계속 처리 (배치 안정성)

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
  - 알림 채널을 이메일로 해둔 상태입니다.                                                                 
  - cron 주기(매일 새벽 3시)가 적절한지, 운영 환경에서 스케줄 정책 논의 필요                                                                        
                               

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 30일 이상 경과한 활성 매물에 대해 매일 자동으로 판매자에게 알림 이메일을 발송합니다.
  * 알림 발송이 완료된 매물은 중복 알림을 방지하도록 처리됩니다.
  * 판매자 정보가 없거나 이메일 발송에 실패한 경우에도 다른 매물 처리는 계속됩니다.

* **테스트**
  * 오래된 매물 조회, 이메일 발송, 발송 완료 처리 및 예외 상황을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->