### PR TITLE
[Feature] #90 매물 목록 응답에 cardId·cardName 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingSummaryResponse.java
@@ -9,6 +9,8 @@ import java.time.LocalDateTime;
 public record ListingSummaryResponse(
         Long id,
         Long sellerId,
+        Long cardId,
+        String cardName,
         Integer price,
         ListingGrade grade,
         ListingStatus status,
@@ -16,7 +18,7 @@ public record ListingSummaryResponse(
         LocalDateTime createdAt
 ) {
 
-    public static ListingSummaryResponse of(Listing listing) {
+    public static ListingSummaryResponse of(Listing listing, String cardName) {
         String thumbnailUrl = listing.getImages().isEmpty()
                 ? null
                 : listing.getImages().get(0).getImageUrl();
@@ -24,6 +26,8 @@ public record ListingSummaryResponse(
         return new ListingSummaryResponse(
                 listing.getId(),
                 listing.getSellerId(),
+                listing.getCardId(),
+                cardName,
                 listing.getPrice(),
                 listing.getGrade(),
                 listing.getStatus(),

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.listing.service;
 
+import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
@@ -19,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -51,9 +54,11 @@ public class ListingService {
     }
 
     public List<ListingSummaryResponse> getActiveListings(Long cardId) {
+        String cardName = cardRepository.findById(cardId).map(Card::getName).orElse(null);
+
         return listingRepository.findByCardIdAndStatusOrderByPriceAsc(cardId, ListingStatus.ACTIVE)
                 .stream()
-                .map(ListingSummaryResponse::of)
+                .map(listing -> ListingSummaryResponse.of(listing, cardName))
                 .toList();
     }
 
@@ -79,8 +84,12 @@ public class ListingService {
                 ? listingRepository.findBySellerIdAndStatus(sellerId, status)
                 : listingRepository.findBySellerId(sellerId);
 
+        List<Long> cardIds = listings.stream().map(Listing::getCardId).distinct().toList();
+        Map<Long, String> cardNamesById = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, Card::getName));
+
         return listings.stream()
-                .map(ListingSummaryResponse::of)
+                .map(listing -> ListingSummaryResponse.of(listing, cardNamesById.get(listing.getCardId())))
                 .toList();
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
@@ -119,7 +119,7 @@ class ListingControllerTest {
     @Test
     void 활성_매물이_있으면_200과_가격순_목록을_반환한다() throws Exception {
         ListingSummaryResponse summary = new ListingSummaryResponse(
-                1L, 100L, 10000, ListingGrade.A, ListingStatus.ACTIVE,
+                1L, 100L, 1L, "테스트카드", 10000, ListingGrade.A, ListingStatus.ACTIVE,
                 "https://example.com/a.png", LocalDateTime.now());
 
         given(listingService.getActiveListings(1L)).willReturn(List.of(summary));
@@ -200,7 +200,7 @@ class ListingControllerTest {
     @Test
     void 내_매물이_있으면_200과_목록을_반환한다() throws Exception {
         ListingSummaryResponse summary = new ListingSummaryResponse(
-                1L, 100L, 10000, ListingGrade.A, ListingStatus.ACTIVE,
+                1L, 100L, 1L, "테스트카드", 10000, ListingGrade.A, ListingStatus.ACTIVE,
                 "https://example.com/a.png", LocalDateTime.now());
 
         given(listingService.getMyListings(100L, null)).willReturn(List.of(summary));
@@ -223,7 +223,7 @@ class ListingControllerTest {
     @Test
     void status_파라미터로_필터링해서_조회한다() throws Exception {
         ListingSummaryResponse summary = new ListingSummaryResponse(
-                2L, 100L, 5000, ListingGrade.B, ListingStatus.SOLD,
+                2L, 100L, 2L, "테스트카드2", 5000, ListingGrade.B, ListingStatus.SOLD,
                 null, LocalDateTime.now());
 
         given(listingService.getMyListings(100L, ListingStatus.SOLD)).willReturn(List.of(summary));


### PR DESCRIPTION
## 📌 관련 이슈
- #90 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
                                                                                                                                                                         
  - 매물 목록 응답(ListingSummaryResponse)에 cardId, cardName 필드 추가                                                                                                         
  - FE "내 매물 조회" 페이지 연동 중 발견     
  - getActiveListings는 단건 카드 조회, getMyListings는 여러 카드가 섞일 수 있어 cardRepository.findAllById()로 배치 조회 처리 (N+1 방지)                                                                                                                                          

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 매물 조회 결과에 카드 ID와 카드명이 함께 표시됩니다.
  * 활성 매물 및 본인 매물 조회에서 각 매물에 연결된 카드 정보가 제공됩니다.

* **버그 수정**
  * 상태별 매물 조회 결과가 확장된 카드 정보 형식에 맞게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->