### PR TITLE
fix: #117 CORS 허용 Origin에 Vercel 배포 도메인 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -65,11 +65,14 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // CORS 설정 — 프론트(localhost:3000)의 인증정보 포함 요청 허용
+    // CORS 설정 — 로컬 개발(localhost:3000) 및 Vercel 배포 프론트의 인증정보 포함 요청 허용
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://aibe-6-final-project-team05-fe.vercel.app"
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## 📌 관련 이슈
- #117

## ✨ 작업 내용
- SecurityConfig의 CORS 허용 Origin이 http://localhost:3000 으로만 설정되어 있어, Vercel 배포 프론트(https://aibe-6-final-project-team05-fe.vercel.app)에서의 요청이 차단되던 문제 수정
- allowedOrigins 목록에 Vercel 배포 도메인 추가

## 📸 스크린샷 / 테스트 결과
- (머지 후 실제 배포 프론트에서 로그인 등 API 호출 정상 동작 확인 예정)

## 🔍 리뷰 포인트
- 로컬 개발용 localhost:3000은 그대로 유지, Vercel 도메인만 추가하는 최소 변경

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Vercel에 배포된 프론트엔드에서도 서비스에 정상적으로 연결할 수 있도록 CORS 허용 출처를 확장했습니다.
  * 기존 로컬 개발 환경(`localhost:3000`) 지원은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->