### PR TITLE
[Feature] #122 사용자 조회 응답에 provider 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.user.dto.response;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 
@@ -11,7 +12,8 @@ public record UserResponse(
         Role role,
         UserStatus status,
         String profileImageUrl,
-        Integer pointBalance
+        Integer pointBalance,
+        Provider provider
 ) {
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -21,7 +23,8 @@ public record UserResponse(
                 user.getRole(),
                 user.getStatus(),
                 user.getProfileImageUrl(),
-                user.getPointBalance()
+                user.getPointBalance(),
+                user.getProvider()
         );
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.user.controller;
 
 import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.service.UserService;
@@ -56,7 +57,7 @@ class UserControllerTest {
     void getMyInfo_success() throws Exception {
         UserResponse res = new UserResponse(
                 1L, "user@pokade.com", "트레이너김",
-                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30);
+                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30, Provider.LOCAL);
         given(userService.getMyInfo(1L)).willReturn(res);
 
         mockMvc.perform(get("/api/users/me").with(userId(1L)))
@@ -66,7 +67,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value("트레이너김"))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andExpect(jsonPath("$.data.status").value("ACTIVE"))
-                .andExpect(jsonPath("$.data.pointBalance").value(30));
+                .andExpect(jsonPath("$.data.pointBalance").value(30))
+                .andExpect(jsonPath("$.data.provider").value("LOCAL"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #122

## ✨ 작업 내용
- `GET /api/users/me` 응답(`UserResponse`)에 `provider` 필드 추가
- FE 마이페이지(#49)에서 LOCAL 유저만 비밀번호 변경 UI를 노출하기 위한 지원
- `User` 엔티티의 기존 `provider` 노출만 추가 (신규 로직 없음)

## 📸 스크린샷 / 테스트 결과
- `UserControllerTest` 통과 (`$.data.provider` = "LOCAL" 검증 추가)

## 🔍 리뷰 포인트
- `UserResponse`가 record라 필드 추가 시 생성자 인자 변경 → 테스트 생성자도 함께 갱신
- **머지 순서**: FE 마이페이지(#49)가 이 provider에 의존 → 이 PR을 FE보다 먼저(또는 같이) 머지

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자 응답에 계정 제공자 정보가 함께 포함되도록 개선되었습니다.

* **Bug Fixes**
  * 사용자 조회 응답에서 제공자 값이 누락되지 않도록 수정되었습니다.
  * 응답 JSON에서 제공자 항목이 올바르게 반환되는지 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->