### PR TITLE
[refactor] #92 이메일 인증코드 발송 비동기화로 응답 지연 개선

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
@@ -5,7 +5,6 @@ import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
-import com.pokade.global.infra.mail.MailSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,7 @@ public class EmailVerificationService {
     private final UserRepository userRepository;
     private final VerificationCodeStore codeStore;
     private final VerificationCodeGenerator codeGenerator;
-    private final MailSender mailSender;
+    private final VerificationMailSender verificationMailSender;
 
     private static final int MAX_VERIFY_ATTEMPTS = 5;
 
@@ -35,7 +34,7 @@ public class EmailVerificationService {
         }
         String code = codeGenerator.generate();
         codeStore.save(email, code);
-        mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
+        verificationMailSender.sendCode(email, code);
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationMailSender.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationMailSender.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.global.infra.mail.MailSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VerificationMailSender {
+
+    private final MailSender mailSender;
+
+    // 인증 코드 메일을 비동기로 발송한다.
+    @Async
+    public void sendCode(String email, String code) {
+        mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/config/AsyncConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/AsyncConfig.java
@@ -1,0 +1,16 @@
+package com.pokade.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+/**
+ * SpringBoot가 기본 스레드 풀(applicationTaskExecutor)자동으로 띄워줌
+ *
+ * @Async는 그걸 알아서 사용함 현재 규모에서는 커스텀 풀 필요 없이
+ * 최소한으로 진행 나중에 튜닝 필요하면 그때 executor 빈 추가
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
@@ -3,7 +3,6 @@ package com.pokade.domain.auth.service;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
-import com.pokade.global.infra.mail.MailSender;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -18,9 +17,6 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -36,7 +32,7 @@ public class EmailVerificationServiceTest {
     @Mock
     VerificationCodeGenerator codeGenerator;
     @Mock
-    MailSender mailSender;
+    VerificationMailSender verificationMailSender;
     @InjectMocks
     EmailVerificationService emailVerificationService;
 
@@ -117,7 +113,7 @@ public class EmailVerificationServiceTest {
 
         emailVerificationService.send(email);
 
-        then(mailSender).should().send(eq(email), anyString(), contains("123456"));
+        then(verificationMailSender).should().sendCode(email, "123456");
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #92

## ✨ 작업 내용
- `POST /api/auth/email/send` 응답이 3.5~4.3초 소요되던 문제 개선.
- 원인: `EmailVerificationService.send()`가 Gmail SMTP를 동기 발송해 응답이 블록됨.
- `@EnableAsync` 활성화(`AsyncConfig`) 후, auth 전용 래퍼 `VerificationMailSender.sendCode()`를
  `@Async`로 감싸 **실제 메일 전송만 비동기화**. 검증·저장 로직은 동기 유지(에러 즉시 반환).
- 발송기(`SmtpMailSender`)는 리스팅 배치도 공유하므로 발송기 자체는 동기로 두고,
  auth 경로만 비동기화해 타 도메인(`ListingStaleNoticeService`) 동작에 영향 없음.

## 📸 스크린샷 / 테스트 결과
- 응답 시간: 약 4초 → 즉시(0.x초)로 단축 확인
- 인증 메일 실제 수신 확인 (받은편지함)
- `EmailVerificationServiceTest` 5건 전부 통과 (BUILD SUCCESSFUL)

## 🔍 리뷰 포인트
- 발송 실패 시 예외는 `@Async` 백그라운드 스레드에서 스프링 기본 핸들러가 로그로 남김
  (코드는 이미 Redis 저장돼 재발송으로 커버 → fire-and-forget 절충).
- `@Async`가 프록시 기반이라 자기호출로는 동작 안 함 → 별도 빈(`VerificationMailSender`)으로 분리한 이유.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 이메일 인증 코드 발송 흐름을 개선했습니다.
  * 인증 메일 발송을 비동기로 처리해 요청 응답성이 향상되었습니다.
  * 인증 코드 이메일의 제목과 본문 구성을 일관되게 관리합니다.

* **테스트**
  * 이메일 인증 코드 발송 검증을 새로운 발송 방식에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->