### PR TITLE
fix: #126 prod 프로파일에 SMTP 메일 설정 추가

### DIFF
--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -29,6 +29,18 @@ spring:
         options:
           model: ${OPENAI_CHAT_MODEL:gpt-4o-mini}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 # 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
 app:
   cookie:


### PR DESCRIPTION
## 📌 관련 이슈
- #126

## ✨ 작업 내용
- `application-prod.yaml`에 `spring.mail` 설정 추가 (`application-dev.yaml`에만 있고 prod에는 누락되어 있었음)
- prod 프로파일에서 `spring.mail.host` 미설정으로 `JavaMailSender` 빈이 생성되지 않아, `SmtpMailSender` 의존성 주입 실패로 애플리케이션 부팅 자체가 실패하던 문제 수정

## 📸 스크린샷 / 테스트 결과
- EC2에서 prod 프로파일로 재기동 시 `JavaMailSender` 빈 생성 실패로 `APPLICATION FAILED TO START` 발생하던 것을 로그로 확인, 설정 추가 후 재현 확인 예정

## 🔍 리뷰 포인트
- EC2 서버 `.env`에 `MAIL_USERNAME`/`MAIL_PASSWORD`(Gmail 앱 비밀번호) 값이 실제로 채워져 있는지 확인 필요합니다. 값이 비어 있으면 부팅은 되지만 이메일 인증/비밀번호 재설정 등 메일 발송 기능이 SMTP 인증 실패로 동작하지 않을 수 있습니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이메일 발송을 위한 메일 서버 연동이 추가되었습니다.
  * Gmail 기반 SMTP를 통해 인증 및 보안 연결이 지원됩니다.
  * 애플리케이션에서 알림 및 안내 메일을 안정적으로 전송할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->