### PR TITLE
[Feature] #87 등락률·거래량 조회 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.controller;
 
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
@@ -45,5 +46,13 @@ public class PriceController {
             @RequestParam String period
     ) {
         return ApiResponse.ok(priceService.getPriceChart(cardId, period));
+    }
+
+    @GetMapping("/{cardId}/stats")
+    public ApiResponse<PriceStatsResponse> getStats(
+            @PathVariable Long cardId,
+            @RequestParam(required = false) Long variantId
+    ) {
+        return ApiResponse.ok(priceService.getStats(cardId, variantId));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/PriceStatsResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/PriceStatsResponse.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.price.dto;
+
+import java.math.BigDecimal;
+
+public record PriceStatsResponse(
+        BigDecimal changeRate,
+        long volume
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -1,0 +1,41 @@
+package com.pokade.domain.price.repository;
+
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+// FR-PRICE-04(시세 등락률/거래량) 전용 조회. trades 테이블은 domain.trade의 Trade/TradeRepository가 이미 소유하고
+// 있으므로, domain.price는 그 리포지토리를 직접 수정하지 않고 읽기 전용 쿼리만 담은 별도 리포지토리로 필요한 조회를 추가한다.
+public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
+
+    // 등락률 비교의 "최근 블록" 평균가(최근 N일 이내, 상한 없음)
+    @Query("SELECT AVG(t.price) FROM Trade t JOIN t.listing l "
+            + "WHERE l.cardId = :cardId AND l.grade = :grade AND t.status = :status AND t.confirmedAt >= :from")
+    Double findAveragePriceByGradeSince(@Param("cardId") Long cardId,
+                                         @Param("grade") ListingGrade grade,
+                                         @Param("status") TradeStatus status,
+                                         @Param("from") LocalDateTime from);
+
+    // 등락률 비교의 "이전 블록" 평균가(직전 N일, [from, to) 구간)
+    @Query("SELECT AVG(t.price) FROM Trade t JOIN t.listing l "
+            + "WHERE l.cardId = :cardId AND l.grade = :grade AND t.status = :status "
+            + "AND t.confirmedAt >= :from AND t.confirmedAt < :to")
+    Double findAveragePriceByGradeBetween(@Param("cardId") Long cardId,
+                                           @Param("grade") ListingGrade grade,
+                                           @Param("status") TradeStatus status,
+                                           @Param("from") LocalDateTime from,
+                                           @Param("to") LocalDateTime to);
+
+    @Query("SELECT COUNT(t) FROM Trade t JOIN t.listing l "
+            + "WHERE l.cardId = :cardId AND l.grade = :grade AND t.status = :status AND t.confirmedAt >= :from")
+    long countCompletedTradesByGradeSince(@Param("cardId") Long cardId,
+                                           @Param("grade") ListingGrade grade,
+                                           @Param("status") TradeStatus status,
+                                           @Param("from") LocalDateTime from);
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -2,13 +2,16 @@ package com.pokade.domain.price.service;
 
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.price.ChartPeriod;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.global.exception.BusinessException;
@@ -18,6 +21,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -31,12 +36,15 @@ public class PriceService {
     private static final String CURRENCY = "KRW";
     private static final int RECENT_TRADES_LIMIT = 20;
     private static final int MAX_SUMMARIES_BATCH_SIZE = 100;
+    private static final int STATS_PERIOD_DAYS = 7;
+    private static final ListingGrade STATS_GRADE = ListingGrade.S;
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final ListingRepository listingRepository;
     private final BuyOfferRepository buyOfferRepository;
     private final TradeRepository tradeRepository;
+    private final PriceTradeStatsRepository priceTradeStatsRepository;
 
     public PriceSummaryResponse getSummary(Long cardId, Long variantId) {
         if (!cardRepository.existsById(cardId)) {
@@ -125,5 +133,41 @@ public class PriceService {
                 .stream()
                 .map(TradeSummaryResponse::of)
                 .toList();
+    }
+
+    // FR-PRICE-04: 카드 상세용 시세 등락률/거래량. card_prices(Scrydex 동기화 데이터)가 아니라
+    // 자체 AI등급(S) COMPLETED 거래 이력으로 계산한다 — 프론트가 대표 시세로 S등급을 쓰는 것과 일관되게 맞춘 설계.
+    public PriceStatsResponse getStats(Long cardId, Long variantId) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+        if (variantId == null) {
+            cardVariantRepository.findPrimaryVariantId(cardId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.PRIMARY_VARIANT_NOT_FOUND));
+        }
+
+        LocalDateTime recentFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS);
+        LocalDateTime previousFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS * 2L);
+
+        long volume = priceTradeStatsRepository.countCompletedTradesByGradeSince(
+                cardId, STATS_GRADE, TradeStatus.COMPLETED, recentFrom);
+
+        Double recentAvg = priceTradeStatsRepository.findAveragePriceByGradeSince(
+                cardId, STATS_GRADE, TradeStatus.COMPLETED, recentFrom);
+        Double previousAvg = priceTradeStatsRepository.findAveragePriceByGradeBetween(
+                cardId, STATS_GRADE, TradeStatus.COMPLETED, previousFrom, recentFrom);
+
+        if (recentAvg == null || previousAvg == null) {
+            return new PriceStatsResponse(BigDecimal.ZERO, volume);
+        }
+
+        BigDecimal recentAvgAmount = BigDecimal.valueOf(recentAvg);
+        BigDecimal previousAvgAmount = BigDecimal.valueOf(previousAvg);
+        BigDecimal changeRate = recentAvgAmount.subtract(previousAvgAmount)
+                .divide(previousAvgAmount, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+
+        return new PriceStatsResponse(changeRate, volume);
     }
 }

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -395,3 +395,26 @@ INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_a
     ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 3830000 AND grade = 'PSA10'), (SELECT id FROM users WHERE email = 'seller2@test.com'), 3830000, 'COMPLETED', now() - interval '250 days', now() - interval '250 days', now() - interval '250 days'),
     ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 2030000 AND grade = 'S'), (SELECT id FROM users WHERE email = 'seller1@test.com'), 2030000, 'COMPLETED', now() - interval '300 days', now() - interval '300 days', now() - interval '300 days'),
     ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 1730000 AND grade IS NULL), (SELECT id FROM users WHERE email = 'seller2@test.com'), 1730000, 'COMPLETED', now() - interval '340 days', now() - interval '340 days', now() - interval '340 days');
+
+-- =========================================================
+-- FR-PRICE-04 검증용 시드 (등락률/거래량 — S등급 최근 7일 vs 그 이전 7일 블록 비교)
+-- Charizard base1-4 : GET /api/prices/{cardId}/stats가 "최근 7일 평균가 vs 이전 7일(8~14일 전) 평균가"를
+-- 블록 단위로 비교하는 방식이라, 두 블록 모두에 S등급 체결이 있어야 등락률이 0이 아닌 실제 값으로 나온다.
+-- - 최근 블록(0~7일): 4건(-1/-3/-5/-6일) → 평균 3,060,000원, 거래량(volume)=4
+-- - 이전 블록(7~14일): 1건(-10일) → 평균 2,950,000원
+-- => changeRate ≈ (3,060,000-2,950,000)/2,950,000*100 ≈ +3.73%
+-- =========================================================
+
+-- ---------- listings (체결 완료, 최근 7일 이내 + 이전 7일 블록 분산) ----------
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at) VALUES
+    ((SELECT id FROM cards WHERE external_id = 'base1-4'), (SELECT id FROM users WHERE email = 'seller1@test.com'), (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'), 3060000, 'S', 'SOLD', now() - interval '6 days', now() - interval '6 days'),
+    ((SELECT id FROM cards WHERE external_id = 'base1-4'), (SELECT id FROM users WHERE email = 'seller2@test.com'), (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'), 3080000, 'S', 'SOLD', now() - interval '5 days', now() - interval '5 days'),
+    ((SELECT id FROM cards WHERE external_id = 'base1-4'), (SELECT id FROM users WHERE email = 'seller1@test.com'), (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'), 3100000, 'S', 'SOLD', now() - interval '1 days', now() - interval '1 days'),
+    ((SELECT id FROM cards WHERE external_id = 'base1-4'), (SELECT id FROM users WHERE email = 'seller2@test.com'), (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'), 2950000, 'S', 'SOLD', now() - interval '10 days', now() - interval '10 days');
+
+-- ---------- trades (위 listings에 1:1 대응하는 체결 완료 내역) ----------
+INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_at, created_at) VALUES
+    ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 3060000 AND grade = 'S'), (SELECT id FROM users WHERE email = 'seller2@test.com'), 3060000, 'COMPLETED', now() - interval '6 days', now() - interval '6 days', now() - interval '6 days'),
+    ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 3080000 AND grade = 'S'), (SELECT id FROM users WHERE email = 'seller1@test.com'), 3080000, 'COMPLETED', now() - interval '5 days', now() - interval '5 days', now() - interval '5 days'),
+    ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 3100000 AND grade = 'S'), (SELECT id FROM users WHERE email = 'seller2@test.com'), 3100000, 'COMPLETED', now() - interval '1 days', now() - interval '1 days', now() - interval '1 days'),
+    ((SELECT id FROM listings WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND price = 2950000 AND grade = 'S'), (SELECT id FROM users WHERE email = 'seller1@test.com'), 2950000, 'COMPLETED', now() - interval '10 days', now() - interval '10 days', now() - interval '10 days');

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.global.exception.BusinessException;
@@ -15,6 +16,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -161,5 +163,36 @@ class PriceControllerTest {
         mockMvc.perform(get("/api/prices/summaries").param("cardIds", "1,2,3"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 시세_등락률과_거래량을_조회하면_200과_값을_반환한다() throws Exception {
+        given(priceService.getStats(1L, null))
+                .willReturn(new PriceStatsResponse(new BigDecimal("6.01"), 1L));
+
+        mockMvc.perform(get("/api/prices/1/stats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.changeRate").value(6.01))
+                .andExpect(jsonPath("$.data.volume").value(1));
+    }
+
+    @Test
+    void 시세_통계_조회시_존재하지_않는_카드면_404를_반환한다() throws Exception {
+        given(priceService.getStats(999L, null))
+                .willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        mockMvc.perform(get("/api/prices/999/stats"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CARD_NOT_FOUND"));
+    }
+
+    @Test
+    void 시세_통계_조회시_대표_변형이_없으면_404를_반환한다() throws Exception {
+        given(priceService.getStats(1L, null))
+                .willThrow(new BusinessException(ErrorCode.PRIMARY_VARIANT_NOT_FOUND));
+
+        mockMvc.perform(get("/api/prices/1/stats"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("PRIMARY_VARIANT_NOT_FOUND"));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
@@ -1,0 +1,142 @@
+package com.pokade.domain.price.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.domain.user.entity.User;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private PriceTradeStatsRepository priceTradeStatsRepository;
+
+    @Autowired
+    private ListingRepository listingRepository;
+
+    @Autowired
+    private TradeRepository tradeRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Long cardId;
+    private Long sellerId;
+    private Long buyerId;
+
+    @BeforeEach
+    void setUp() {
+        Card card = Card.builder().name("Charizard").build();
+        entityManager.persist(card);
+        cardId = card.getId();
+
+        User seller = User.createLocalUser("stats-seller@test.com", "hashed", "seller");
+        User buyer = User.createLocalUser("stats-buyer@test.com", "hashed", "buyer");
+        entityManager.persist(seller);
+        entityManager.persist(buyer);
+        sellerId = seller.getId();
+        buyerId = buyer.getId();
+    }
+
+    private Listing persistListing(int price, ListingGrade grade) {
+        return listingRepository.save(
+                Listing.builder().cardId(cardId).sellerId(sellerId).price(price).grade(grade).build());
+    }
+
+    private Trade persistCompletedTrade(Listing listing, LocalDateTime confirmedAt) {
+        Trade trade = tradeRepository.save(
+                Trade.builder().listing(listing).buyerId(buyerId).price(listing.getPrice()).build());
+        trade.complete();
+        entityManager.flush();
+        entityManager.createNativeQuery("UPDATE trades SET confirmed_at = :confirmedAt WHERE id = :id")
+                .setParameter("confirmedAt", confirmedAt)
+                .setParameter("id", trade.getId())
+                .executeUpdate();
+        entityManager.clear();
+        return trade;
+    }
+
+    @Test
+    @DisplayName("t1 최근 블록(since) 내 등급별 체결 평균가를 계산한다")
+    void t1() {
+        Listing a = persistListing(3000000, ListingGrade.S);
+        Listing b = persistListing(3100000, ListingGrade.S);
+        Listing outsideWindow = persistListing(2830000, ListingGrade.S);
+        Listing otherGrade = persistListing(5000000, ListingGrade.PSA10);
+
+        persistCompletedTrade(a, LocalDateTime.now().minusDays(5));
+        persistCompletedTrade(b, LocalDateTime.now().minusDays(1));
+        persistCompletedTrade(outsideWindow, LocalDateTime.now().minusDays(15));
+        persistCompletedTrade(otherGrade, LocalDateTime.now().minusDays(1));
+
+        Double avg = priceTradeStatsRepository.findAveragePriceByGradeSince(
+                cardId, ListingGrade.S, TradeStatus.COMPLETED, LocalDateTime.now().minusDays(7));
+
+        assertThat(avg).isEqualTo(3050000.0);
+    }
+
+    @Test
+    @DisplayName("t2 이전 블록([from, to)) 내 등급별 체결 평균가를 계산한다")
+    void t2() {
+        Listing withinBlock = persistListing(2830000, ListingGrade.S);
+        Listing beforeBlock = persistListing(2630000, ListingGrade.S);
+        Listing afterBlock = persistListing(3000000, ListingGrade.S);
+
+        persistCompletedTrade(withinBlock, LocalDateTime.now().minusDays(10));
+        persistCompletedTrade(beforeBlock, LocalDateTime.now().minusDays(20));
+        persistCompletedTrade(afterBlock, LocalDateTime.now().minusDays(3));
+
+        Double avg = priceTradeStatsRepository.findAveragePriceByGradeBetween(
+                cardId, ListingGrade.S, TradeStatus.COMPLETED,
+                LocalDateTime.now().minusDays(14), LocalDateTime.now().minusDays(7));
+
+        assertThat(avg).isEqualTo(2830000.0);
+    }
+
+    @Test
+    @DisplayName("t3 해당 블록에 등급별 체결 이력이 없으면 null을 반환한다")
+    void t3() {
+        Listing recent = persistListing(3000000, ListingGrade.S);
+        persistCompletedTrade(recent, LocalDateTime.now().minusDays(3));
+
+        Double avg = priceTradeStatsRepository.findAveragePriceByGradeBetween(
+                cardId, ListingGrade.S, TradeStatus.COMPLETED,
+                LocalDateTime.now().minusDays(14), LocalDateTime.now().minusDays(7));
+
+        assertThat(avg).isNull();
+    }
+
+    @Test
+    @DisplayName("t4 기간 내 등급별 체결 건수를 집계한다")
+    void t4() {
+        Listing withinWindow = persistListing(3000000, ListingGrade.S);
+        Listing outsideWindow = persistListing(2830000, ListingGrade.S);
+        Listing otherGrade = persistListing(5000000, ListingGrade.PSA10);
+
+        persistCompletedTrade(withinWindow, LocalDateTime.now().minusDays(3));
+        persistCompletedTrade(outsideWindow, LocalDateTime.now().minusDays(15));
+        persistCompletedTrade(otherGrade, LocalDateTime.now().minusDays(1));
+
+        long count = priceTradeStatsRepository.countCompletedTradesByGradeSince(
+                cardId, ListingGrade.S, TradeStatus.COMPLETED, LocalDateTime.now().minusDays(7));
+
+        assertThat(count).isEqualTo(1L);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -7,8 +7,10 @@ import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.trade.repository.TradeRepository;
@@ -21,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -49,6 +52,9 @@ class PriceServiceTest {
 
     @Mock
     private TradeRepository tradeRepository;
+
+    @Mock
+    private PriceTradeStatsRepository priceTradeStatsRepository;
 
     @InjectMocks
     private PriceService priceService;
@@ -146,6 +152,82 @@ class PriceServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT);
+    }
+
+    @Test
+    @DisplayName("t8 존재하지 않는 카드면 CARD_NOT_FOUND 예외가 발생하고 거래 리포지토리를 조회하지 않는다")
+    void t8() {
+        given(cardRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> priceService.getStats(999L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        verify(priceTradeStatsRepository, never()).countCompletedTradesByGradeSince(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("t9 variantId 미지정이고 대표 변형이 없으면 PRIMARY_VARIANT_NOT_FOUND 예외가 발생한다")
+    void t9() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> priceService.getStats(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRIMARY_VARIANT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("t10 S등급 체결 이력이 전혀 없으면 등락률 0, 거래량 0을 반환한다")
+    void t10() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(priceTradeStatsRepository.countCompletedTradesByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(0L);
+        given(priceTradeStatsRepository.findAveragePriceByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(null);
+        given(priceTradeStatsRepository.findAveragePriceByGradeBetween(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(null);
+
+        PriceStatsResponse result = priceService.getStats(1L, 10L);
+
+        assertThat(result.changeRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.volume()).isZero();
+    }
+
+    @Test
+    @DisplayName("t11 최근 7일 체결은 있지만 그 이전 블록에 체결 이력이 없으면 등락률 0, 거래량은 실제 건수를 반환한다")
+    void t11() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(priceTradeStatsRepository.countCompletedTradesByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(1L);
+        given(priceTradeStatsRepository.findAveragePriceByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(3000000.0);
+        given(priceTradeStatsRepository.findAveragePriceByGradeBetween(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(null);
+
+        PriceStatsResponse result = priceService.getStats(1L, 10L);
+
+        assertThat(result.changeRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.volume()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("t12 최근 7일 평균가와 그 이전 7일 평균가가 모두 있으면 블록 간 등락률을 계산해 반환한다")
+    void t12() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(priceTradeStatsRepository.countCompletedTradesByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(4L);
+        given(priceTradeStatsRepository.findAveragePriceByGradeSince(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(3000000.0);
+        given(priceTradeStatsRepository.findAveragePriceByGradeBetween(eq(1L), eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(2830000.0);
+
+        PriceStatsResponse result = priceService.getStats(1L, 10L);
+
+        // (3,000,000 - 2,830,000) / 2,830,000 * 100 ≈ 6.01
+        assertThat(result.changeRate()).isEqualByComparingTo(new BigDecimal("6.01"));
+        assertThat(result.volume()).isEqualTo(4L);
     }
 
     private CardVariantRepository.PrimaryVariantIdView primaryVariantIdView(Long cardId, Long variantId) {


### PR DESCRIPTION
## 📌 관련 이슈
- #87 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- `GET /api/prices/{cardId}/stats?variantId={optional}` 추가 — 카드 상세 화면용 시세 등락률(`changeRate`)/거래량(`volume`) 조회 API (로그인 필요)
- 등락률은 `card_prices`(Scrydex 동기화 데이터) 대신 자체 `trades` 이력을 사용: 최근 7일 S등급 COMPLETED 체결 평균가 vs 그 이전 7일(8~14일 전) 평균가를 비교하는 블록 단위 방식으로 계산 (한쪽 블록에 데이터가 없으면 0 반환)
- 거래량은 최근 7일 이내 S등급 COMPLETED 체결 건수
- `variantId` 미지정 시 대표 변형(`is_primary`) 기준으로 검증하며, 대표 변형이 없으면 404(`PRIMARY_VARIANT_NOT_FOUND`)
- 존재하지 않는 `cardId`는 404(`CARD_NOT_FOUND`)
- `trades` 관련 조회는 `domain.trade`의 `TradeRepository`를 직접 수정하지 않고, `domain.price.repository.PriceTradeStatsRepository`(읽기 전용, `Repository<Trade, Long>` 상속)를 새로 만들어 도메인 경계를 지킴
- `data.sql`에 S등급 체결 시드 데이터 보강 (최근 7일 블록 4건 + 이전 7일 블록 1건 → 등락률/거래량이 0이 아닌 값으로 실제 검증 가능)
- `SecurityConfig` 변경 없음 — 신규 경로가 `permitAll` 목록에 없어 기본 인증 규칙으로 이미 보호됨

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- `./gradlew test` 전체 통과 (`PriceServiceTest`, `PriceControllerTest`, `PriceTradeStatsRepositoryTest` 신규/수정 케이스 포함)
- 로컬에서 회원가입 → DB에서 `status` 수동 `ACTIVE` 처리 → 로그인 → curl로 실제 호출 검증:
  ```json
  // GET /api/prices/1/stats (Authorization: Bearer {accessToken})
  {"status":200,"code":"OK","msg":"요청이 성공했습니다.","data":{"changeRate":3.73,"volume":4}}
- 인증 없이 호출 시 401, 존재하지 않는 cardId 호출 시 404(CARD_NOT_FOUND) 확인

🔍 리뷰 포인트

<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 등락률을 1일 단위로 자르면 너무 등락률의 변화가 적을 것 같아"최근 7일 평균 vs 이전 7일 평균" 블록 비교로 구현하였습니다.
- variantId는 대표 변형 존재 여부 검증에만 쓰이고 실제 체결 집계는 카드 단위입니다(/trades, /chart와 동일한 방식) — variant별 세분화가 필요한 시점인지 의견 부탁드립니다.

✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카드별 가격 통계 조회 기능을 추가했습니다.
  * 선택적으로 카드 변형을 지정해 최근 거래량과 가격 변동률을 확인할 수 있습니다.
  * 최근 7일과 이전 기간의 평균 거래가를 비교해 변동률을 제공합니다.
  * 카드 또는 변형 정보를 찾을 수 없는 경우 적절한 오류를 반환합니다.

* **테스트**
  * 가격 통계 조회, 거래량 집계, 변동률 계산 및 예외 상황을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->