### PR TITLE
[Feature]#95 마이패이지 내 정보 수정 (닉네임 변경, 비밀번호 변경)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -1,13 +1,14 @@
 package com.pokade.domain.user.controller;
 
+import com.pokade.domain.user.dto.request.NicknameUpdateRequest;
+import com.pokade.domain.user.dto.request.PasswordUpdateRequest;
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.service.UserService;
 import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -19,5 +20,18 @@ public class UserController {
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
         return ApiResponse.ok("내 정보 조회 성공", userService.getMyInfo(userId));
+    }
+
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateNickname(@AuthenticationPrincipal Long userId,
+                                            @Valid @RequestBody NicknameUpdateRequest request) {
+        userService.updateNickname(userId, request.nickname());
+        return ApiResponse.ok("닉네임 변경 성공");
+    }
+
+    @PutMapping("/me/password")
+    public ApiResponse<Void> changePassword(@AuthenticationPrincipal Long userId,
+                                            @Valid @RequestBody PasswordUpdateRequest request) {
+        return ApiResponse.ok("비밀번호가 변경되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -32,6 +32,7 @@ public class UserController {
     @PutMapping("/me/password")
     public ApiResponse<Void> changePassword(@AuthenticationPrincipal Long userId,
                                             @Valid @RequestBody PasswordUpdateRequest request) {
+        userService.changePassword(userId, request.currentPassword(), request.newPassword());
         return ApiResponse.ok("비밀번호가 변경되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.pokade.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NicknameUpdateRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해야 합니다.")
+        String nickname
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/request/PasswordUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PasswordUpdateRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다.")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "새 비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)\\S+$",
+                message = "비밀번호는 영문과 숫자를 포함하며 공백을 포함할 수 없습니다."
+        )
+        String newPassword
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -92,4 +92,28 @@ public class User {
     public void verifyEmail() {
         this.status = UserStatus.ACTIVE;
     }
+
+    private static final int NICKNAME_CHANGE_COOLDOWN_DAYS = 30;
+
+    // 닉네임을 마지막 변경 후 쿨 다운이 지났는지 여부
+    public boolean canChangeNickname(LocalDateTime now) {
+        return nicknameChangedAt == null || !now.isBefore(nicknameChangedAt.plusDays(NICKNAME_CHANGE_COOLDOWN_DAYS));
+    }
+
+    // 닉네임을 변경하고 변경 시각을 기록한다.
+    public void changeNickname(String newNickname, LocalDateTime now) {
+        this.nickname = newNickname;
+        this.nicknameChangedAt = now;
+    }
+
+    // 자체(LOCAL) 가입 계정인지 여부
+    public boolean isLocalUser() {
+        return provider == Provider.LOCAL;
+    }
+
+    // 비밀번호를 변경한다 (인코딩된 값)
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -28,7 +28,7 @@ public class User {
 
     private String password;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 20, unique = true)
     private String nickname;
 
     @Column(name = "nickname_changed_at")

--- a/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
@@ -1,23 +1,66 @@
 package com.pokade.domain.user.service;
 
 import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional(readOnly = true)
     public UserResponse getMyInfo(Long userId) {
         return userRepository.findById(userId)
                 .map(UserResponse::from)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, String newNickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 현재 닉네임과 동일하면 변경할 것이 없음 (중복검사 오탐, 쿨다운 소모 방지)
+        if (user.getNickname().equals(newNickname)) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        if (!user.canChangeNickname(now)) {
+            throw new BusinessException(ErrorCode.NICKNAME_CHANGE_LIMITED);
+        }
+
+        if (userRepository.existsByNickname(newNickname)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        user.changeNickname(newNickname, now);
+    }
+
+    @Transactional
+    public void changePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isLocalUser()) {
+            throw new BusinessException(ErrorCode.PASSWORD_CHANGE_NOT_ALLOWED);
+        }
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        user.changePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,7 +46,12 @@ public class UserService {
             throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
         }
 
-        user.changeNickname(newNickname, now);
+        try {
+            user.changeNickname(newNickname, now);
+            userRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -43,6 +43,11 @@ public enum ErrorCode {
     EMAIL_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
     EMAIL_VERIFY_ATTEMPT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "인증 시도 횟수를 초과했습니다."),
 
+    // ===== 마이페이지 (내 정보 수정) =====
+    NICKNAME_CHANGE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "닉네임은 마지막 변경 후 30일이 지나야 다시 변경할 수 있습니다."),
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
+    PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
+
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),
 

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -112,7 +112,7 @@ CREATE TABLE IF NOT EXISTS users (
     id                    BIGSERIAL PRIMARY KEY,
     email                 VARCHAR(255) UNIQUE NOT NULL,
     password              VARCHAR(255),                        -- 소셜 로그인 시 null 가능
-    nickname              VARCHAR(50) NOT NULL,
+    nickname              VARCHAR(50) UNIQUE NOT NULL,
     nickname_changed_at   TIMESTAMP,
     provider              VARCHAR(20) NOT NULL,                -- LOCAL / GOOGLE / KAKAO
     role                  VARCHAR(20) NOT NULL,                -- USER / ADMIN

--- a/Pokade/src/test/java/com/pokade/domain/trade/repository/TradeDomainFkIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/repository/TradeDomainFkIntegrationTest.java
@@ -97,10 +97,12 @@ class TradeDomainFkIntegrationTest {
     }
 
     private Long insertUser(String email) {
+        String nickname = email.split("@")[0];
         return ((Number) entityManager.createNativeQuery(
                         "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) " +
-                                "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                                "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
                 .setParameter("email", email)
+                .setParameter("nickname", nickname)
                 .getSingleResult()).longValue();
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -159,6 +161,20 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.updateNickname(999L, "리코"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("동시 요청 경합으로 DB 유니크 제약을 위반하면 DUPLICATE_NICKNAME 예외를 던진다")
+    void updateNickname_uniqueViolation() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname("리코")).willReturn(false);
+        willThrow(new DataIntegrityViolationException("uk_users_nickname"))
+                .given(userRepository).flush();
+
+        assertThatThrownBy(() -> userService.updateNickname(1L, "리코"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.user.service;
 
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
@@ -13,18 +14,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
 
     @Mock
     UserRepository userRepository;
+    @Mock
+    PasswordEncoder passwordEncoder;
     @InjectMocks
     UserService userService;
 
@@ -38,6 +46,30 @@ class UserServiceTest {
                 .status(UserStatus.ACTIVE)
                 .profileImageUrl("https://img/x.png")
                 .pointBalance(30)
+                .build();
+    }
+
+    private User localUser(String nickname, LocalDateTime nicknameChangedAt) {
+        return User.builder()
+                .id(1L)
+                .email("user@pokade.com")
+                .password("ENCODED_OLD")
+                .nickname(nickname)
+                .nicknameChangedAt(nicknameChangedAt)
+                .role(Role.USER)
+                .provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    private User socialUser() {
+        return User.builder()
+                .id(1L)
+                .email("kakao@pokade.com")
+                .nickname("카카오")
+                .role(Role.USER)
+                .provider(Provider.KAKAO)
+                .status(UserStatus.ACTIVE)
                 .build();
     }
 
@@ -63,6 +95,117 @@ class UserServiceTest {
         given(userRepository.findById(999L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.getMyInfo(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공 시 닉네임과 변경 시각이 갱신된다")
+    void updateNickname_success() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname("리코")).willReturn(false);
+
+        userService.updateNickname(1L, "리코");
+
+        assertThat(user.getNickname()).isEqualTo("리코");
+        assertThat(user.getNicknameChangedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("현재 닉네임과 동일하면 중복검사 없이 통과한다")
+    void updateNickname_sameNickname_noOp() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        userService.updateNickname(1L, "지우");
+
+        then(userRepository).should(never()).existsByNickname(any());
+        assertThat(user.getNickname()).isEqualTo("지우");
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 쿨다운(30일) 중이면 NICKNAME_CHANGE_LIMITED 예외를 던진다")
+    void updateNickname_cooldown() {
+        User user = localUser("지우", LocalDateTime.now().minusDays(5));
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userService.updateNickname(1L, "리코"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NICKNAME_CHANGE_LIMITED);
+
+        assertThat(user.getNickname()).isEqualTo("지우");
+    }
+
+    @Test
+    @DisplayName("변경할 닉네임이 이미 사용 중이면 DUPLICATE_NICKNAME 예외를 던진다")
+    void updateNickname_duplicate() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(userRepository.existsByNickname("리코")).willReturn(true);
+
+        assertThatThrownBy(() -> userService.updateNickname(1L, "리코"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_NICKNAME);
+
+        assertThat(user.getNickname()).isEqualTo("지우");
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 시 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+    void updateNickname_userNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.updateNickname(999L, "리코"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 일치하면 새 비밀번호로 변경한다")
+    void changePassword_success() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("curPw1234", "ENCODED_OLD")).willReturn(true);
+        given(passwordEncoder.encode("newPw1234")).willReturn("ENCODED_NEW");
+
+        userService.changePassword(1L, "curPw1234", "newPw1234");
+
+        assertThat(user.getPassword()).isEqualTo("ENCODED_NEW");
+    }
+
+    @Test
+    @DisplayName("소셜 로그인 계정이면 PASSWORD_CHANGE_NOT_ALLOWED 예외를 던진다")
+    void changePassword_socialUser() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(socialUser()));
+
+        assertThatThrownBy(() -> userService.changePassword(1L, "curPw1234", "newPw1234"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PASSWORD_CHANGE_NOT_ALLOWED);
+
+        then(passwordEncoder).should(never()).matches(any(), any());
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호가 일치하지 않으면 INVALID_CURRENT_PASSWORD 예외를 던진다")
+    void changePassword_wrongCurrent() {
+        User user = localUser("지우", null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrongPw", "ENCODED_OLD")).willReturn(false);
+
+        assertThatThrownBy(() -> userService.changePassword(1L, "wrongPw", "newPw1234"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CURRENT_PASSWORD);
+
+        assertThat(user.getPassword()).isEqualTo("ENCODED_OLD");
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 시 유저가 없으면 USER_NOT_FOUND 예외를 던진다")
+    void changePassword_userNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userService.changePassword(999L, "curPw1234", "newPw1234"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- #95

## ✨ 작업 내용
- 마이페이지 내 정보 수정 기능 추가. 성격이 다른 두 기능을 엔드포인트로 분리.
- `PATCH /api/users/me` — 닉네임 변경
  - 현재 닉네임과 동일하면 no-op(중복검사 오탐·쿨다운 소모 방지)
  - 30일 쿨다운(`nicknameChangedAt`) → 중복검사(`existsByNickname`) 순으로 검증
  - 성공 시 닉네임·변경 시각 갱신
- `PUT /api/users/me/password` — 비밀번호 변경
  - LOCAL 계정만 허용(소셜 차단) → 현재 비밀번호 확인(`matches`) → 새 비번 인코딩 저장
  - 새 비번 정책은 회원가입과 동일(`@Size(8,20)` + 영문·숫자 포함, 공백 불가)
- 상태 변경은 `User` 도메인 메서드(`canChangeNickname`/`changeNickname`/`isLocalUser`/`changePassword`)로 캡슐화
- `ErrorCode` 추가: `NICKNAME_CHANGE_LIMITED`(429), `INVALID_CURRENT_PASSWORD`(400), `PASSWORD_CHANGE_NOT_ALLOWED`(400)

## 📸 스크린샷 / 테스트 결과
- `UserServiceTest` 11건 통과(BUILD SUCCESSFUL): 닉네임 5(성공/동일/쿨다운/중복/유저없음) + 비번 4(성공/소셜/현재비번불일치/유저없음) + 기존 2
- Swagger 스모크 테스트 통과: 닉네임 변경 200 / 쿨다운 429 / 중복 409, 비번 변경 200(변경 후 새 비번 로그인 확인) / 현재비번 오류 400

## 🔍 리뷰 포인트
- 쿨다운 규칙(30일 + `nicknameChangedAt`)은 엔티티에 캡슐화(`canChangeNickname`), 예외는 서비스에서 던져 도메인이 전역 예외에 결합되지 않도록 분리
- 닉네임 검증 순서: 동일 → 쿨다운 → 중복 (가장 실행 가능한 에러를 우선 노출)
- 비번 변경은 provider 확인을 `matches`보다 먼저 (소셜 계정은 대조할 비번 자체가 없음)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 마이페이지에서 닉네임을 변경할 수 있습니다.
  - 닉네임은 2~20자, 공백 없이 입력해야 하며 중복 및 변경 주기 제한이 적용됩니다.
  - 현재 비밀번호 확인 후 새 비밀번호로 변경할 수 있습니다.
  - 새 비밀번호는 8~20자이며 영문과 숫자를 포함해야 합니다.
  - 소셜 로그인 계정은 비밀번호를 변경할 수 없습니다.
- **오류 안내**
  - 닉네임 변경 제한, 비밀번호 불일치 등 상황별 오류 메시지가 제공됩니다.

병합 후 psql 쿼리문 입력 or 도커 DB 초기화
`docker exec pokade-postgres psql -U pokade -d pokade -c "ALTER TABLE users ADD CONSTRAINT uk_users_nickname UNIQUE (nickname);"`

`docker exec pokade-postgres psql -U pokade -d pokade -c "SELECT nickname, COUNT(*) FROM users GROUP BY nickname HAVING COUNT(*) > 1;"`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->