### PR TITLE
[Chore] #121 카드검색 도메인 매직넘버 상수화 및 계층 구조 정리

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
-import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.response.ApiResponse;
 
@@ -34,14 +33,14 @@ public class CardController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
-            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
+            @PageableDefault(size = CardService.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.search(types, rarity, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")
     public ApiResponse<Page<CardResponse>> searchByKeyword(
             @RequestParam(required = false) String q,
-            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
+            @PageableDefault(size = CardService.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.searchByKeyword(q, pageable));
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.response.ApiResponse;
 
@@ -33,14 +34,14 @@ public class CardController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.search(types, rarity, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")
     public ApiResponse<Page<CardResponse>> searchByKeyword(
             @RequestParam(required = false) String q,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.searchByKeyword(q, pageable));
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -37,11 +37,14 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
     // bucketsByIp 무한 증가 방지용 유휴 만료 기준 — 이 시간 동안 요청이 없으면 정리 대상
     private static final Duration IDLE_TTL = Duration.ofMinutes(10);
     private static final Duration CLEANUP_INTERVAL = Duration.ofMinutes(5);
+    private static final String CLEANUP_THREAD_NAME = "card-rate-limit-cleanup";
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String JSON_CONTENT_TYPE = "application/json;charset=UTF-8";
 
     private final Map<String, BucketEntry> bucketsByIp = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-        Thread thread = new Thread(runnable, "card-rate-limit-cleanup");
+        Thread thread = new Thread(runnable, CLEANUP_THREAD_NAME);
         thread.setDaemon(true);
         return thread;
     });
@@ -63,7 +66,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         }
 
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
-        response.setContentType("application/json;charset=UTF-8");
+        response.setContentType(JSON_CONTENT_TYPE);
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
     }
 
@@ -80,7 +83,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
 
     private String resolveClientIp(HttpServletRequest request) {
         String remoteAddr = request.getRemoteAddr();
-        String forwardedFor = request.getHeader("X-Forwarded-For");
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
         if (forwardedFor != null && !forwardedFor.isBlank() && isTrustedProxy(remoteAddr)) {
             return forwardedFor.split(",")[0].trim();
         }

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.global.exception.ErrorCode;
-import com.pokade.global.exception.ErrorResponse;
+import com.pokade.global.response.ApiResponse;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
@@ -64,7 +64,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
 
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -25,6 +25,15 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     int DEFAULT_PAGE_SIZE = 20;
 
     /**
+     * listings.status가 ACTIVE(매물 도메인 {@code com.pokade.domain.listing.entity.ListingStatus.ACTIVE})인
+     * 매물만 조회할 때 쓰는 네이티브 쿼리 리터럴. status 컬럼은 {@code @Enumerated(EnumType.STRING)}이라
+     * "ACTIVE"라는 문자열이 실제 저장값과 같지만, 이 상수는 그 값을 그대로 베낀 것일 뿐 enum과 타입으로
+     * 연결되어 있지 않다. 따라서 ListingStatus.ACTIVE의 이름이 바뀌면 컴파일 에러 없이 이 값만 조용히
+     * 어긋날 수 있다 — 상수화가 그 위험 자체를 없애주지는 않는다.
+     */
+    String LISTING_STATUS_ACTIVE = "ACTIVE";
+
+    /**
      * sort 요청 파라미터 화이트리스트. 값은 아래 default search()의 if/else 디스패치에서
      * 어떤 @Query를 실행할지 고르는 키로만 쓰이고 SQL 문자열에 직접 삽입되지 않으므로
      * (고정된 세 개의 @Query 중 택일), 인젝션 여지가 없다.
@@ -40,7 +49,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:hasPrice = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -53,7 +62,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:hasPrice = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -112,7 +121,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT DISTINCT l.card_id AS cardId, l.grade AS grade
             FROM listings l
             WHERE l.card_id IN (:cardIds)
-              AND l.status = 'ACTIVE'
+              AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
               AND l.grade IN (:validGrades)
             """,
             nativeQuery = true)
@@ -162,7 +171,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :id
             AND c.national_pokedex_numbers && src.national_pokedex_numbers
             ORDER BY c.name
-            LIMIT """ + DEFAULT_PAGE_SIZE,
+            LIMIT\s""" + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByPokedexNumber(@Param("id") Long id);
 
@@ -171,7 +180,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :excludeCardId
             AND c.expansion_id = :expansionId
             ORDER BY c.name
-            LIMIT """ + DEFAULT_PAGE_SIZE,
+            LIMIT\s""" + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByExpansion(@Param("expansionId") String expansionId, @Param("excludeCardId") Long excludeCardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -21,6 +21,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     String SORT_NAME = "name";
     String SORT_POPULAR = "popular";
 
+    /** 카드 목록/연관 카드 조회의 기본 페이지 크기·상한 개수. */
+    int DEFAULT_PAGE_SIZE = 20;
+
     /**
      * sort 요청 파라미터 화이트리스트. 값은 아래 default search()의 if/else 디스패치에서
      * 어떤 @Query를 실행할지 고르는 키로만 쓰이고 SQL 문자열에 직접 삽입되지 않으므로
@@ -159,8 +162,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :id
             AND c.national_pokedex_numbers && src.national_pokedex_numbers
             ORDER BY c.name
-            LIMIT 20
-            """,
+            LIMIT """ + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByPokedexNumber(@Param("id") Long id);
 
@@ -169,8 +171,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :excludeCardId
             AND c.expansion_id = :expansionId
             ORDER BY c.name
-            LIMIT 20
-            """,
+            LIMIT """ + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByExpansion(@Param("expansionId") String expansionId, @Param("excludeCardId") Long excludeCardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -36,7 +36,7 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
             FROM listings l
             LEFT JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
             WHERE l.card_id = :cardId
-              AND l.status = 'ACTIVE'
+              AND l.status = '""" + CardRepository.LISTING_STATUS_ACTIVE + "'" + """
               AND l.grade IN (:validGrades)
               AND COALESCE(l.variant_id, cv.id) IS NOT NULL
             """,

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -29,7 +29,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CardService {
 
-    // size 상한: 응답 payload/DB 부하를 고려해 BE 기본값(20)의 5배 수준으로 제한.
+    /** CardController가 @PageableDefault에 쓰는 기본 페이지 크기. 원본 값은 {@link CardRepository#DEFAULT_PAGE_SIZE}. */
+    public static final int DEFAULT_PAGE_SIZE = CardRepository.DEFAULT_PAGE_SIZE;
+    // size 상한: 응답 payload/DB 부하를 고려해 BE 기본값(DEFAULT_PAGE_SIZE)의 5배 수준으로 제한.
     // application.yaml의 Pageable 전역 max-page-size(기본 2000)와 별개로 카드 도메인에서 한 번 더 검증.
     private static final int MAX_PAGE_SIZE = 100;
     // types/rarity 상한: 현재 FE 필터 옵션(각 6개)보다 넉넉히 여유를 둔 값.

--- a/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
@@ -145,8 +145,9 @@ class CardRateLimitFilterTest {
         }
         assertThat(filter.bucketCountForTest()).isEqualTo(5);
 
-        Thread.sleep(50);
-        filter.evictIdleEntriesForTest(10);
+        // Long.MIN_VALUE 임계값을 주면 "경과 시간 > 임계값"이 실제 경과 시간(0이어도)과 무관하게
+        // 항상 참이 되어, 실제로 시간이 흐르길 기다리지 않고도 유휴 판정 로직을 결정론적으로 검증할 수 있다.
+        filter.evictIdleEntriesForTest(Long.MIN_VALUE);
 
         assertThat(filter.bucketCountForTest()).isEqualTo(0);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- #121 

## ✨ 작업 내용
- CardRateLimitFilter의 에러 응답을 ErrorResponse에서 ApiResponse로 통일
- CardRepository/CardController의 목록 크기 제한(LIMIT 20)을 named constant로 통일
- CardRateLimitFilter의 헤더명/스레드명/Content-Type 리터럴을 상수로 추출
- 'ACTIVE' 리터럴(매물 도메인 ListingStatus.ACTIVE를 문자열로 복사한 값) 상수화
- CardController가 CardRepository를 직접 참조하던 것을 CardService 경유로 정리 (계층 구조 원칙 준수)
- CardRateLimitFilterTest의 Thread.sleep 제거, 결정론적 검증으로 변경

## 📸 스크린샷 / 테스트 결과
- 카드 도메인 테스트 전체(62개) + 프로젝트 전체 테스트 통과 확인


## 🔍 리뷰 포인트
- 매직넘버 상수화 중 지난 커밋의 실제 버그(LIMIT 쿼리가 텍스트 블록 공백 제거로 깨져있던 것)를 발견해서 같이 고쳤습니다.
- 'ACTIVE' 리터럴은 매물 도메인 enum 값을 복사한 것이라, 상수화해도 두 도메인 값이 어긋날 위험 자체는 남아있습니다 (주석으로 명시).


## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 카드 목록 및 키워드 검색의 기본 페이지 크기 기준을 일관되게 조정했습니다.
  - 카드 검색 결과에서 활성 매물만 안정적으로 조회되도록 동작을 정비했습니다.
  - 관련 카드 및 등급 조회 결과의 표시 기준을 통일했습니다.

- **버그 수정**
  - 요청 제한 초과 시 API 응답 형식과 JSON 콘텐츠 유형이 일관되게 제공됩니다.
  - 요청자의 클라이언트 IP 확인 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->