### PR TITLE
[Feature]#103 비밀번호 찾기/재설정 기능 구현 (이메일 인증코드 기반)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/PasswordResetController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/PasswordResetController.java
@@ -1,0 +1,33 @@
+package com.pokade.domain.auth.controller;
+
+import com.pokade.domain.auth.dto.request.PasswordResetConfirmRequest;
+import com.pokade.domain.auth.dto.request.PasswordResetSendRequest;
+import com.pokade.domain.auth.service.PasswordResetService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth/password/reset")
+@RequiredArgsConstructor
+public class PasswordResetController {
+
+    private final PasswordResetService passwordResetService;
+
+    @PostMapping("/send")
+    public ApiResponse<Void> sendResetCode(@Valid @RequestBody PasswordResetSendRequest request) {
+        passwordResetService.send(request.email());
+        return ApiResponse.ok("비밀번호 재설정 코드가 발송되었습니다.");
+    }
+
+    @PostMapping("/confirm")
+    public ApiResponse<Void> confirmReset(@Valid @RequestBody PasswordResetConfirmRequest request) {
+        passwordResetService.confirm(request.email(), request.code(), request.newPassword());
+        return ApiResponse.ok("비밀번호가 재설정되었습니다.");
+    }
+
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/PasswordResetConfirmRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/PasswordResetConfirmRequest.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record PasswordResetConfirmRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+
+        @NotBlank(message = "인증 코드는 필수입니다.")
+        @Pattern(regexp = "\\d{6}", message = "인증 코드는 6자리 숫자여야 합니다.")
+        String code,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "새 비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)\\S+$",
+                message = "비밀번호는 영문과 숫자를 포함하며 공백을 포함할 수 없습니다."
+        )
+        String newPassword
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/PasswordResetSendRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/PasswordResetSendRequest.java
@@ -1,0 +1,11 @@
+package com.pokade.domain.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetSendRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
@@ -1,0 +1,56 @@
+package com.pokade.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PasswordResetCodeStore {
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration COOLDOWN_TTL = Duration.ofSeconds(60);
+    private static final String CODE_KEY_PREFIX = "auth:reset:code:";
+    private static final String COOLDOWN_KEY_PREFIX = "auth:reset:cooldown:";
+    private static final String ATTEMPT_KEY_PREFIX = "auth:reset:attempt:";
+    private static final RedisScript<Long> INCR_WITH_TTL = RedisScript.of(
+            "local c = redis.call('INCR', KEYS[1]) " +
+                    "if c == 1 or redis.call('TTL', KEYS[1]) == -1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
+                    "return c", Long.class);
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean isRecentlySent(String email) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(COOLDOWN_KEY_PREFIX + email));
+    }
+
+    public void save(String email, String code) {
+        redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
+        redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
+    }
+
+    public Optional<String> find(String email) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(CODE_KEY_PREFIX + email));
+    }
+
+    public long getAttemptCount(String email) {
+        String value = redisTemplate.opsForValue().get(ATTEMPT_KEY_PREFIX + email);
+        return value != null ? Long.parseLong(value) : 0;
+    }
+
+    public void incrementAttempt(String email) {
+        redisTemplate.execute(INCR_WITH_TTL,
+                List.of(ATTEMPT_KEY_PREFIX + email),
+                String.valueOf(CODE_TTL.getSeconds()));
+    }
+
+    public void delete(String email) {
+        redisTemplate.delete(CODE_KEY_PREFIX + email);
+        redisTemplate.delete(COOLDOWN_KEY_PREFIX + email);
+        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
@@ -23,14 +23,16 @@ public class PasswordResetCodeStore {
                     "return c", Long.class);
     private final StringRedisTemplate redisTemplate;
 
-    public boolean isRecentlySent(String email) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(COOLDOWN_KEY_PREFIX + email));
-    }
-
-    public void save(String email, String code) {
+    public boolean save(String email, String code) {
+        // 쿨다운 키를 원자적으로 선점 (없을 때만 성공)
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+        if (!Boolean.TRUE.equals(acquired)) {
+            return false;   // 이미 쿨다운 중 → 선점 실패
+        }
         redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-        redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
         redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
+        return true;
     }
 
     public Optional<String> find(String email) {

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
@@ -1,0 +1,68 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+
+    private final UserRepository userRepository;
+    private final PasswordResetCodeStore codeStore;
+    private final VerificationCodeGenerator codeGenerator;
+    private final VerificationMailSender verificationMailSender;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final int MAX_RESET_ATTEMPTS = 5;
+
+    // 재설정 코드 발송: ACTIVE + LOCAL 계정만
+    public void send(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.isLocalUser()) {
+            throw new BusinessException(ErrorCode.PASSWORD_CHANGE_NOT_ALLOWED);
+        }
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+        }
+
+        if ( codeStore.isRecentlySent(email) ) {
+            throw new BusinessException(ErrorCode.EMAIL_SEND_RATE_LIMITED);
+        }
+
+        String code = codeGenerator.generate();
+        codeStore.save(email, code);
+        verificationMailSender.sendResetCode(email, code);
+    }
+
+    // 코드 검증 후 새 비밀번호로 변경
+    @Transactional
+    public void confirm(String email, String code, String newPassword) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (codeStore.getAttemptCount(email) >= MAX_RESET_ATTEMPTS) {
+            throw new BusinessException(ErrorCode.EMAIL_VERIFY_ATTEMPT_EXCEEDED);
+        }
+
+        String storeCode = codeStore.find(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_CODE_EXPIRED));
+
+        if (!storeCode.equals(code)) {
+            codeStore.incrementAttempt(email);
+            throw new BusinessException(ErrorCode.EMAIL_CODE_MISMATCH);
+        }
+
+        user.changePassword(passwordEncoder.encode(newPassword));
+        codeStore.delete(email);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
@@ -35,12 +35,10 @@ public class PasswordResetService {
             throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
         }
 
-        if ( codeStore.isRecentlySent(email) ) {
+        String code = codeGenerator.generate();
+        if (!codeStore.save(email, code)) {
             throw new BusinessException(ErrorCode.EMAIL_SEND_RATE_LIMITED);
         }
-
-        String code = codeGenerator.generate();
-        codeStore.save(email, code);
         verificationMailSender.sendResetCode(email, code);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationMailSender.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationMailSender.java
@@ -16,4 +16,10 @@ public class VerificationMailSender {
     public void sendCode(String email, String code) {
         mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
     }
+
+    // 비밀번호 재설정 코드 메일을 비동기로 발송한다.
+    @Async
+    public void sendResetCode(String email, String code) {
+        mailSender.send(email, "[Pokade] 비밀번호 재설정 코드", "재설정 코드: " + code + "\n5분 이내 입력");
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
@@ -61,8 +61,8 @@ public class PasswordResetServiceTest {
     void send_storesGeneratedCode() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(false);
         given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(true);
 
         passwordResetService.send(email);
 
@@ -74,8 +74,8 @@ public class PasswordResetServiceTest {
     void send_sendsResetEmail() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(false);
         given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(true);
 
         passwordResetService.send(email);
 
@@ -125,18 +125,18 @@ public class PasswordResetServiceTest {
     }
 
     @Test
-    @DisplayName("60초 내 재요청이면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 저장·생성하지 않는다")
-    void send_rejectsWhenRecentlySent() {
+    @DisplayName("쿨다운 선점 실패(동시 요청·60초 내 재요청)면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 메일을 발송하지 않는다")
+    void send_rejectsWhenCooldownActive() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(true);
+        given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(false);
 
         assertThatThrownBy(() -> passwordResetService.send(email))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_RATE_LIMITED);
 
-        then(codeGenerator).should(never()).generate();
-        then(codeStore).should(never()).save(any(), any());
+        then(verificationMailSender).should(never()).sendResetCode(any(), any());
     }
 
     // ===== confirm =====

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
@@ -1,0 +1,221 @@
+package com.pokade.domain.auth.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+public class PasswordResetServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordResetCodeStore codeStore;
+    @Mock VerificationCodeGenerator codeGenerator;
+    @Mock VerificationMailSender verificationMailSender;
+    @Mock PasswordEncoder passwordEncoder;
+    @InjectMocks PasswordResetService passwordResetService;
+
+    private User activeLocalUser(String email) {
+        return User.builder()
+                .email(email)
+                .password("ENCODED_PW")
+                .status(UserStatus.ACTIVE)
+                .provider(Provider.LOCAL)
+                .build();
+    }
+
+    private User socialUser(String email) {
+        return User.builder()
+                .email(email)
+                .status(UserStatus.ACTIVE)
+                .provider(Provider.KAKAO)
+                .build();
+    }
+
+    private User pendingUser(String email) {
+        return User.createLocalUser(email, "ENCODED_PW", "닉네임"); // PENDING + LOCAL
+    }
+
+    // ===== send =====
+
+    @Test
+    @DisplayName("정상 요청 시 생성한 재설정 코드를 저장소에 저장한다")
+    void send_storesGeneratedCode() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(false);
+        given(codeGenerator.generate()).willReturn("123456");
+
+        passwordResetService.send(email);
+
+        then(codeStore).should().save(email, "123456");
+    }
+
+    @Test
+    @DisplayName("정상 요청 시 생성한 코드로 재설정 메일을 발송한다")
+    void send_sendsResetEmail() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(false);
+        given(codeGenerator.generate()).willReturn("123456");
+
+        passwordResetService.send(email);
+
+        then(verificationMailSender).should().sendResetCode(email, "123456");
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 USER_NOT_FOUND 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenUserNotFound() {
+        String email = "unknown@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> passwordResetService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("소셜(비-LOCAL) 계정이면 PASSWORD_CHANGE_NOT_ALLOWED 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenSocialAccount() {
+        String email = "kakao@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(socialUser(email)));
+
+        assertThatThrownBy(() -> passwordResetService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PASSWORD_CHANGE_NOT_ALLOWED);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("아직 인증 안 된(PENDING) 계정이면 EMAIL_NOT_VERIFIED 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenNotActive() {
+        String email = "pending@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
+
+        assertThatThrownBy(() -> passwordResetService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_NOT_VERIFIED);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    @Test
+    @DisplayName("60초 내 재요청이면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 저장·생성하지 않는다")
+    void send_rejectsWhenRecentlySent() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
+        given(codeStore.isRecentlySent(email)).willReturn(true);
+
+        assertThatThrownBy(() -> passwordResetService.send(email))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_RATE_LIMITED);
+
+        then(codeGenerator).should(never()).generate();
+        then(codeStore).should(never()).save(any(), any());
+    }
+
+    // ===== confirm =====
+
+    @Test
+    @DisplayName("코드가 일치하면 새 비밀번호로 변경하고 저장된 코드를 삭제한다")
+    void confirm_changesPasswordAndDeletesCode() {
+        String email = "user@pokade.com";
+        User user = activeLocalUser(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(codeStore.getAttemptCount(email)).willReturn(0L);
+        given(codeStore.find(email)).willReturn(Optional.of("123456"));
+        given(passwordEncoder.encode("newPass123")).willReturn("ENCODED_NEW");
+
+        passwordResetService.confirm(email, "123456", "newPass123");
+
+        assertThat(user.getPassword()).isEqualTo("ENCODED_NEW");
+        then(codeStore).should().delete(email);
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일이면 USER_NOT_FOUND 예외를 던지고 코드를 삭제하지 않는다")
+    void confirm_rejectsWhenUserNotFound() {
+        String email = "unknown@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> passwordResetService.confirm(email, "123456", "newPass123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패 횟수가 최대치 이상이면 EMAIL_VERIFY_ATTEMPT_EXCEEDED 예외를 던지고 코드 조회조차 하지 않는다")
+    void confirm_rejectsWhenAttemptExceeded() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
+        given(codeStore.getAttemptCount(email)).willReturn(5L);
+
+        assertThatThrownBy(() -> passwordResetService.confirm(email, "123456", "newPass123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_VERIFY_ATTEMPT_EXCEEDED);
+
+        then(codeStore).should(never()).find(any());
+        then(codeStore).should(never()).incrementAttempt(any());
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("저장된 코드가 없으면(만료·미발송) EMAIL_CODE_EXPIRED 예외를 던지고 코드를 삭제하지 않는다")
+    void confirm_rejectsWhenCodeExpired() {
+        String email = "user@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(activeLocalUser(email)));
+        given(codeStore.getAttemptCount(email)).willReturn(0L);
+        given(codeStore.find(email)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> passwordResetService.confirm(email, "123456", "newPass123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_CODE_EXPIRED);
+
+        then(codeStore).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("저장된 코드와 다르면 EMAIL_CODE_MISMATCH 예외를 던지고 실패 횟수만 올린 뒤 비번 변경·삭제를 하지 않는다")
+    void confirm_rejectsWhenCodeMismatch() {
+        String email = "user@pokade.com";
+        User user = activeLocalUser(email);
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(user));
+        given(codeStore.getAttemptCount(email)).willReturn(0L);
+        given(codeStore.find(email)).willReturn(Optional.of("999999"));
+
+        assertThatThrownBy(() -> passwordResetService.confirm(email, "123456", "newPass123"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_CODE_MISMATCH);
+
+        assertThat(user.getPassword()).isEqualTo("ENCODED_PW"); // 그대로
+        then(codeStore).should().incrementAttempt(email);
+        then(codeStore).should(never()).delete(any());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #103

## ✨ 작업 내용
- 비로그인 상태에서 이메일 인증코드로 본인 확인 후 새 비밀번호를 설정하는 재설정 기능 (ACTIVE + LOCAL 계정 대상)
- `PasswordResetCodeStore`: `auth:reset:*` 네임스페이스 Redis 저장 (TTL 5분 / 쿨다운 60s / 시도제한 5회, Lua 원자 increment)
- `PasswordResetService`: `send`(코드 발송) · `confirm`(코드 검증 후 `changePassword`)
- `PasswordResetController`: `POST /api/auth/password/reset/send` · `/confirm`
- `VerificationMailSender.sendResetCode` 추가 (재설정용 메일 제목/본문)
- 요청 DTO 2종 (`PasswordResetSendRequest` · `PasswordResetConfirmRequest`)
- `PasswordResetServiceTest` 11건

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과
- 로컬 e2e: send → Redis 코드 확인 → confirm → 새 비번으로 로그인 성공

## 🔍 리뷰 포인트
- **`PasswordResetCodeStore`를 기존 `VerificationCodeStore` 인터페이스와 공유하지 않고 독립 클래스로 신설** — 인터페이스 공유 시 `EmailVerificationService`의 무자격(@Qualifier 없는) 주입이 깨져서 분리했습니다.
- **에러코드는 신규 추가 없이 기존 재사용** (`EMAIL_SEND_RATE_LIMITED` / `EMAIL_CODE_*` / `EMAIL_VERIFY_ATTEMPT_EXCEEDED` / `PASSWORD_CHANGE_NOT_ALLOWED`). 이슈 To-do의 "ErrorCode 추가" 항목은 이 결정으로 대체했습니다.
- **PENDING 계정의 재설정 요청은 `EMAIL_NOT_VERIFIED`로 응답** → 이메일 인증부터 유도.
- 계정 열거는 팀 정책상 비밀번호 찾기에서 허용(`USER_NOT_FOUND` 노출)이라 응답을 뭉개지 않았습니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이메일을 통한 비밀번호 재설정 기능을 추가했습니다.
  * 재설정 코드 발송, 코드 확인 및 새 비밀번호 설정을 지원합니다.
  * 인증 코드 유효 시간과 재발송·입력 시도 제한을 적용합니다.
  * 이메일 형식, 인증 코드, 새 비밀번호 입력값을 검증합니다.

* **버그 수정**
  * 비밀번호 재설정 과정의 만료 코드, 잘못된 코드 및 제한 초과 상황을 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->