### PR TITLE
refactor: Listing/Trade API 응답을 ApiResponse 래퍼로 통일

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
@@ -11,8 +11,6 @@ import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.service.ListingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,17 +32,16 @@ public class ListingController {
     private final ListingService listingService;
 
     @PostMapping
-    public ResponseEntity<ListingResponse> createListing(
+    public ApiResponse<ListingResponse> createListing(
             @AuthenticationPrincipal Long sellerId,
             @Valid @RequestBody ListingCreateRequest request
     ) {
-        ListingResponse response = listingService.createListing(sellerId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.ok("매물이 등록되었습니다.", listingService.createListing(sellerId, request));
     }
 
     @GetMapping
-    public ResponseEntity<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
-        return ResponseEntity.ok(listingService.getActiveListings(cardId));
+    public ApiResponse<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
+        return ApiResponse.ok(listingService.getActiveListings(cardId));
     }
 
     @GetMapping("/{cardId}/orderbook")
@@ -57,28 +54,28 @@ public class ListingController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<ListingSummaryResponse>> getMyListings(
+    public ApiResponse<List<ListingSummaryResponse>> getMyListings(
             @AuthenticationPrincipal Long sellerId,
             @RequestParam(required = false) ListingStatus status
     ) {
-        return ResponseEntity.ok(listingService.getMyListings(sellerId, status));
+        return ApiResponse.ok(listingService.getMyListings(sellerId, status));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ListingResponse> updateListing(
+    public ApiResponse<ListingResponse> updateListing(
             @AuthenticationPrincipal Long sellerId,
             @PathVariable Long id,
             @Valid @RequestBody ListingUpdateRequest request
     ) {
-        return ResponseEntity.ok(listingService.updatePrice(sellerId, id, request));
+        return ApiResponse.ok("매물 가격이 수정되었습니다.", listingService.updatePrice(sellerId, id, request));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteListing(
+    public ApiResponse<Void> deleteListing(
             @AuthenticationPrincipal Long sellerId,
             @PathVariable Long id
     ) {
         listingService.deleteListing(sellerId, id);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.ok("매물이 삭제되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
@@ -3,10 +3,9 @@ package com.pokade.domain.trade.controller;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,35 +23,34 @@ public class TradeController {
     private final TradeService tradeService;
 
     @PostMapping
-    public ResponseEntity<TradeResponse> createTrade(
+    public ApiResponse<TradeResponse> createTrade(
             @AuthenticationPrincipal Long buyerId,
             @Valid @RequestBody TradeCreateRequest request
     ) {
-        TradeResponse response = tradeService.createTrade(buyerId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.ok("구매 요청이 접수되었습니다.", tradeService.createTrade(buyerId, request));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<TradeResponse> getTrade(
+    public ApiResponse<TradeResponse> getTrade(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.getTrade(userId, id));
+        return ApiResponse.ok(tradeService.getTrade(userId, id));
     }
 
     @PatchMapping("/{id}/confirm")
-    public ResponseEntity<TradeResponse> confirmTrade(
+    public ApiResponse<TradeResponse> confirmTrade(
             @AuthenticationPrincipal Long buyerId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.confirmTrade(buyerId, id));
+        return ApiResponse.ok("구매가 확정되었습니다.", tradeService.confirmTrade(buyerId, id));
     }
 
     @PatchMapping("/{id}/cancel")
-    public ResponseEntity<TradeResponse> cancelTrade(
+    public ApiResponse<TradeResponse> cancelTrade(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.cancelTrade(userId, id));
+        return ApiResponse.ok("거래가 취소되었습니다.", tradeService.cancelTrade(userId, id));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
@@ -69,7 +69,7 @@ class ListingControllerTest {
     }
 
     @Test
-    void 매물_등록에_성공하면_201과_등록된_매물을_반환한다() throws Exception {
+    void 매물_등록에_성공하면_200과_등록된_매물을_반환한다() throws Exception {
         ListingCreateRequest request = new ListingCreateRequest(1L, null, 10000, ListingGrade.A);
         ListingResponse response = new ListingResponse(
                 1L, 1L, 100L, null, 10000, ListingGrade.A, ListingStatus.ACTIVE, LocalDateTime.now());
@@ -81,9 +81,9 @@ class ListingControllerTest {
                         .with(userId(100L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.sellerId").value(100L));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.sellerId").value(100L));
     }
 
     @Test
@@ -122,8 +122,8 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings").param("cardId", "1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].id").value(1L));
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
     }
 
     @Test
@@ -132,7 +132,7 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings").param("cardId", "1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test
@@ -202,8 +202,8 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings/me").with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].id").value(1L));
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
     }
 
     @Test
@@ -212,7 +212,7 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings/me").with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test
@@ -226,7 +226,7 @@ class ListingControllerTest {
                         .with(userId(100L))
                         .param("status", "SOLD"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].status").value("SOLD"));
+                .andExpect(jsonPath("$.data[0].status").value("SOLD"));
     }
 
     @Test
@@ -243,7 +243,7 @@ class ListingControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.price").value(20000));
+                .andExpect(jsonPath("$.data.price").value(20000));
     }
 
     @Test
@@ -304,11 +304,11 @@ class ListingControllerTest {
     }
 
     @Test
-    void 매물_삭제에_성공하면_204를_반환한다() throws Exception {
+    void 매물_삭제에_성공하면_200을_반환한다() throws Exception {
         willDoNothing().given(listingService).deleteListing(anyLong(), anyLong());
 
         mockMvc.perform(delete("/api/listings/1").with(userId(100L)))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -62,7 +62,7 @@ class TradeControllerTest {
     }
 
     @Test
-    void 즉시구매에_성공하면_201과_생성된_거래를_반환한다() throws Exception {
+    void 즉시구매에_성공하면_200과_생성된_거래를_반환한다() throws Exception {
         TradeCreateRequest request = new TradeCreateRequest(1L);
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
@@ -75,10 +75,10 @@ class TradeControllerTest {
                         .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.buyerId").value(200L))
-                .andExpect(jsonPath("$.status").value("PENDING"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.buyerId").value(200L))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
     }
 
     @Test
@@ -149,9 +149,9 @@ class TradeControllerTest {
         mockMvc.perform(get("/api/trades/{id}", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.buyerId").value(200L))
-                .andExpect(jsonPath("$.status").value("PENDING"));
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.buyerId").value(200L))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
     }
 
     @Test
@@ -187,7 +187,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("COMPLETED"));
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
     }
 
     @Test
@@ -234,7 +234,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("CANCELLED"));
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
     }
 
     @Test
@@ -248,7 +248,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
                         .with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("CANCELLED"));
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #124 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- 매물/거래(Listing/Trade) 도메인 컨트롤러가 `ResponseEntity<T>`로 raw 응답을 반환하던 것을 팀 공통 `ApiResponse<T>` 래퍼로 통일                                                  
    - `ListingController`: 등록/목록조회/호가/내매물/가격수정/삭제 6개 엔드포인트                                                                                                   
    - `TradeController`: 즉시구매/상태조회/확정/취소 4개 엔드포인트                                                                                                                 
- 매물 등록·수정 응답 상태 코드 201→200, 삭제 204→200으로 다른 도메인(auth 등)과 통일 (`ApiResponse<T>`는 항상 200 반환하는 게 팀 컨벤션)                                         
- 전역 예외 처리(`GlobalExceptionHandler`, `ExceptionTranslationAspect`)는 재검토했고, Listing/Trade 도메인 자체는 이미 `BusinessException`/`ErrorCode`로 일관되게 연결되어 있어  
  추가 수정 없음

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 매물 및 거래 API 응답 형식을 공통 응답 구조로 통일했습니다.
  * 매물 등록·수정·삭제와 거래 생성·확정·취소 시 성공 메시지를 제공합니다.
  * 삭제 요청도 일관된 성공 응답 형식으로 반환됩니다.
  * 응답 데이터가 `data` 영역에서 제공되도록 변경되었습니다.

* **테스트**
  * 변경된 응답 구조와 HTTP 상태 코드에 맞춰 관련 검증을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->