### PR TITLE
[Fix]/#86 이메일 인증 갇힘 2건 (미인증 재가입 유도 + 5회 초과 재발송 해제)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -31,12 +31,16 @@ public class AuthService {
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
-        if (userRepository.existsByEmail(request.email())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        User existing = userRepository.findByEmail(request.email()).orElse(null);
+        if (existing != null) {
+            throw new BusinessException(existing.getStatus() != UserStatus.ACTIVE
+                    ? ErrorCode.EMAIL_NOT_VERIFIED : ErrorCode.DUPLICATE_EMAIL);
         }
+
         if (userRepository.existsByNickname(request.nickname())) {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
+
         String encodedPassword = passwordEncoder.encode(request.password());
         User user = userRepository.save(
                 User.createLocalUser(request.email(), encodedPassword, request.nickname())
@@ -105,13 +109,13 @@ public class AuthService {
             return new TokenPair(newAccessToken, newRefreshToken); // Option X: refresh 재
         }
 
-       if (refreshTokenStore.matchesGrace(userId, refreshToken)) { // 직전 refresh(동시요청) -> 새 access만
-           String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-           return new TokenPair(accessToken, null); // Option Y: refresh 재발급,재세팅 안 함
-       }
+        if (refreshTokenStore.matchesGrace(userId, refreshToken)) { // 직전 refresh(동시요청) -> 새 access만
+            String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
+            return new TokenPair(accessToken, null); // Option Y: refresh 재발급,재세팅 안 함
+        }
 
-       refreshTokenStore.delete(userId); // 키는 있는데 어느 것과도 불일치 -> 탈취 의심, 전면 폐기
-       throw new BusinessException(ErrorCode.TOKEN_STOLEN);
+        refreshTokenStore.delete(userId); // 키는 있는데 어느 것과도 불일치 -> 탈취 의심, 전면 폐기
+        throw new BusinessException(ErrorCode.TOKEN_STOLEN);
     }
 
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -33,6 +33,7 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     public void save(String email, String code) {
         redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
         redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
     }
 
     @Override

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -64,7 +64,7 @@ class AuthServiceTest {
     void signup_success() {
         // given
         SignupRequest req = request("test@pokade.com", "pokade1234", "홍길동");
-        given(userRepository.existsByEmail(req.email())).willReturn(false);
+        given(userRepository.findByEmail(req.email())).willReturn(Optional.empty());
         given(userRepository.existsByNickname(req.nickname())).willReturn(false);
         given(passwordEncoder.encode(req.password())).willReturn("ENCODED_PW");
         given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
@@ -85,10 +85,11 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("이메일이 중복되면 DUPLICATE_EMAIL 예외를 던지고 저장하지 않는다")
+    @DisplayName("이미 활성(ACTIVE) 계정 이메일이면 DUPLICATE_EMAIL 예외를 던지고 저장하지 않는다")
     void signup_duplicateEmail() {
         SignupRequest req = request("dup@pokade.com", "pokade1234", "홍길동");
-        given(userRepository.existsByEmail(req.email())).willReturn(true);
+        given(userRepository.findByEmail(req.email()))
+                .willReturn(Optional.of(userWithStatus("dup@pokade.com", UserStatus.ACTIVE)));
 
         assertThatThrownBy(() -> authService.signup(req))
                 .isInstanceOf(BusinessException.class)
@@ -98,10 +99,24 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("미인증(PENDING) 계정 이메일이면 EMAIL_NOT_VERIFIED 예외를 던지고 저장하지 않는다")
+    void signup_pendingEmail() {
+        SignupRequest req = request("pending@pokade.com", "pokade1234", "홍길동");
+        given(userRepository.findByEmail(req.email()))
+                .willReturn(Optional.of(userWithStatus("pending@pokade.com", UserStatus.PENDING)));
+
+        assertThatThrownBy(() -> authService.signup(req))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_NOT_VERIFIED);
+
+        then(userRepository).should(never()).save(any());
+    }
+
+    @Test
     @DisplayName("닉네임이 중복되면 DUPLICATE_NICKNAME 예외를 던진다")
     void signup_duplicateNickname() {
         SignupRequest req = request("new@pokade.com", "pokade1234", "중복닉");
-        given(userRepository.existsByEmail(req.email())).willReturn(false);
+        given(userRepository.findByEmail(req.email())).willReturn(Optional.empty());
         given(userRepository.existsByNickname(req.nickname())).willReturn(true);
 
         assertThatThrownBy(() -> authService.signup(req))

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
@@ -78,6 +78,19 @@ public class RedisVerificationCodeStoreTest {
     }
 
     @Test
+    @DisplayName("save(재발송)하면 실패 카운터가 리셋되어 getAttemptCount가 0이 된다")
+    void save_resetsAttemptCount() {
+        String email = "resend@pokade.com";
+        store.incrementAttempt(email);
+        store.incrementAttempt(email);
+        assertThat(store.getAttemptCount(email)).isEqualTo(2L);
+
+        store.save(email, "123456");
+
+        assertThat(store.getAttemptCount(email)).isZero();
+    }
+
+    @Test
     @DisplayName("delete하면 실패 카운터도 제거되어 getAttemptCount가 0이 된다")
     void delete_resetsAttemptCount() {
         String email = "attempt-del@pokade.com";


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #86

## ✨ 작업 내용
이메일 인증 과정에서 사용자가 갇히는 두 가지 문제를 함께 수정했습니다.

### 1. 미인증(PENDING) 계정 재가입 시 인증 유도 불가
- 기존 `AuthService.signup`은 이메일이 존재하면 status와 무관하게 `DUPLICATE_EMAIL`을 던져, 인증 미완료(PENDING) 계정으로 재가입하면 인증을 재개할 방법이 없었습니다(로그인도 비-ACTIVE는 `EMAIL_NOT_VERIFIED`로 막혀 계정이 갇힘).
- `existsByEmail` → `findByEmail`로 바꿔 status를 구분: 미인증(`!= ACTIVE`)이면 `EMAIL_NOT_VERIFIED`, ACTIVE면 기존 `DUPLICATE_EMAIL`. `login()`의 status 판정과 동일 규칙을 재사용합니다.
- `findByEmail` 도입으로 도달 불가해진 기존 `existsByEmail` 분기(죽은 코드)를 제거했습니다.

### 2. 인증 5회 초과 후 재발송해도 잠금이 유지됨
- 코드 5회 오입력 시 `EMAIL_VERIFY_ATTEMPT_EXCEEDED`로 잠긴 뒤, 재발송해도 `attempt` 카운터가 리셋되지 않아 새 코드를 받아도 막혔습니다(`attempt` TTL 5분 대기).
- `RedisVerificationCodeStore.save()`(재발송 경로)에서 `attempt` 키를 리셋해, 재발송하면 새 코드로 다시 시도할 수 있게 했습니다. 60초 쿨다운은 유지합니다.

## 📸 스크린샷 / 테스트 결과
- `AuthServiceTest`: signup 분기 4케이스(정상 / ACTIVE 중복 → `DUPLICATE_EMAIL` / PENDING → `EMAIL_NOT_VERIFIED` / 닉네임 중복) + `login_notVerified` 등 회귀 전부 green
- `RedisVerificationCodeStoreTest`: 재발송(`save`) 후 `getAttemptCount`가 0으로 리셋 + 기존 케이스 회귀 green (Testcontainers Redis)

## 🔍 리뷰 포인트
- **`signup`의 미인증 판정(`status != ACTIVE`)은 `login()`과 동일 규칙을 재사용**해 일관성을 맞췄습니다.
- **`EMAIL_NOT_VERIFIED`는 403**인데 signup 맥락에서 나갑니다. 로그인과 코드·의미가 일관("미인증")이라 그대로 두는 게 낫다고 판단했는데(중복은 통상 409지만 여기선 "미인증" 의미 우선), 이견 있으면 코멘트 부탁드립니다.
- **재발송 시 `attempt` 리셋의 안전성**: 코드가 매 재발송마다 새 난수로 바뀌고 60초 쿨다운이 있어 brute-force 위험이 없습니다(6자리 100만 조합, 60초당 최대 5회).
- 이 PR은 **"인증 이탈 후 재개"의 BE 선행 작업**입니다. 실제 재개 UX(로그인/회원가입에서 인증 화면 유도)는 FE 후속 이슈로 진행됩니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가? (죽은 코드도 함께 제거)
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 회원가입 시 이메일 상태에 따라 안내가 구분됩니다.
    * 인증되지 않은 기존 이메일: 이메일 인증 필요 안내
    * 활성화된 기존 이메일: 이메일 중복 안내
  * 인증 코드 재발송 시 기존 시도 횟수가 초기화됩니다.

* **테스트**
  * 이메일 상태별 회원가입 검증과 인증 코드 시도 횟수 초기화 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->