### PR TITLE
[Fix]#106 이메일 인증 코드 발송 쿨다운 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
@@ -29,11 +29,10 @@ public class EmailVerificationService {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_VERIFIED);
         }
 
-        if(codeStore.isRecentlySent(email)) {
+        String code = codeGenerator.generate();
+        if (!codeStore.save(email, code)) {
             throw new BusinessException(ErrorCode.EMAIL_SEND_RATE_LIMITED);
         }
-        String code = codeGenerator.generate();
-        codeStore.save(email, code);
         verificationMailSender.sendCode(email, code);
     }
 
@@ -42,18 +41,18 @@ public class EmailVerificationService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        if(user.getStatus() != UserStatus.PENDING) {
+        if (user.getStatus() != UserStatus.PENDING) {
             throw new BusinessException(ErrorCode.EMAIL_ALREADY_VERIFIED);
         }
 
-        if(codeStore.getAttemptCount(email) >= MAX_VERIFY_ATTEMPTS) {
+        if (codeStore.getAttemptCount(email) >= MAX_VERIFY_ATTEMPTS) {
             throw new BusinessException(ErrorCode.EMAIL_VERIFY_ATTEMPT_EXCEEDED);
         }
 
         String storedCode = codeStore.find(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EMAIL_CODE_EXPIRED));
 
-        if(!storedCode.equals(code)) {
+        if (!storedCode.equals(code)) {
             codeStore.incrementAttempt(email);
             throw new BusinessException(ErrorCode.EMAIL_CODE_MISMATCH);
         }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetCodeStore.java
@@ -21,18 +21,22 @@ public class PasswordResetCodeStore {
             "local c = redis.call('INCR', KEYS[1]) " +
                     "if c == 1 or redis.call('TTL', KEYS[1]) == -1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
                     "return c", Long.class);
+    private static final RedisScript<Long> SAVE_WITH_COOLDOWN = RedisScript.of(
+            "if redis.call('SET', KEYS[1], '1', 'NX', 'EX', ARGV[2]) then " +
+                    "  redis.call('SET', KEYS[2], ARGV[1], 'EX', ARGV[3]) " +
+                    "  redis.call('DEL', KEYS[3]) " +
+                    "  return 1 " +
+                    "else return 0 end", Long.class);
+
     private final StringRedisTemplate redisTemplate;
 
     public boolean save(String email, String code) {
-        // 쿨다운 키를 원자적으로 선점 (없을 때만 성공)
-        Boolean acquired = redisTemplate.opsForValue()
-                .setIfAbsent(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
-        if (!Boolean.TRUE.equals(acquired)) {
-            return false;   // 이미 쿨다운 중 → 선점 실패
-        }
-        redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
-        return true;
+        Long result = redisTemplate.execute(SAVE_WITH_COOLDOWN,
+                List.of(COOLDOWN_KEY_PREFIX + email, CODE_KEY_PREFIX + email, ATTEMPT_KEY_PREFIX + email),
+                code,
+                String.valueOf(COOLDOWN_TTL.getSeconds()),
+                String.valueOf(CODE_TTL.getSeconds()));
+        return result != null && result == 1L;
     }
 
     public Optional<String> find(String email) {

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -22,18 +22,23 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
             "local c = redis.call('INCR', KEYS[1]) " +
                     "if c == 1 or redis.call('TTL', KEYS[1]) == -1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end " +
                     "return c", Long.class);
+    private static final RedisScript<Long> SAVE_WITH_COOLDOWN = RedisScript.of(
+            "if redis.call('SET', KEYS[1], '1', 'NX', 'EX', ARGV[2]) then " +
+                    "  redis.call('SET', KEYS[2], ARGV[1], 'EX', ARGV[3]) " +
+                    "  redis.call('DEL', KEYS[3]) " +
+                    "  return 1 " +
+                    "else return 0 end", Long.class);
+
     private final StringRedisTemplate redisTemplate;
 
     @Override
     public boolean save(String email, String code) {
-        Boolean acquired = redisTemplate.opsForValue()
-                .setIfAbsent(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
-        if (!Boolean.TRUE.equals(acquired)) {
-            return false;
-        }
-        redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-        redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
-        return true;
+        Long result = redisTemplate.execute(SAVE_WITH_COOLDOWN,
+                List.of(COOLDOWN_KEY_PREFIX + email, CODE_KEY_PREFIX + email, ATTEMPT_KEY_PREFIX + email),
+                code,
+                String.valueOf(COOLDOWN_TTL.getSeconds()),
+                String.valueOf(CODE_TTL.getSeconds()));
+        return result != null && result == 1L;
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/RedisVerificationCodeStore.java
@@ -25,15 +25,15 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
     private final StringRedisTemplate redisTemplate;
 
     @Override
-    public boolean isRecentlySent(String email) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(COOLDOWN_KEY_PREFIX + email));
-    }
-
-    @Override
-    public void save(String email, String code) {
+    public boolean save(String email, String code) {
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
+        if (!Boolean.TRUE.equals(acquired)) {
+            return false;
+        }
         redisTemplate.opsForValue().set(CODE_KEY_PREFIX + email, code, CODE_TTL);
-        redisTemplate.opsForValue().set(COOLDOWN_KEY_PREFIX + email, "1", COOLDOWN_TTL);
         redisTemplate.delete(ATTEMPT_KEY_PREFIX + email);
+        return true;
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/VerificationCodeStore.java
@@ -3,10 +3,9 @@ package com.pokade.domain.auth.service;
 import java.util.Optional;
 
 public interface VerificationCodeStore {
-    boolean isRecentlySent(String email);
-    void save(String email, String code);
-    Optional<String> find (String email);
+    boolean save(String email, String code);
+    Optional<String> find(String email);
     void delete(String email);
-    long getAttemptCount(String email); // 현재 실패 횟수 조회
-    void incrementAttempt(String email); // 실패시 +1
+    long getAttemptCount(String email);
+    void incrementAttempt(String email);
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
@@ -52,8 +52,8 @@ public class EmailVerificationServiceTest {
     void send_storesGeneratedCode() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(false);
         given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(true);
 
         emailVerificationService.send(email);
 
@@ -61,18 +61,18 @@ public class EmailVerificationServiceTest {
     }
 
     @Test
-    @DisplayName("60초 내 재요청이면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 저장·생성하지 않는다")
-    void send_rejectsWhenRecentlySent() {
+    @DisplayName("쿨다운 선점 실패(동시 요청·60초 내 재요청)면 EMAIL_SEND_RATE_LIMITED 예외를 던지고 메일을 발송하지 않는다")
+    void send_rejectsWhenCooldownActive() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(true);
+        given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(false);
 
         assertThatThrownBy(() -> emailVerificationService.send(email))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_RATE_LIMITED);
 
-        then(codeGenerator).should(never()).generate();
-        then(codeStore).should(never()).save(any(), any());
+        then(verificationMailSender).should(never()).sendCode(any(), any());
     }
 
     @Test
@@ -108,8 +108,8 @@ public class EmailVerificationServiceTest {
     void send_sendsVerificationEmail() {
         String email = "user@pokade.com";
         given(userRepository.findByEmail(email)).willReturn(Optional.of(pendingUser(email)));
-        given(codeStore.isRecentlySent(email)).willReturn(false);
         given(codeGenerator.generate()).willReturn("123456");
+        given(codeStore.save(email, "123456")).willReturn(true);
 
         emailVerificationService.send(email);
 

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
@@ -33,14 +33,12 @@ public class RedisVerificationCodeStoreTest {
     RedisVerificationCodeStore store;
 
     @Test
-    @DisplayName("save하면 isRecentlySent가 true, 저장 전엔 false")
-    void isRecentlySent_reflectsSave() {
+    @DisplayName("save는 최초 호출 시 쿨다운을 선점해 true, 쿨다운 중 재호출은 false를 반환한다")
+    void save_acquiresCooldownOnce() {
         String email = "user@pokade.com";
-        assertThat(store.isRecentlySent(email)).isFalse();
+        assertThat(store.save(email, "123456")).isTrue();
 
-        store.save(email, "123456");
-
-        assertThat(store.isRecentlySent(email)).isTrue();
+        assertThat(store.save(email, "654321")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #106

## ✨ 작업 내용
- `EmailVerificationService.send()`의 `isRecentlySent`(확인) → `save`(쿨다운 기록) 사이 TOCTOU race 제거
- 같은 이메일로 병렬 요청 시 여러 요청이 쿨다운을 통과해 인증 메일이 중복 발송되던 문제(60초 rate-limit 우회) 수정
- `VerificationCodeStore.save`를 `setIfAbsent`(Redis `SET NX`) 기반 **원자적 선점**으로 변경 (반환형 `void` → `boolean`), 선점에 성공한 요청만 코드 저장·메일 발송
- 사용하지 않게 된 `isRecentlySent`는 인터페이스·구현에서 제거
- 비밀번호 재설정(#103)에서 적용한 것과 동일한 패턴

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과
- `RedisVerificationCodeStoreTest`: 최초 `save`는 `true`(선점), 쿨다운 중 재호출은 `false` (실제 Redis / Testcontainers)
- `EmailVerificationServiceTest`: 선점 실패 시 `EMAIL_SEND_RATE_LIMITED` + 메일 미발송 검증

## 🔍 리뷰 포인트
- **`save`가 이제 쿨다운 선점 결과(boolean)를 반환** — 호출부(`send`)가 이 값으로 rate-limit을 판단합니다. `void` 시절의 "확인 후 저장" 2단계를 단일 원자 연산으로 합쳐 race를 닫았습니다.
- `setIfAbsent(key, value, timeout)`는 `SET key value NX PX ttl` 단일 명령이라 동시 요청 중 정확히 하나만 성공합니다.
- **동일 race가 있던 비밀번호 재설정은 #103에서 이미 수정 완료** — 이 PR은 이메일 인증 경로에 같은 수정을 적용한 것입니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 인증 코드 발송 시 쿨다운 제한이 더욱 안정적으로 적용됩니다.
  - 제한 시간 내 중복 또는 동시 발송 요청이 차단되며, 불필요한 인증 메일이 발송되지 않습니다.
  - 인증 코드 저장에 실패한 경우 발송 제한 안내가 제공됩니다.

- **테스트**
  - 정상 발송, 저장 실패, 동시 요청 및 쿨다운 상황에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->