### PR TITLE
chore: develop → main 배포 반영 (#126, #121, #122)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,5 +43,5 @@ jobs:
             docker rm pokade-app || true
             docker run -d --name pokade-app --network host --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
-              -e SPRING_PROFILES_ACTIVE=dev \
+              -e SPRING_PROFILES_ACTIVE=prod \
               ghcr.io/${{ github.repository_owner }}/pokade-backend:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
+          envs: OPENAI_API_KEY
           script: |
             docker pull ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
             docker stop pokade-app || true
@@ -44,4 +45,7 @@ jobs:
             docker run -d --name pokade-app --network host --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
+              -e OPENAI_API_KEY="$OPENAI_API_KEY" \
               ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
-import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.response.ApiResponse;
 
@@ -34,14 +33,14 @@ public class CardController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
-            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
+            @PageableDefault(size = CardService.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.search(types, rarity, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")
     public ApiResponse<Page<CardResponse>> searchByKeyword(
             @RequestParam(required = false) String q,
-            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
+            @PageableDefault(size = CardService.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.searchByKeyword(q, pageable));
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardResponse;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.response.ApiResponse;
 
@@ -33,14 +34,14 @@ public class CardController {
             @RequestParam(required = false) Integer minPrice,
             @RequestParam(required = false) Integer maxPrice,
             @RequestParam(required = false) String sort,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.search(types, rarity, expansionId, minPrice, maxPrice, sort, pageable));
     }
 
     @GetMapping("/search")
     public ApiResponse<Page<CardResponse>> searchByKeyword(
             @RequestParam(required = false) String q,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @PageableDefault(size = CardRepository.DEFAULT_PAGE_SIZE) Pageable pageable) {
         return ApiResponse.ok(cardService.searchByKeyword(q, pageable));
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -37,11 +37,14 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
     // bucketsByIp 무한 증가 방지용 유휴 만료 기준 — 이 시간 동안 요청이 없으면 정리 대상
     private static final Duration IDLE_TTL = Duration.ofMinutes(10);
     private static final Duration CLEANUP_INTERVAL = Duration.ofMinutes(5);
+    private static final String CLEANUP_THREAD_NAME = "card-rate-limit-cleanup";
+    private static final String FORWARDED_FOR_HEADER = "X-Forwarded-For";
+    private static final String JSON_CONTENT_TYPE = "application/json;charset=UTF-8";
 
     private final Map<String, BucketEntry> bucketsByIp = new ConcurrentHashMap<>();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ScheduledExecutorService cleanupExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
-        Thread thread = new Thread(runnable, "card-rate-limit-cleanup");
+        Thread thread = new Thread(runnable, CLEANUP_THREAD_NAME);
         thread.setDaemon(true);
         return thread;
     });
@@ -63,7 +66,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         }
 
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
-        response.setContentType("application/json;charset=UTF-8");
+        response.setContentType(JSON_CONTENT_TYPE);
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
     }
 
@@ -80,7 +83,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
 
     private String resolveClientIp(HttpServletRequest request) {
         String remoteAddr = request.getRemoteAddr();
-        String forwardedFor = request.getHeader("X-Forwarded-For");
+        String forwardedFor = request.getHeader(FORWARDED_FOR_HEADER);
         if (forwardedFor != null && !forwardedFor.isBlank() && isTrustedProxy(remoteAddr)) {
             return forwardedFor.split(",")[0].trim();
         }

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -13,7 +13,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.global.exception.ErrorCode;
-import com.pokade.global.exception.ErrorResponse;
+import com.pokade.global.response.ApiResponse;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
@@ -64,7 +64,7 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
 
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
         response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));
     }
 
     @Override

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -25,6 +25,15 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     int DEFAULT_PAGE_SIZE = 20;
 
     /**
+     * listings.status가 ACTIVE(매물 도메인 {@code com.pokade.domain.listing.entity.ListingStatus.ACTIVE})인
+     * 매물만 조회할 때 쓰는 네이티브 쿼리 리터럴. status 컬럼은 {@code @Enumerated(EnumType.STRING)}이라
+     * "ACTIVE"라는 문자열이 실제 저장값과 같지만, 이 상수는 그 값을 그대로 베낀 것일 뿐 enum과 타입으로
+     * 연결되어 있지 않다. 따라서 ListingStatus.ACTIVE의 이름이 바뀌면 컴파일 에러 없이 이 값만 조용히
+     * 어긋날 수 있다 — 상수화가 그 위험 자체를 없애주지는 않는다.
+     */
+    String LISTING_STATUS_ACTIVE = "ACTIVE";
+
+    /**
      * sort 요청 파라미터 화이트리스트. 값은 아래 default search()의 if/else 디스패치에서
      * 어떤 @Query를 실행할지 고르는 키로만 쓰이고 SQL 문자열에 직접 삽입되지 않으므로
      * (고정된 세 개의 @Query 중 택일), 인젝션 여지가 없다.
@@ -40,7 +49,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:hasPrice = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -53,7 +62,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             (:hasTypes = false OR EXISTS (SELECT 1 FROM unnest(c.types) AS t(val) WHERE val IN (:types))) AND
             (:hasRarities = false OR c.rarity IN (:rarities)) AND
             (:hasPrice = false OR EXISTS (
-                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = 'ACTIVE'
+                SELECT 1 FROM listings l WHERE l.card_id = c.id AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
                 AND (:minPrice IS NULL OR l.price >= :minPrice)
                 AND (:maxPrice IS NULL OR l.price <= :maxPrice)
             )) AND
@@ -112,7 +121,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             SELECT DISTINCT l.card_id AS cardId, l.grade AS grade
             FROM listings l
             WHERE l.card_id IN (:cardIds)
-              AND l.status = 'ACTIVE'
+              AND l.status = '""" + LISTING_STATUS_ACTIVE + "'" + """
               AND l.grade IN (:validGrades)
             """,
             nativeQuery = true)
@@ -162,7 +171,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :id
             AND c.national_pokedex_numbers && src.national_pokedex_numbers
             ORDER BY c.name
-            LIMIT """ + DEFAULT_PAGE_SIZE,
+            LIMIT\s""" + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByPokedexNumber(@Param("id") Long id);
 
@@ -171,7 +180,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :excludeCardId
             AND c.expansion_id = :expansionId
             ORDER BY c.name
-            LIMIT """ + DEFAULT_PAGE_SIZE,
+            LIMIT\s""" + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByExpansion(@Param("expansionId") String expansionId, @Param("excludeCardId") Long excludeCardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -21,6 +21,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     String SORT_NAME = "name";
     String SORT_POPULAR = "popular";
 
+    /** 카드 목록/연관 카드 조회의 기본 페이지 크기·상한 개수. */
+    int DEFAULT_PAGE_SIZE = 20;
+
     /**
      * sort 요청 파라미터 화이트리스트. 값은 아래 default search()의 if/else 디스패치에서
      * 어떤 @Query를 실행할지 고르는 키로만 쓰이고 SQL 문자열에 직접 삽입되지 않으므로
@@ -159,8 +162,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :id
             AND c.national_pokedex_numbers && src.national_pokedex_numbers
             ORDER BY c.name
-            LIMIT 20
-            """,
+            LIMIT """ + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByPokedexNumber(@Param("id") Long id);
 
@@ -169,8 +171,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
             WHERE c.id <> :excludeCardId
             AND c.expansion_id = :expansionId
             ORDER BY c.name
-            LIMIT 20
-            """,
+            LIMIT """ + DEFAULT_PAGE_SIZE,
             nativeQuery = true)
     List<Card> findRelatedByExpansion(@Param("expansionId") String expansionId, @Param("excludeCardId") Long excludeCardId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -36,7 +36,7 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
             FROM listings l
             LEFT JOIN card_variants cv ON cv.card_id = l.card_id AND cv.is_primary = true
             WHERE l.card_id = :cardId
-              AND l.status = 'ACTIVE'
+              AND l.status = '""" + CardRepository.LISTING_STATUS_ACTIVE + "'" + """
               AND l.grade IN (:validGrades)
               AND COALESCE(l.variant_id, cv.id) IS NOT NULL
             """,

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -29,7 +29,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CardService {
 
-    // size 상한: 응답 payload/DB 부하를 고려해 BE 기본값(20)의 5배 수준으로 제한.
+    /** CardController가 @PageableDefault에 쓰는 기본 페이지 크기. 원본 값은 {@link CardRepository#DEFAULT_PAGE_SIZE}. */
+    public static final int DEFAULT_PAGE_SIZE = CardRepository.DEFAULT_PAGE_SIZE;
+    // size 상한: 응답 payload/DB 부하를 고려해 BE 기본값(DEFAULT_PAGE_SIZE)의 5배 수준으로 제한.
     // application.yaml의 Pageable 전역 max-page-size(기본 2000)와 별개로 카드 도메인에서 한 번 더 검증.
     private static final int MAX_PAGE_SIZE = 100;
     // types/rarity 상한: 현재 FE 필터 옵션(각 6개)보다 넉넉히 여유를 둔 값.

--- a/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
@@ -11,8 +11,6 @@ import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.service.ListingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,17 +32,16 @@ public class ListingController {
     private final ListingService listingService;
 
     @PostMapping
-    public ResponseEntity<ListingResponse> createListing(
+    public ApiResponse<ListingResponse> createListing(
             @AuthenticationPrincipal Long sellerId,
             @Valid @RequestBody ListingCreateRequest request
     ) {
-        ListingResponse response = listingService.createListing(sellerId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.ok("매물이 등록되었습니다.", listingService.createListing(sellerId, request));
     }
 
     @GetMapping
-    public ResponseEntity<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
-        return ResponseEntity.ok(listingService.getActiveListings(cardId));
+    public ApiResponse<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
+        return ApiResponse.ok(listingService.getActiveListings(cardId));
     }
 
     @GetMapping("/{cardId}/orderbook")
@@ -57,28 +54,28 @@ public class ListingController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<ListingSummaryResponse>> getMyListings(
+    public ApiResponse<List<ListingSummaryResponse>> getMyListings(
             @AuthenticationPrincipal Long sellerId,
             @RequestParam(required = false) ListingStatus status
     ) {
-        return ResponseEntity.ok(listingService.getMyListings(sellerId, status));
+        return ApiResponse.ok(listingService.getMyListings(sellerId, status));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ListingResponse> updateListing(
+    public ApiResponse<ListingResponse> updateListing(
             @AuthenticationPrincipal Long sellerId,
             @PathVariable Long id,
             @Valid @RequestBody ListingUpdateRequest request
     ) {
-        return ResponseEntity.ok(listingService.updatePrice(sellerId, id, request));
+        return ApiResponse.ok("매물 가격이 수정되었습니다.", listingService.updatePrice(sellerId, id, request));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteListing(
+    public ApiResponse<Void> deleteListing(
             @AuthenticationPrincipal Long sellerId,
             @PathVariable Long id
     ) {
         listingService.deleteListing(sellerId, id);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.ok("매물이 삭제되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
@@ -3,10 +3,9 @@ package com.pokade.domain.trade.controller;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,35 +23,34 @@ public class TradeController {
     private final TradeService tradeService;
 
     @PostMapping
-    public ResponseEntity<TradeResponse> createTrade(
+    public ApiResponse<TradeResponse> createTrade(
             @AuthenticationPrincipal Long buyerId,
             @Valid @RequestBody TradeCreateRequest request
     ) {
-        TradeResponse response = tradeService.createTrade(buyerId, request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ApiResponse.ok("구매 요청이 접수되었습니다.", tradeService.createTrade(buyerId, request));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<TradeResponse> getTrade(
+    public ApiResponse<TradeResponse> getTrade(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.getTrade(userId, id));
+        return ApiResponse.ok(tradeService.getTrade(userId, id));
     }
 
     @PatchMapping("/{id}/confirm")
-    public ResponseEntity<TradeResponse> confirmTrade(
+    public ApiResponse<TradeResponse> confirmTrade(
             @AuthenticationPrincipal Long buyerId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.confirmTrade(buyerId, id));
+        return ApiResponse.ok("구매가 확정되었습니다.", tradeService.confirmTrade(buyerId, id));
     }
 
     @PatchMapping("/{id}/cancel")
-    public ResponseEntity<TradeResponse> cancelTrade(
+    public ApiResponse<TradeResponse> cancelTrade(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(tradeService.cancelTrade(userId, id));
+        return ApiResponse.ok("거래가 취소되었습니다.", tradeService.cancelTrade(userId, id));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.user.dto.response;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 
@@ -11,7 +12,8 @@ public record UserResponse(
         Role role,
         UserStatus status,
         String profileImageUrl,
-        Integer pointBalance
+        Integer pointBalance,
+        Provider provider
 ) {
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -21,7 +23,8 @@ public record UserResponse(
                 user.getRole(),
                 user.getStatus(),
                 user.getProfileImageUrl(),
-                user.getPointBalance()
+                user.getPointBalance(),
+                user.getProvider()
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -65,11 +65,15 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // CORS 설정 — 프론트(localhost:3000)의 인증정보 포함 요청 허용
+    // CORS 설정 — 프론트(로컬 개발 서버 + 운영 도메인)의 인증정보 포함 요청 허용
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://www.pokade.store",
+                "https://pokade.store"
+        ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -22,6 +22,13 @@ spring:
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
 
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+      chat:
+        options:
+          model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
+
 # 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
 app:
   cookie:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: Pokade
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:prod}
   config:
     import:
       - optional:file:.env[.properties]

--- a/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
@@ -145,8 +145,9 @@ class CardRateLimitFilterTest {
         }
         assertThat(filter.bucketCountForTest()).isEqualTo(5);
 
-        Thread.sleep(50);
-        filter.evictIdleEntriesForTest(10);
+        // Long.MIN_VALUE 임계값을 주면 "경과 시간 > 임계값"이 실제 경과 시간(0이어도)과 무관하게
+        // 항상 참이 되어, 실제로 시간이 흐르길 기다리지 않고도 유휴 판정 로직을 결정론적으로 검증할 수 있다.
+        filter.evictIdleEntriesForTest(Long.MIN_VALUE);
 
         assertThat(filter.bucketCountForTest()).isEqualTo(0);
     }

--- a/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
@@ -69,7 +69,7 @@ class ListingControllerTest {
     }
 
     @Test
-    void 매물_등록에_성공하면_201과_등록된_매물을_반환한다() throws Exception {
+    void 매물_등록에_성공하면_200과_등록된_매물을_반환한다() throws Exception {
         ListingCreateRequest request = new ListingCreateRequest(1L, null, 10000, ListingGrade.A);
         ListingResponse response = new ListingResponse(
                 1L, 1L, 100L, null, 10000, ListingGrade.A, ListingStatus.ACTIVE, LocalDateTime.now());
@@ -81,9 +81,9 @@ class ListingControllerTest {
                         .with(userId(100L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.sellerId").value(100L));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.sellerId").value(100L));
     }
 
     @Test
@@ -122,8 +122,8 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings").param("cardId", "1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].id").value(1L));
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
     }
 
     @Test
@@ -132,7 +132,7 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings").param("cardId", "1"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test
@@ -202,8 +202,8 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings/me").with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(1))
-                .andExpect(jsonPath("$[0].id").value(1L));
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
     }
 
     @Test
@@ -212,7 +212,7 @@ class ListingControllerTest {
 
         mockMvc.perform(get("/api/listings/me").with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test
@@ -226,7 +226,7 @@ class ListingControllerTest {
                         .with(userId(100L))
                         .param("status", "SOLD"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].status").value("SOLD"));
+                .andExpect(jsonPath("$.data[0].status").value("SOLD"));
     }
 
     @Test
@@ -243,7 +243,7 @@ class ListingControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.price").value(20000));
+                .andExpect(jsonPath("$.data.price").value(20000));
     }
 
     @Test
@@ -304,11 +304,11 @@ class ListingControllerTest {
     }
 
     @Test
-    void 매물_삭제에_성공하면_204를_반환한다() throws Exception {
+    void 매물_삭제에_성공하면_200을_반환한다() throws Exception {
         willDoNothing().given(listingService).deleteListing(anyLong(), anyLong());
 
         mockMvc.perform(delete("/api/listings/1").with(userId(100L)))
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -62,7 +62,7 @@ class TradeControllerTest {
     }
 
     @Test
-    void 즉시구매에_성공하면_201과_생성된_거래를_반환한다() throws Exception {
+    void 즉시구매에_성공하면_200과_생성된_거래를_반환한다() throws Exception {
         TradeCreateRequest request = new TradeCreateRequest(1L);
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
@@ -75,10 +75,10 @@ class TradeControllerTest {
                         .with(userId(200L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.buyerId").value(200L))
-                .andExpect(jsonPath("$.status").value("PENDING"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.buyerId").value(200L))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
     }
 
     @Test
@@ -149,9 +149,9 @@ class TradeControllerTest {
         mockMvc.perform(get("/api/trades/{id}", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.buyerId").value(200L))
-                .andExpect(jsonPath("$.status").value("PENDING"));
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.buyerId").value(200L))
+                .andExpect(jsonPath("$.data.status").value("PENDING"));
     }
 
     @Test
@@ -187,7 +187,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/confirm", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("COMPLETED"));
+                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
     }
 
     @Test
@@ -234,7 +234,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
                         .with(userId(200L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("CANCELLED"));
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
     }
 
     @Test
@@ -248,7 +248,7 @@ class TradeControllerTest {
         mockMvc.perform(patch("/api/trades/{id}/cancel", 1L)
                         .with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("CANCELLED"));
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.user.controller;
 
 import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.service.UserService;
@@ -56,7 +57,7 @@ class UserControllerTest {
     void getMyInfo_success() throws Exception {
         UserResponse res = new UserResponse(
                 1L, "user@pokade.com", "트레이너김",
-                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30);
+                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30, Provider.LOCAL);
         given(userService.getMyInfo(1L)).willReturn(res);
 
         mockMvc.perform(get("/api/users/me").with(userId(1L)))
@@ -66,7 +67,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value("트레이너김"))
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andExpect(jsonPath("$.data.status").value("ACTIVE"))
-                .andExpect(jsonPath("$.data.pointBalance").value(30));
+                .andExpect(jsonPath("$.data.pointBalance").value(30))
+                .andExpect(jsonPath("$.data.provider").value("LOCAL"));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #126
- #121
- #122

## ✨ 작업 내용
- OpenAI(Spring AI) 등급 진단 배포 설정 추가 및 배포 프로파일 `dev` → `prod` 전환 (#126)
- 배포 워크플로우(`deploy.yml`)에서 `OPENAI_API_KEY`를 GitHub Secrets로 컨테이너에 주입
- CORS 허용 origin에 운영 도메인(`www.pokade.store`, `pokade.store`) 추가 — 운영 환경 AI 진단 API 401/CORS 오류 핫픽스
- Listing/Trade API 응답을 `ApiResponse` 래퍼로 통일 (#121)
- Controller가 Repository를 직접 참조하던 부분을 Service 경유로 정리, 매직넘버/리터럴 상수화 (#121)
- `CardRateLimitFilterTest`의 `Thread.sleep` 제거 및 극단값 기반 결정론적 테스트로 개선 (#121)
- 사용자 조회 응답에 `provider` 필드 추가 (#122)

## 📸 스크린샷 / 테스트 결과
- 

## 🔍 리뷰 포인트
- 배포 시 `SPRING_PROFILES_ACTIVE` 기본값이 `prod`로 바뀌었으니, 로컬/스테이징에서 `dev`로 돌릴 때는 `.env`에 `SPRING_PROFILES_ACTIVE=dev`를 명시해야 합니다.
- GitHub Actions repo secret `OPENAI_API_KEY` 등록 여부 최종 확인 필요합니다.
- 운영 배포 후 AI 등급 진단 API가 CORS/401 없이 정상 동작하는지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?