### PR TITLE
[Feature] #101 시세 등락률 조회에 등락액(changeAmount) 필드 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/dto/PriceStatsResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/PriceStatsResponse.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 
 public record PriceStatsResponse(
         BigDecimal changeRate,
+        long changeAmount,
         long volume
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -158,16 +158,18 @@ public class PriceService {
                 cardId, STATS_GRADE, TradeStatus.COMPLETED, previousFrom, recentFrom);
 
         if (recentAvg == null || previousAvg == null) {
-            return new PriceStatsResponse(BigDecimal.ZERO, volume);
+            return new PriceStatsResponse(BigDecimal.ZERO, 0L, volume);
         }
 
         BigDecimal recentAvgAmount = BigDecimal.valueOf(recentAvg);
         BigDecimal previousAvgAmount = BigDecimal.valueOf(previousAvg);
-        BigDecimal changeRate = recentAvgAmount.subtract(previousAvgAmount)
+        BigDecimal diff = recentAvgAmount.subtract(previousAvgAmount);
+        BigDecimal changeRate = diff
                 .divide(previousAvgAmount, 4, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
                 .setScale(2, RoundingMode.HALF_UP);
+        long changeAmount = diff.setScale(0, RoundingMode.HALF_UP).longValue();
 
-        return new PriceStatsResponse(changeRate, volume);
+        return new PriceStatsResponse(changeRate, changeAmount, volume);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -168,11 +168,12 @@ class PriceControllerTest {
     @Test
     void 시세_등락률과_거래량을_조회하면_200과_값을_반환한다() throws Exception {
         given(priceService.getStats(1L, null))
-                .willReturn(new PriceStatsResponse(new BigDecimal("6.01"), 1L));
+                .willReturn(new PriceStatsResponse(new BigDecimal("6.01"), 170000L, 1L));
 
         mockMvc.perform(get("/api/prices/1/stats"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.changeRate").value(6.01))
+                .andExpect(jsonPath("$.data.changeAmount").value(170000))
                 .andExpect(jsonPath("$.data.volume").value(1));
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -192,6 +192,7 @@ class PriceServiceTest {
         PriceStatsResponse result = priceService.getStats(1L, 10L);
 
         assertThat(result.changeRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.changeAmount()).isZero();
         assertThat(result.volume()).isZero();
     }
 
@@ -209,6 +210,7 @@ class PriceServiceTest {
         PriceStatsResponse result = priceService.getStats(1L, 10L);
 
         assertThat(result.changeRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(result.changeAmount()).isZero();
         assertThat(result.volume()).isEqualTo(1L);
     }
 
@@ -227,6 +229,7 @@ class PriceServiceTest {
 
         // (3,000,000 - 2,830,000) / 2,830,000 * 100 ≈ 6.01
         assertThat(result.changeRate()).isEqualByComparingTo(new BigDecimal("6.01"));
+        assertThat(result.changeAmount()).isEqualTo(170000L);
         assertThat(result.volume()).isEqualTo(4L);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #101 

## ✨ 작업 내용
- FR-PRICE-04(`GET /api/prices/{cardId}/stats`) 응답에 등락액(changeAmount) 필드 추가
- `PriceStatsResponse`에 `changeAmount`(long, 원 단위) 필드 추가
- `PriceService.getStats()`에서 changeRate 계산에 쓰던 평균 차이값(BigDecimal diff)을 재사용해, 반올림만 다르게 적용한 changeAmount 계산 로직 추가 (recentAvg - previousAvg)
- 두 블록(최근 7일/이전 7일) 중 하나라도 거래가 없으면 changeRate와 마찬가지로 changeAmount도 0 반환

## 📸 스크린샷 / 테스트 결과
- PriceServiceTest: changeAmount 계산 케이스 검증 (거래 없음 → 0, 정상 계산 → 170000)
- PriceControllerTest: `$.data.changeAmount` 응답 필드 검증 추가
- `./gradlew test --tests "com.pokade.domain.price.*"` 통과

## 🔍 리뷰 포인트
- changeAmount는 changeRate와 별도 쿼리 없이, 이미 계산해둔 평균 차이값(diff)을 그대로 재사용해 계산
- 추후에는 따로 계산하는 방식이 아닌 API 제공 데이터를 이용할 예정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 가격 통계 조회 결과에 최근 평균가와 이전 평균가의 차이를 나타내는 변동 금액이 추가되었습니다.
  * 비교 가능한 가격 정보가 없을 경우 변동 금액은 0으로 표시됩니다.

* **테스트**
  * 가격 변동 금액이 정상적으로 계산·반환되는지 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->