### PR TITLE
[Chore] #112 AWS EC2 배포 및 GitHub Actions CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy Backend
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./Pokade
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            docker pull ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+            docker stop pokade-app || true
+            docker rm pokade-app || true
+            docker run -d --name pokade-app --network host --restart unless-stopped \
+              --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
+              -e SPRING_PROFILES_ACTIVE=dev \
+              ghcr.io/${{ github.repository_owner }}/pokade-backend:latest

--- a/Pokade/.dockerignore
+++ b/Pokade/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gradle
+build
+.env
+.env.example
+*.md
+.idea

--- a/Pokade/Dockerfile
+++ b/Pokade/Dockerfile
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /app
+
+COPY gradlew settings.gradle.kts build.gradle.kts gradle.properties ./
+COPY gradle ./gradle
+RUN ./gradlew --version
+
+COPY src ./src
+RUN ./gradlew clean bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre AS runtime
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 📌 관련 이슈
- #112

## ✨ 작업 내용
- AWS EC2(pokade-web, t3.small, 서울 리전) 인스턴스 생성 및 수동 배포 완료 (Docker Compose로 PostgreSQL/Redis 운영, dev 프로파일로 백엔드 컨테이너 실행 검증)
- Pokade/Dockerfile 추가: 멀티스테이지 빌드 (eclipse-temurin:21-jdk로 빌드 → eclipse-temurin:21-jre로 런타임 이미지 경량화)
- Pokade/.dockerignore 추가: 빌드 컨텍스트에서 .git, .gradle, build, .env 등 제외
- .github/workflows/deploy.yml 추가: main 브랜치 push 시 GHCR로 이미지 빌드/푸시 → EC2 SSH 접속하여 컨테이너 재배포

## 📸 스크린샷 / 테스트 결과
- EC2에서 수동으로 `docker build` + `docker run` 실행, Swagger UI(`/swagger-ui.html`) 및 `/actuator/health` 정상 응답 확인
- Hikari DB 커넥션 풀 정상 생성, 초기 더미 유저 데이터 insert까지 확인됨

## 🔍 리뷰 포인트
- GitHub Secrets(SSH_HOST, SSH_USER, SSH_KEY)는 등록 완료, main 병합 전까지는 워크플로우 미실행 상태
- 현재는 도메인/HTTPS 미적용 상태로 dev 프로파일 기준 배포 (prod 프로파일은 쿠키 Secure 플래그 때문에 HTTPS 적용 후 전환 예정)
- GHCR 패키지 첫 push 후 Public 전환 필요 (EC2에서 인증 없이 pull 가능하도록) — 별도 후속 작업으로 진행 예정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬(EC2 수동 배포)에서 빌드 및 실행이 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (Notion 배포 문서는 별도 정리 중)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션을 Docker 이미지로 빌드하고 자동 배포하는 CI/CD 파이프라인을 추가했습니다.
  * `main` 브랜치에 변경 사항이 반영되면 최신 버전이 자동으로 배포됩니다.
  * Docker 기반 실행 환경을 추가하고 애플리케이션 포트 8080을 제공합니다.

* **개선**
  * 배포 이미지에서 불필요한 파일을 제외해 빌드 효율성과 이미지 구성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->