### PR TITLE
chore: #119 EC2에서 GHCR Private 이미지 인증 pull하도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           script: |
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker pull ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
             docker stop pokade-app || true
             docker rm pokade-app || true


### PR DESCRIPTION
## 📌 관련 이슈
- #119

## ✨ 작업 내용
- GHCR 패키지가 조직 정책상 Public 전환 불가함을 확인
- PAT(read:packages)를 GHCR_PAT Secret으로 등록하고, EC2 배포 스크립트에서 docker login 후 pull하도록 수정

## 🔍 리뷰 포인트
- GHCR_PAT는 개인 PAT라 만료(90일) 관리 필요 — 만료 시 재발급 후 Secret 갱신 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?