### PR TITLE
[refactor] #109 auth 인증 로직을 service/store/support 패키지로 분리

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import com.pokade.domain.auth.dto.TokenPair;
 import com.pokade.domain.auth.dto.request.LoginRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
 import com.pokade.domain.auth.dto.response.SignupResponse;
+import com.pokade.domain.auth.store.LoginAttemptStore;
+import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/EmailVerificationService.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.VerificationCodeStore;
+import com.pokade.domain.auth.support.VerificationCodeGenerator;
+import com.pokade.domain.auth.support.VerificationMailSender;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/PasswordResetService.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.PasswordResetCodeStore;
+import com.pokade.domain.auth.support.VerificationCodeGenerator;
+import com.pokade.domain.auth.support.VerificationMailSender;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/LoginAttemptStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/LoginAttemptStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 public interface LoginAttemptStore {
     void recordFailure(String username);

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/PasswordResetCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/PasswordResetCodeStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/RedisLoginAttemptStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/RedisLoginAttemptStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/RedisRefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/RedisRefreshTokenStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 import com.pokade.global.security.JwtProperties;
 import lombok.RequiredArgsConstructor;

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/RedisVerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/RedisVerificationCodeStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/RefreshTokenStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/RefreshTokenStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 public interface RefreshTokenStore {
     void save(Long userId, String refreshToken);

--- a/Pokade/src/main/java/com/pokade/domain/auth/store/VerificationCodeStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/store/VerificationCodeStore.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.store;
 
 import java.util.Optional;
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationCodeGenerator.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationCodeGenerator.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.support;
 
 import org.springframework.stereotype.Component;
 

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailSender.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailSender.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.auth.service;
+package com.pokade.domain.auth.support;
 
 import com.pokade.global.infra.mail.MailSender;
 import lombok.RequiredArgsConstructor;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -4,6 +4,8 @@ import com.pokade.domain.auth.dto.TokenPair;
 import com.pokade.domain.auth.dto.request.LoginRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
 import com.pokade.domain.auth.dto.response.SignupResponse;
+import com.pokade.domain.auth.store.LoginAttemptStore;
+import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.VerificationCodeStore;
+import com.pokade.domain.auth.support.VerificationCodeGenerator;
+import com.pokade.domain.auth.support.VerificationMailSender;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/PasswordResetServiceTest.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.PasswordResetCodeStore;
+import com.pokade.domain.auth.support.VerificationCodeGenerator;
+import com.pokade.domain.auth.support.VerificationMailSender;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.UserStatus;
@@ -27,9 +30,12 @@ import static org.mockito.Mockito.never;
 public class PasswordResetServiceTest {
 
     @Mock UserRepository userRepository;
-    @Mock PasswordResetCodeStore codeStore;
-    @Mock VerificationCodeGenerator codeGenerator;
-    @Mock VerificationMailSender verificationMailSender;
+    @Mock
+    PasswordResetCodeStore codeStore;
+    @Mock
+    VerificationCodeGenerator codeGenerator;
+    @Mock
+    VerificationMailSender verificationMailSender;
     @Mock PasswordEncoder passwordEncoder;
     @InjectMocks PasswordResetService passwordResetService;
 

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisLoginAttemptStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisLoginAttemptStoreTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.RedisLoginAttemptStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisRefreshTokenStoreTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.RedisRefreshTokenStore;
 import com.pokade.global.security.JwtProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/RedisVerificationCodeStoreTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.store.RedisVerificationCodeStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/VerificationCodeGeneratorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/VerificationCodeGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.auth.service;
 
+import com.pokade.domain.auth.support.VerificationCodeGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 


### PR DESCRIPTION
## 📌 관련 이슈
- #109

## ✨ 작업 내용
- `domain/auth/service/`에 뒤섞여 있던 유스케이스 서비스·Redis 저장소·헬퍼를 역할별 패키지로 분리
  - `auth/service/` — 유스케이스: `AuthService`, `EmailVerificationService`, `PasswordResetService`
  - `auth/store/` — Redis 저장 계층(인터페이스+구현): `LoginAttemptStore`/`RedisLoginAttemptStore`, `RefreshTokenStore`/`RedisRefreshTokenStore`, `VerificationCodeStore`/`RedisVerificationCodeStore`, `PasswordResetCodeStore`
  - `auth/support/` — 헬퍼: `VerificationCodeGenerator`, `VerificationMailSender`
- IntelliJ Move 리팩터로 package 선언·참조 import·테스트 import 자동 갱신
- **파일 이동만 있고 로직 변경 없음**

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과 (컴파일·전체 테스트 그린 = 동작 변경 0 검증)

## 🔍 리뷰 포인트
- **순수 패키지 이동, 로직 변경 0** — GitHub diff에서 "Show rename" 기준으로 보면 실제 코드 변화가 없음을 빠르게 확인하실 수 있습니다.
- 컴포넌트 스캔은 `@SpringBootApplication`이 `com.pokade` 전체를 스캔하므로 하위 패키지 이동에 설정 변경 불필요.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - 인증, 이메일 인증, 비밀번호 재설정 관련 구성 요소의 역할별 패키지 구조를 정리했습니다.
  - 기존 인터페이스와 동작은 변경되지 않았습니다.
  - 인증 코드 생성 및 메일 발송 기능의 구성을 명확히 분리했습니다.

- **테스트**
  - 인증 및 토큰 저장소, 인증 코드 생성 기능의 테스트 참조를 새 구조에 맞게 업데이트했습니다.
  - 관련 서비스 테스트의 의존성 구성을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->