### PR TITLE
chore: #126 배포 환경에 OpenAI 설정 및 prod 프로파일 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,5 +43,5 @@ jobs:
             docker rm pokade-app || true
             docker run -d --name pokade-app --network host --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
-              -e SPRING_PROFILES_ACTIVE=dev \
+              -e SPRING_PROFILES_ACTIVE=prod \
               ghcr.io/${{ github.repository_owner }}/pokade-backend:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          envs: OPENAI_API_KEY
           script: |
             docker pull ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
             docker stop pokade-app || true
@@ -44,4 +45,7 @@ jobs:
             docker run -d --name pokade-app --network host --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
+              -e OPENAI_API_KEY="$OPENAI_API_KEY" \
               ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -65,11 +65,15 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // CORS 설정 — 프론트(localhost:3000)의 인증정보 포함 요청 허용
+    // CORS 설정 — 프론트(로컬 개발 서버 + 운영 도메인)의 인증정보 포함 요청 허용
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://www.pokade.store",
+                "https://pokade.store"
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -22,6 +22,13 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
+
 # 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
 app:
   cookie:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: Pokade
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:prod}
   config:
     import:
       - optional:file:.env[.properties]


### PR DESCRIPTION
## 📌 관련 이슈
- #126

## ✨ 작업 내용
- `application-prod.yaml`에 OpenAI(Spring AI) 설정 추가 (api-key, chat model)
- 기본 활성 프로파일을 `dev`에서 `prod`로 전환 (`application.yaml`, 배포 워크플로우)
- 배포 워크플로우(`deploy.yml`)에서 `OPENAI_API_KEY`를 GitHub Secrets → 배포 서버 컨테이너 환경변수로 주입하도록 추가

## 📸 스크린샷 / 테스트 결과
- 

## 🔍 리뷰 포인트
- `SPRING_PROFILES_ACTIVE` 기본값을 `prod`로 바꾼 것이 로컬/다른 브랜치의 dev 실행에 영향 없는지 확인 부탁드립니다.
- `OPENAI_API_KEY` Secret이 저장소 Actions Secrets에 등록되어 있는지 확인 필요합니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * OpenAI 기반 AI 기능을 사용할 수 있도록 설정을 추가했습니다.
  * 기본 채팅 모델로 `gpt-4o-mini`를 사용하며, 필요에 따라 모델을 변경할 수 있습니다.

* **개선**
  * 애플리케이션의 기본 실행 환경을 운영 프로필로 변경했습니다.
  * 배포 시 운영 설정과 OpenAI API 키가 자동으로 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->