### PR TITLE
[Chore] #96 카드 도메인 정리 + 공유 예외 처리 개선

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -18,10 +18,6 @@ public record CardResponse(
         List<String> grades
 ) {
 
-    public static CardResponse from(Card card) {
-        return from(card, List.of());
-    }
-
     public static CardResponse from(Card card, List<String> grades) {
         return new CardResponse(
                 card.getId(),

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorResponse.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorResponse.java
@@ -1,6 +1,6 @@
 package com.pokade.global.exception;
 
-public record ErrorResponse(int status, String code, String message) {
+public record ErrorResponse(int status, String code, String msg) {
 
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getStatus().value(), errorCode.name(), errorCode.getMessage());

--- a/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
@@ -49,6 +50,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
                 .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage()));
+    }
+
+    // 경로 변수 타입 불일치 (예: /api/cards/abc) - 내부 예외 메시지 노출 방지 (400)
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "잘못된 요청 형식입니다."));
     }
 
     // 업로드 파일/요청 용량 초과 (413)

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -319,4 +319,27 @@ class CardControllerTest {
                 .bodyJson()
                 .extractingPath("$.code").isEqualTo("CARD_NOT_FOUND");
     }
+
+    @Test
+    @DisplayName("t22 숫자가 아닌 카드 id로 상세조회하면 400과 일반화된 메시지를 반환하고 내부 예외 정보를 노출하지 않는다")
+    void t22() {
+        var result = mockMvcTester.get()
+                .uri("/api/cards/abc")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+        result.bodyJson().extractingPath("$.code").isEqualTo("INVALID_INPUT");
+        result.bodyJson().extractingPath("$.msg").isEqualTo("잘못된 요청 형식입니다.");
+        result.bodyText().doesNotContain("MethodArgumentTypeMismatchException", "java.lang.Long", "NumberFormatException");
+    }
+
+    @Test
+    @DisplayName("t23 숫자가 아닌 카드 id로 유사 카드를 조회하면 400과 일반화된 메시지를 반환한다")
+    void t23() {
+        mockMvcTester.get()
+                .uri("/api/cards/abc/related")
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST)
+                .bodyJson()
+                .extractingPath("$.code").isEqualTo("INVALID_INPUT");
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #96 

## ✨ 작업 내용
- CardResponse.from(Card) 미사용 오버로드 삭제
- ErrorResponse 필드명 message → msg로 ApiResponse와 통일
- {id} 파라미터 타입 오류 시 내부 예외 정보 노출 방지 
   (GlobalExceptionHandler, 전역 처리라 카드/매물/거래/시세/AI진단 총 9개 API가 함께 보호됨)

## 📸 스크린샷 / 테스트 결과
- ./gradlew build 전체 통과, 회귀 없음
- curl로 실제 검증: /api/cards/abc, /api/prices/{id}/summary → 400 + 일반화된 메시지 확인 (내부 예외 정보 없음)
- 인증 필요한 API(매물/거래/AI)는 GlobalExceptionHandler를 카드/시세와 동일하게 공유하는 구조라 로그인 후 동일 동작 예상

## 🔍 리뷰 포인트
- ErrorResponse, GlobalExceptionHandler 둘 다 전체 도메인이 같이 쓰는 파일이라 신경 써서 봐주세요
- msg 필드명 통일했으니, FE에서 예전에 msg/message 둘 다 처리하던 코드는 이제 안 써도 됩니다 (FE는 별도로 정리 필요)
- {id} 오류 처리는 파일 하나만 고쳤지만, 카드/AI진단/매물/거래/시세 API 9곳이 한 번에 같이 영향받습니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카드 ID 또는 유사 카드 ID에 잘못된 숫자 형식이 입력되면 HTTP 400 오류를 반환합니다.
  * 입력 오류 응답에 내부 예외 정보가 노출되지 않고, 일관된 안내 메시지가 제공됩니다.
  * 오류 응답 형식이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->