### PR TITLE
[Feature] #82 AI 등급 진단 이력 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Thumbs.db
 CLAUDE.md
 CLAUDE.local.md
 **/CLAUDE.md
+REVIEW_NOTES.md
+**/REVIEW_NOTES.md

--- a/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
@@ -65,7 +65,7 @@ public class AiGradeController {
 
             @AuthenticationPrincipal Long principalUserId
     ) {
-        Long userId = resolveUserId(principalUserId);
+        Long userId = requireUserId(principalUserId);
 
         GradeRequest request = new GradeRequest(front, back, cornerTl, cornerTr, cornerBl, cornerBr, retryOfId);
         GradeResponse response = aiGradeService.grade(userId, request);
@@ -103,12 +103,6 @@ public class AiGradeController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO: 프론트 로그인 연동 완료 후 permitAll·기본값 제거하고 @AuthenticationPrincipal 값을 그대로 사용할 것
-    private Long resolveUserId(Long principalUserId) {
-        return principalUserId != null ? principalUserId : 1L;
-    }
-
-    // 결과/이력 조회는 타인 데이터 노출 위험이 있어 인증 없는 접근을 허용하지 않는다
     private Long requireUserId(Long principalUserId) {
         if (principalUserId == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);

--- a/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
@@ -98,7 +98,7 @@ public class AiGradeController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
             Pageable pageable
     ) {
-        Long userId = resolveUserId(principalUserId);
+        Long userId = requireUserId(principalUserId);
         Page<GradeResponse> response = aiGradeService.getGradeHistory(userId, pageable);
         return ResponseEntity.ok(response);
     }

--- a/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/controller/AiGradeController.java
@@ -9,6 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -81,6 +85,21 @@ public class AiGradeController {
     ) {
         Long userId = requireUserId(principalUserId);
         GradeResponse response = aiGradeService.getGradeResult(userId, resultId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(
+            summary = "AI 등급 진단 이력 조회",
+            description = "본인이 요청한 AI 등급 진단 이력을 최신순으로 페이징 조회합니다."
+    )
+    @GetMapping("/grade/history")
+    public ResponseEntity<Page<GradeResponse>> getGradeHistory(
+            @AuthenticationPrincipal Long principalUserId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Long userId = resolveUserId(principalUserId);
+        Page<GradeResponse> response = aiGradeService.getGradeHistory(userId, pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/ai/repository/GradeResultRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/repository/GradeResultRepository.java
@@ -2,10 +2,15 @@ package com.pokade.domain.ai.repository;
 
 import com.pokade.domain.ai.entity.GradeResult;
 import com.pokade.domain.ai.entity.GradeStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface GradeResultRepository extends JpaRepository<GradeResult, Long> {
+
+    // 진단 이력 조회: 본인 이력만 페이징 조회
+    Page<GradeResult> findByUserId(Long userId, Pageable pageable);
 
     // 무료 사용 횟수: 정상 산출(SUCCESS) 건만 카운트
     long countByUserIdAndStatus(Long userId, GradeStatus status);

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -16,6 +16,8 @@ import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
@@ -128,6 +130,11 @@ public class AiGradeService {
         }
 
         return GradeResponse.from(gradeResult);
+    }
+
+    public Page<GradeResponse> getGradeHistory(Long userId, Pageable pageable) {
+        return gradeResultRepository.findByUserId(userId, pageable)
+                .map(GradeResponse::from);
     }
 
     private void validateImageFormats(GradeRequest request) {

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -9,6 +9,7 @@ import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.web.PageableValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -134,16 +135,9 @@ public class AiGradeService {
     }
 
     public Page<GradeResponse> getGradeHistory(Long userId, Pageable pageable) {
-        validatePageSize(pageable);
+        PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
         return gradeResultRepository.findByUserId(userId, pageable)
                 .map(GradeResponse::from);
-    }
-
-    private void validatePageSize(Pageable pageable) {
-        if (pageable.getPageSize() > MAX_PAGE_SIZE) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT,
-                    "size는 최대 " + MAX_PAGE_SIZE + "까지 요청할 수 있습니다.");
-        }
     }
 
     private void validateImageFormats(GradeRequest request) {

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -37,6 +37,7 @@ import java.util.Set;
 public class AiGradeService {
 
     private static final int FREE_LIMIT = 3;
+    private static final int MAX_PAGE_SIZE = 100;
 
     // OpenAI Vision이 실제로 지원하는 이미지 포맷 (ImageIO는 디코딩되지만 Vision은 거부하는 bmp/tiff 등을 사전 차단)
     private static final Set<String> SUPPORTED_IMAGE_TYPES =
@@ -133,8 +134,16 @@ public class AiGradeService {
     }
 
     public Page<GradeResponse> getGradeHistory(Long userId, Pageable pageable) {
+        validatePageSize(pageable);
         return gradeResultRepository.findByUserId(userId, pageable)
                 .map(GradeResponse::from);
+    }
+
+    private void validatePageSize(Pageable pageable) {
+        if (pageable.getPageSize() > MAX_PAGE_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "size는 최대 " + MAX_PAGE_SIZE + "까지 요청할 수 있습니다.");
+        }
     }
 
     private void validateImageFormats(GradeRequest request) {

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -13,6 +13,7 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.web.PageableValidator;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,7 +47,7 @@ public class CardService {
 
     @Transactional(readOnly = true)
     public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
-        validatePageSize(pageable);
+        PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
         validateFilterSize(types, "types");
         validateFilterSize(rarities, "rarity");
         validatePriceRange(minPrice, maxPrice);
@@ -81,7 +82,7 @@ public class CardService {
         if (q == null || q.isBlank()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        validatePageSize(pageable);
+        PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
         String keyword = q.trim();
         if (keyword.length() > MAX_KEYWORD_LENGTH) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
@@ -130,13 +131,6 @@ public class CardService {
 
     private boolean hasPokedexNumber(Card card) {
         return card.getNationalPokedexNumbers() != null && !card.getNationalPokedexNumbers().isEmpty();
-    }
-
-    private void validatePageSize(Pageable pageable) {
-        if (pageable.getPageSize() > MAX_PAGE_SIZE) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT,
-                    "size는 최대 " + MAX_PAGE_SIZE + "까지 요청할 수 있습니다.");
-        }
     }
 
     private void validateFilterSize(List<String> values, String fieldName) {

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -36,8 +36,7 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/v3/api-docs/**",
             "/actuator/health",
-            "/actuator/prometheus",
-            "/api/ai/grade" // TODO: 로컬 테스트용 임시 permitAll(진단 요청만) — 인증 연동 후 제거할 것. 결과/이력 조회는 본인 데이터 노출 위험이 있어 인증 필수로 유지
+            "/actuator/prometheus"
     };
 
     // 보안 필터체인 — CSRF/CORS 설정과 경로별 인가 규칙을 정의

--- a/Pokade/src/main/java/com/pokade/global/web/PageableValidator.java
+++ b/Pokade/src/main/java/com/pokade/global/web/PageableValidator.java
@@ -1,0 +1,19 @@
+package com.pokade.global.web;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.springframework.data.domain.Pageable;
+
+// 페이징 API의 size 상한 검증 — 도메인마다 자체 MAX_PAGE_SIZE를 두되, 검증/예외 로직만 공용화한다.
+public final class PageableValidator {
+
+    private PageableValidator() {
+    }
+
+    public static void validatePageSize(Pageable pageable, int maxPageSize) {
+        if (pageable.getPageSize() > maxPageSize) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "size는 최대 " + maxPageSize + "까지 요청할 수 있습니다.");
+        }
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/ai/controller/AiGradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/controller/AiGradeControllerTest.java
@@ -1,0 +1,73 @@
+package com.pokade.domain.ai.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+import com.pokade.domain.ai.service.AiGradeService;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+
+/**
+ * 인증 필터(addFilters=false)를 꺼둔 상태라 @AuthenticationPrincipal은 항상 null로 주입된다.
+ * 즉 이 테스트는 "principal이 없으면 컨트롤러가 401을 던지는지"만 검증하고,
+ * JWT 필터 자체의 동작(토큰 파싱 등)은 검증 대상이 아니다.
+ */
+@WebMvcTest(AiGradeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AiGradeControllerTest {
+
+    @Autowired
+    private MockMvcTester mockMvcTester;
+
+    @MockitoBean
+    private AiGradeService aiGradeService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Test
+    @DisplayName("인증 없이 진단 결과를 조회하면 401을 반환한다")
+    void getGradeResult_withoutAuth_returnsUnauthorized() {
+        mockMvcTester.get()
+                .uri("/api/ai/grade/1")
+                .assertThat()
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("인증 없이 진단 이력을 조회하면 401을 반환한다")
+    void getGradeHistory_withoutAuth_returnsUnauthorized() {
+        mockMvcTester.get()
+                .uri("/api/ai/grade/history")
+                .assertThat()
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("인증 없이 진단을 요청하면 401을 반환한다")
+    void grade_withoutAuth_returnsUnauthorized() {
+        MockMultipartFile front = new MockMultipartFile("front", "front.png", "image/png", new byte[]{1});
+        MockMultipartFile back = new MockMultipartFile("back", "back.png", "image/png", new byte[]{1});
+        MockMultipartFile cornerTl = new MockMultipartFile("corner_tl", "tl.png", "image/png", new byte[]{1});
+        MockMultipartFile cornerTr = new MockMultipartFile("corner_tr", "tr.png", "image/png", new byte[]{1});
+        MockMultipartFile cornerBl = new MockMultipartFile("corner_bl", "bl.png", "image/png", new byte[]{1});
+        MockMultipartFile cornerBr = new MockMultipartFile("corner_br", "br.png", "image/png", new byte[]{1});
+
+        mockMvcTester.post()
+                .uri("/api/ai/grade")
+                .multipart()
+                .file(front).file(back).file(cornerTl).file(cornerTr).file(cornerBl).file(cornerBr)
+                .assertThat()
+                .hasStatus(HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
@@ -1,7 +1,10 @@
 package com.pokade.domain.ai.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
@@ -21,6 +24,8 @@ import com.pokade.domain.ai.entity.GradeResult;
 import com.pokade.domain.ai.entity.GradeStatus;
 import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,5 +70,19 @@ class AiGradeServiceTest {
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).grade()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 상한(100)을 초과하면 BusinessException(INVALID_INPUT)을 던진다")
+    void getGradeHistory_throwsWhenPageSizeExceedsLimit() {
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 101);
+
+        assertThatThrownBy(() -> aiGradeService.getGradeHistory(userId, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT);
+
+        verify(gradeResultRepository, never()).findByUserId(userId, pageable);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
@@ -1,0 +1,69 @@
+package com.pokade.domain.ai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.pokade.domain.ai.dto.GradeResponse;
+import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.ai.entity.GradeStatus;
+import com.pokade.domain.ai.repository.GradeResultImageRepository;
+import com.pokade.domain.ai.repository.GradeResultRepository;
+import org.springframework.ai.chat.client.ChatClient;
+
+@ExtendWith(MockitoExtension.class)
+class AiGradeServiceTest {
+
+    @Mock
+    private ChatClient chatClient;
+
+    @Mock
+    private S3UploadService s3UploadService;
+
+    @Mock
+    private ImageQualityChecker imageQualityChecker;
+
+    @Mock
+    private GradeResultRepository gradeResultRepository;
+
+    @Mock
+    private GradeResultImageRepository gradeResultImageRepository;
+
+    @InjectMocks
+    private AiGradeService aiGradeService;
+
+    @Test
+    @DisplayName("본인의 진단 이력을 페이징 조회하면 최신순으로 매핑된 응답을 반환한다")
+    void getGradeHistory_returnsMappedPage() {
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
+        GradeResult gradeResult = GradeResult.builder()
+                .userId(userId)
+                .status(GradeStatus.SUCCESS)
+                .grade("A")
+                .isFree(true)
+                .pointUsed(0)
+                .retryAllowed(false)
+                .build();
+        Page<GradeResult> page = new PageImpl<>(List.of(gradeResult), pageable, 1);
+
+        given(gradeResultRepository.findByUserId(userId, pageable)).willReturn(page);
+
+        Page<GradeResponse> result = aiGradeService.getGradeHistory(userId, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).grade()).isEqualTo("A");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #82

## ✨ 작업 내용
- AI 등급 진단 이력 조회 API 구현 (`GET /api/ai/grade/history`)
  - `GradeResultRepository.findByUserId`로 본인 이력만 페이징 조회 (최신순 기본 정렬)
  - 페이지 크기 상한(100) 검증 추가
- CodeRabbit 리뷰 피드백 반영 (PR #81)
  - 진단 결과/이력 조회 API 인증 우회 가능하던 문제 수정 (permitAll + 1L fallback 조합으로 타인 데이터 조회 가능했던 부분)
  - 예외 로그에서 서비스 인자(민감정보 포함 가능) 제거
  - S3 SdkException이 변환 안 되고 그대로 전파되던 문제 수정
- 프론트 로그인 연동 완료에 따른 후속 조치
  - POST `/api/ai/grade`까지 인증 필수화 (permitAll·1L fallback 완전 제거)
  - 컨트롤러 레벨에서 미인증 시 401 반환하는지 검증하는 테스트 추가
- 페이지 크기 검증 로직 공용화 (`PageableValidator`) — `CardService`에 있던 동일 로직과 통합

## 🔍 리뷰 포인트 / 논의된 트레이드오프
- **SdkException → FILE_IO_ERROR 매핑**: AWS SDK 전체 최상위 예외를 하나의 에러코드로 묶어서, 나중에 S3 외 다른 AWS 서비스가 추가되면 세분화가 필요할 수 있습니다.

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - AI 등급 진단 이력을 페이지 단위로 조회할 수 있습니다.
  - 진단 이력 조회 시 페이지 크기는 최대 100개로 제한됩니다.

- **개선 사항**
  - AI 진단 관련 기능은 인증된 사용자만 이용할 수 있습니다.
  - 인증 정보가 없는 요청은 401 오류로 처리됩니다.
  - 카드 및 키워드 검색의 페이지 크기 검증이 일관되게 적용됩니다.

- **버그 수정**
  - 인증 정보가 없을 때 임의의 기본 사용자로 처리되던 문제가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->