### PR TITLE
[Feature] #130 급등/급락 카드 랭킹 API 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/RankingType.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/RankingType.java
@@ -1,0 +1,24 @@
+package com.pokade.domain.price;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+
+public enum RankingType {
+    RISE("rise"),
+    FALL("fall");
+
+    private final String code;
+
+    RankingType(String code) {
+        this.code = code;
+    }
+
+    public static RankingType from(String code) {
+        for (RankingType type : values()) {
+            if (type.code.equals(code)) {
+                return type;
+            }
+        }
+        throw new BusinessException(ErrorCode.INVALID_RANKING_TYPE);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -2,6 +2,7 @@ package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
@@ -59,5 +60,10 @@ public class PriceController {
             @RequestParam(required = false) Long variantId
     ) {
         return ApiResponse.ok(priceService.getStats(cardId, variantId));
+    }
+
+    @GetMapping("/ranking")
+    public ApiResponse<List<PriceRankingResponse>> getRanking(@RequestParam String type) {
+        return ApiResponse.ok(priceService.getRanking(type));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/PriceRankingResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/PriceRankingResponse.java
@@ -1,0 +1,31 @@
+package com.pokade.domain.price.dto;
+
+import com.pokade.domain.price.entity.CardPrice;
+
+import java.math.BigDecimal;
+
+public record PriceRankingResponse(
+        Long cardId,
+        String cardName,
+        String imageUrl,
+        String grade,
+        String company,
+        BigDecimal price,
+        String currency,
+        BigDecimal changeRate
+) {
+
+    public static PriceRankingResponse of(CardPrice cardPrice) {
+        var card = cardPrice.getVariant().getCard();
+        return new PriceRankingResponse(
+                card.getId(),
+                card.getName(),
+                card.getImageSmall(),
+                cardPrice.getGrade(),
+                cardPrice.getCompany(),
+                cardPrice.getMarket(),
+                cardPrice.getCurrency(),
+                cardPrice.getChange7dPct()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/entity/CardPrice.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/entity/CardPrice.java
@@ -1,0 +1,50 @@
+package com.pokade.domain.price.entity;
+
+import com.pokade.domain.card.entity.CardVariant;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "card_prices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CardPrice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "variant_id")
+    private CardVariant variant;
+
+    @Column(name = "price_type")
+    private String priceType;
+
+    private String grade;
+
+    private String company;
+
+    private BigDecimal market;
+
+    private String currency;
+
+    @Column(name = "change_7d_pct")
+    private BigDecimal change7dPct;
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/entity/CardPrice.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/entity/CardPrice.java
@@ -17,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "card_prices")
@@ -47,4 +48,7 @@ public class CardPrice {
 
     @Column(name = "change_7d_pct")
     private BigDecimal change7dPct;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/CardPriceRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/CardPriceRepository.java
@@ -1,0 +1,18 @@
+package com.pokade.domain.price.repository;
+
+import com.pokade.domain.price.entity.CardPrice;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface CardPriceRepository extends JpaRepository<CardPrice, Long> {
+
+    @Query("SELECT cp FROM CardPrice cp JOIN FETCH cp.variant v JOIN FETCH v.card c "
+            + "WHERE cp.change7dPct IS NOT NULL ORDER BY cp.change7dPct DESC")
+    List<CardPrice> findTopRising(Pageable pageable);
+
+    @Query("SELECT cp FROM CardPrice cp JOIN FETCH cp.variant v JOIN FETCH v.card c "
+            + "WHERE cp.change7dPct IS NOT NULL ORDER BY cp.change7dPct ASC")
+    List<CardPrice> findTopFalling(Pageable pageable);
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -6,11 +6,15 @@ import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.price.ChartPeriod;
+import com.pokade.domain.price.RankingType;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
+import com.pokade.domain.price.entity.CardPrice;
 import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.price.repository.CardPriceRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.domain.trade.entity.TradeStatus;
@@ -18,6 +22,7 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +43,7 @@ public class PriceService {
     private static final int MAX_SUMMARIES_BATCH_SIZE = 100;
     private static final int STATS_PERIOD_DAYS = 7;
     private static final ListingGrade STATS_GRADE = ListingGrade.S;
+    private static final int RANKING_LIMIT = 10;
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
@@ -45,6 +51,7 @@ public class PriceService {
     private final BuyOfferRepository buyOfferRepository;
     private final TradeRepository tradeRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
+    private final CardPriceRepository cardPriceRepository;
 
     public PriceSummaryResponse getSummary(Long cardId, Long variantId) {
         if (!cardRepository.existsById(cardId)) {
@@ -182,5 +189,19 @@ public class PriceService {
         long changeAmount = diff.setScale(0, RoundingMode.HALF_UP).longValue();
 
         return new PriceStatsResponse(changeRate, changeAmount, volume);
+    }
+
+    // FR-PRICE-06: card_prices.change_7d_pct(Scrydex 동기화 배치가 채우는 값)를 그대로 정렬해 상위 10건을 보여준다.
+    // 카드 단위로 묶지 않고 card_prices 전체 행(variant/grade/company 조합) 중 변동률 상위 10건을 그대로 노출한다.
+    // 동기화 배치가 아직 안 돌아 change_7d_pct가 전부 NULL이면 자연스럽게 빈 목록이 된다.
+    public List<PriceRankingResponse> getRanking(String type) {
+        RankingType rankingType = RankingType.from(type);
+        Pageable topTen = PageRequest.of(0, RANKING_LIMIT);
+
+        List<CardPrice> rows = rankingType == RankingType.RISE
+                ? cardPriceRepository.findTopRising(topTen)
+                : cardPriceRepository.findTopFalling(topTen);
+
+        return rows.stream().map(PriceRankingResponse::of).toList();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_TRADE_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 처리할 수 없는 거래입니다."),
     SELF_PURCHASE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 매물은 구매할 수 없습니다."),
     INVALID_PERIOD(HttpStatus.BAD_REQUEST, "잘못된 기간 값입니다."),
+    INVALID_RANKING_TYPE(HttpStatus.BAD_REQUEST, "잘못된 랭킹 타입입니다."),
 
     PAYMENT_FAILED(HttpStatus.PAYMENT_REQUIRED, "결제에 실패했습니다."),
 

--- a/Pokade/src/test/java/com/pokade/domain/price/RankingTypeTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/RankingTypeTest.java
@@ -1,0 +1,46 @@
+package com.pokade.domain.price;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+
+class RankingTypeTest {
+
+    @Test
+    @DisplayName("t1 rise, fall 코드는 각각 대응하는 랭킹 타입으로 해석된다")
+    void t1() {
+        assertThat(RankingType.from("rise")).isEqualTo(RankingType.RISE);
+        assertThat(RankingType.from("fall")).isEqualTo(RankingType.FALL);
+    }
+
+    @Test
+    @DisplayName("t2 정의되지 않은 코드는 INVALID_RANKING_TYPE 예외가 발생한다")
+    void t2() {
+        assertThatThrownBy(() -> RankingType.from("up"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+    }
+
+    @Test
+    @DisplayName("t3 대소문자가 다르거나 빈 문자열, null이면 INVALID_RANKING_TYPE 예외가 발생한다")
+    void t3() {
+        assertThatThrownBy(() -> RankingType.from("RISE"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+        assertThatThrownBy(() -> RankingType.from(""))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+        assertThatThrownBy(() -> RankingType.from(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
@@ -241,5 +242,64 @@ class PriceControllerTest {
         mockMvc.perform(get("/api/prices/1/stats"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("PRIMARY_VARIANT_NOT_FOUND"));
+    }
+
+    @Test
+    void 급등_랭킹을_조회하면_200과_변동률_상위_목록을_반환한다() throws Exception {
+        List<PriceRankingResponse> ranking = List.of(
+                new PriceRankingResponse(11L, "Mega Lucario ex", "img-11", "10", "PSA",
+                        new BigDecimal("51.20"), "USD", new BigDecimal("8.47")),
+                new PriceRankingResponse(1L, "Charizard", "img-1", "10", "PSA",
+                        new BigDecimal("2567.88"), "USD", new BigDecimal("4.55"))
+        );
+        given(priceService.getRanking("rise")).willReturn(ranking);
+
+        mockMvc.perform(get("/api/prices/ranking").param("type", "rise"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].cardName").value("Mega Lucario ex"))
+                .andExpect(jsonPath("$.data[0].changeRate").value(8.47))
+                .andExpect(jsonPath("$.data[1].cardName").value("Charizard"));
+    }
+
+    @Test
+    void 급락_랭킹을_조회하면_200과_변동률_하위_목록을_반환한다() throws Exception {
+        List<PriceRankingResponse> ranking = List.of(
+                new PriceRankingResponse(8L, "Alakazam GX", "img-8", "10", "PSA",
+                        new BigDecimal("27.40"), "USD", new BigDecimal("-1.08"))
+        );
+        given(priceService.getRanking("fall")).willReturn(ranking);
+
+        mockMvc.perform(get("/api/prices/ranking").param("type", "fall"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].cardName").value("Alakazam GX"))
+                .andExpect(jsonPath("$.data[0].changeRate").value(-1.08));
+    }
+
+    @Test
+    void 랭킹_조회시_배치_미실행_등으로_결과가_없으면_200과_빈_목록을_반환한다() throws Exception {
+        given(priceService.getRanking("rise")).willReturn(List.of());
+
+        mockMvc.perform(get("/api/prices/ranking").param("type", "rise"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void 랭킹_조회시_type_파라미터가_없으면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/prices/ranking"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 랭킹_조회시_잘못된_type_값이면_400을_반환한다() throws Exception {
+        given(priceService.getRanking("up"))
+                .willThrow(new BusinessException(ErrorCode.INVALID_RANKING_TYPE));
+
+        mockMvc.perform(get("/api/prices/ranking").param("type", "up"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_RANKING_TYPE"));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/CardPriceRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/CardPriceRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.pokade.domain.price.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.price.entity.CardPrice;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class CardPriceRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private CardPriceRepository cardPriceRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Long persistCardPrice(String cardName, BigDecimal change7dPct) {
+        Card card = Card.builder().name(cardName).build();
+        entityManager.persist(card);
+
+        CardVariant variant = CardVariant.builder()
+                .card(card)
+                .variantName("holofoil")
+                .primary(true)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(variant);
+
+        CardPrice cardPrice = CardPrice.builder()
+                .variant(variant)
+                .priceType("graded")
+                .grade("10")
+                .company("PSA")
+                .market(new BigDecimal("100.00"))
+                .currency("USD")
+                .change7dPct(change7dPct)
+                .updatedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(cardPrice);
+
+        return card.getId();
+    }
+
+    @Test
+    @DisplayName("t1 변동률 내림차순으로 정렬해 상위 N건을 반환한다")
+    void t1() {
+        persistCardPrice("A", new BigDecimal("1.00"));
+        persistCardPrice("B", new BigDecimal("8.47"));
+        persistCardPrice("C", new BigDecimal("-5.63"));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<CardPrice> result = cardPriceRepository.findTopRising(PageRequest.of(0, 2));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getChange7dPct()).isEqualByComparingTo("8.47");
+        assertThat(result.get(1).getChange7dPct()).isEqualByComparingTo("1.00");
+    }
+
+    @Test
+    @DisplayName("t2 변동률 오름차순(가장 많이 하락한 순)으로 정렬해 상위 N건을 반환한다")
+    void t2() {
+        persistCardPrice("A", new BigDecimal("1.00"));
+        persistCardPrice("B", new BigDecimal("8.47"));
+        persistCardPrice("C", new BigDecimal("-5.63"));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<CardPrice> result = cardPriceRepository.findTopFalling(PageRequest.of(0, 2));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getChange7dPct()).isEqualByComparingTo("-5.63");
+        assertThat(result.get(1).getChange7dPct()).isEqualByComparingTo("1.00");
+    }
+
+    @Test
+    @DisplayName("t3 change_7d_pct가 NULL인 행(동기화 배치 미실행)은 결과에서 제외된다")
+    void t3() {
+        persistCardPrice("A", null);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<CardPrice> risingResult = cardPriceRepository.findTopRising(PageRequest.of(0, 10));
+        List<CardPrice> fallingResult = cardPriceRepository.findTopFalling(PageRequest.of(0, 10));
+
+        assertThat(risingResult).isEmpty();
+        assertThat(fallingResult).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t4 조회 결과의 variant와 card는 JOIN FETCH로 함께 로딩된다")
+    void t4() {
+        persistCardPrice("Charizard", new BigDecimal("3.63"));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<CardPrice> result = cardPriceRepository.findTopRising(PageRequest.of(0, 1));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getVariant().getCard().getName()).isEqualTo("Charizard");
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.price.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.listing.entity.Listing;
@@ -7,9 +9,12 @@ import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
+import com.pokade.domain.price.entity.CardPrice;
 import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.price.repository.CardPriceRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
@@ -22,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -34,6 +40,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PriceServiceTest {
@@ -55,6 +62,9 @@ class PriceServiceTest {
 
     @Mock
     private PriceTradeStatsRepository priceTradeStatsRepository;
+
+    @Mock
+    private CardPriceRepository cardPriceRepository;
 
     @InjectMocks
     private PriceService priceService;
@@ -350,5 +360,73 @@ class PriceServiceTest {
                 return price;
             }
         };
+    }
+
+    private CardPrice cardPrice(String cardName, String grade, BigDecimal changeRate) {
+        Card card = Card.builder().name(cardName).build();
+        CardVariant variant = CardVariant.builder().card(card).variantName("holofoil").primary(true).build();
+        return CardPrice.builder()
+                .variant(variant)
+                .priceType("graded")
+                .grade(grade)
+                .company("PSA")
+                .market(new BigDecimal("100.00"))
+                .currency("USD")
+                .change7dPct(changeRate)
+                .build();
+    }
+
+    @Test
+    @DisplayName("t17 type이 rise면 변동률 상위 10건을 급등 목록으로 조회한다")
+    void t17() {
+        List<CardPrice> rows = List.of(
+                cardPrice("Mega Lucario ex", "10", new BigDecimal("8.47")),
+                cardPrice("Charizard", "10", new BigDecimal("4.55"))
+        );
+        given(cardPriceRepository.findTopRising(eq(PageRequest.of(0, 10)))).willReturn(rows);
+
+        List<PriceRankingResponse> result = priceService.getRanking("rise");
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).cardName()).isEqualTo("Mega Lucario ex");
+        assertThat(result.get(0).changeRate()).isEqualByComparingTo("8.47");
+        assertThat(result.get(1).cardName()).isEqualTo("Charizard");
+        verify(cardPriceRepository, never()).findTopFalling(any());
+    }
+
+    @Test
+    @DisplayName("t18 type이 fall이면 변동률 하위 10건을 급락 목록으로 조회한다")
+    void t18() {
+        List<CardPrice> rows = List.of(
+                cardPrice("Alakazam GX", "10", new BigDecimal("-1.08"))
+        );
+        given(cardPriceRepository.findTopFalling(eq(PageRequest.of(0, 10)))).willReturn(rows);
+
+        List<PriceRankingResponse> result = priceService.getRanking("fall");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).cardName()).isEqualTo("Alakazam GX");
+        assertThat(result.get(0).changeRate()).isEqualByComparingTo("-1.08");
+        verify(cardPriceRepository, never()).findTopRising(any());
+    }
+
+    @Test
+    @DisplayName("t19 잘못된 type 값이면 INVALID_RANKING_TYPE 예외가 발생하고 리포지토리를 조회하지 않는다")
+    void t19() {
+        assertThatThrownBy(() -> priceService.getRanking("up"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+        verifyNoInteractions(cardPriceRepository);
+    }
+
+    @Test
+    @DisplayName("t20 동기화 배치 미실행 등으로 조회 결과가 없으면 빈 목록을 반환한다")
+    void t20() {
+        given(cardPriceRepository.findTopRising(eq(PageRequest.of(0, 10)))).willReturn(List.of());
+
+        List<PriceRankingResponse> result = priceService.getRanking("rise");
+
+        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #130 

## ✨ 작업 내용
- FR-PRICE-06: 급등/급락 카드 랭킹 API 구현 (`GET /api/prices/ranking?type=rise|fall`)
- `card_prices.change_7d_pct`(Scrydex 동기화 배치가 채우는 값)를 그대로 정렬해 상위 10건을 반환 — 새로운 집계 배치는 추가하지 않음
- 카드 단위로 묶지 않고 `card_prices` 원본 행(variant/grade/company 조합) 중 변동률 상위 10건을 그대로 노출
- `change_7d_pct`가 전부 NULL(동기화 배치 미실행)이면 자동으로 빈 목록 반환
- `RankingType` enum 추가 (`rise`/`fall` 파싱, 잘못된 값은 `ErrorCode.INVALID_RANKING_TYPE`로 400)
- `CardPrice` 엔티티/`CardPriceRepository` 신규 추가 (`card_prices` 테이블 최초 매핑 — 기존엔 이 테이블을 읽는 코드가 없었음), `domain.card`의 `CardVariant`/`Card` 엔티티 재사용
- 보안: 별도 `permitAll()` 추가하지 않아 기존 `/trades`, `/chart`, `/stats`와 동일하게 로그인(JWT) 필요

## 📸 스크린샷 / 테스트 결과
- 로컬에서 `SPRING_PROFILES_ACTIVE=dev`로 앱 기동 후 회원가입 → 이메일 인증 상태 수동 처리 → 로그인 → JWT로 직접 curl 검증
  - `type=rise` → `change_7d_pct` 내림차순 top 10 (1위 Mega Lucario ex PSA10, +8.47%)
  - `type=fall` → 오름차순 top 10 (1위 Alakazam GX PSA10, -1.08%)
  - `type` 누락 → 400 `INVALID_INPUT`, 잘못된 값(`up`) → 400 `INVALID_RANKING_TYPE`, 토큰 없이 요청 → 401 `UNAUTHORIZED` 모두 확인
- `./gradlew test` 전체 366개 테스트 통과 (신규 추가분 16개 포함: `RankingTypeTest` 3, `CardPriceRepositoryTest` 4, `PriceServiceTest`/`PriceControllerTest` 각 4/5)

## 🔍 리뷰 포인트
- `card_prices`를 카드 단위로 그룹핑하지 않고 원본 행 그대로 top 10을 뽑는 설계가 맞는지 (동일 카드가 등급별로 여러 번 랭킹에 노출될 수 있음)
- `GET /api/prices/ranking`을 로그인 필요로 남겨둔 것(공개 페이지에서 보여줄 거면 `permitAll()` 추가 필요)
- `CardPrice` 엔티티가 `card_prices`의 일부 컬럼만 매핑하고 있는 점(프로젝트 컨벤션상 의도된 것)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카드 가격 상승·하락 랭킹 조회 기능을 추가했습니다.
  * 랭킹별 상위 10개 카드의 이름, 이미지, 등급, 가격, 통화, 7일 변동률을 제공합니다.
  * 잘못된 랭킹 유형이나 누락된 요청에는 명확한 오류 응답을 반환합니다.

* **테스트**
  * 상승·하락 조회, 빈 결과, 잘못된 입력 및 가격 변동률 정렬을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->