### PR TITLE
[Feature] #132 회원 탈퇴

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -71,8 +71,13 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
 
-        if (user.getStatus() != UserStatus.ACTIVE) {
-            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED); // 미인증은 실패로 안 셈
+        switch (user.getStatus()) {
+            case PENDING -> throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+            case SUSPENDED -> throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+            case DELETED -> throw new BusinessException(ErrorCode.LOGIN_FAILED);
+            case ACTIVE, WITHDRAWAL_PENDING -> {
+                // 로그인 허용
+            }
         }
 
         loginAttemptStore.reset(email); // 로그인 성공 시 실패 기록 초기화

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -45,4 +45,10 @@ public class UserController {
         withdrawalService.requestWithdrawal(userId, request.password());
         return ApiResponse.ok("탈퇴 신청이 접수되었습니다.");
     }
+
+    @PostMapping("/me/withdrawal/cancel")
+    public ApiResponse<Void> cancelWithdrawal(@AuthenticationPrincipal Long userId) {
+        withdrawalService.cancelWithdrawal(userId);
+        return ApiResponse.ok("탈퇴 신청이 철회되었습니다.");
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -2,8 +2,10 @@ package com.pokade.domain.user.controller;
 
 import com.pokade.domain.user.dto.request.NicknameUpdateRequest;
 import com.pokade.domain.user.dto.request.PasswordUpdateRequest;
+import com.pokade.domain.user.dto.request.WithdrawalRequest;
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.service.UserService;
+import com.pokade.domain.user.service.WithdrawalService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final WithdrawalService withdrawalService;
 
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
@@ -34,5 +37,12 @@ public class UserController {
                                             @Valid @RequestBody PasswordUpdateRequest request) {
         userService.changePassword(userId, request.currentPassword(), request.newPassword());
         return ApiResponse.ok("비밀번호가 변경되었습니다.");
+    }
+
+    @DeleteMapping("/me")
+    public ApiResponse<Void> requestWithdrawal(@AuthenticationPrincipal Long userId,
+                                               @Valid @RequestBody WithdrawalRequest request) {
+        withdrawalService.requestWithdrawal(userId, request.password());
+        return ApiResponse.ok("탈퇴 신청이 접수되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/request/WithdrawalRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/request/WithdrawalRequest.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawalRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -67,6 +67,9 @@ public class User {
     @Column(name = "deleted_at")
     private LocalDateTime deleted_At;
 
+    @Column(name = "withdrawal_requested_at")
+    private LocalDateTime withdrawalRequestedAt;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime created_At;
@@ -114,6 +117,18 @@ public class User {
     // 비밀번호를 변경한다 (인코딩된 값)
     public void changePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    // 탈퇴를 신청한다 (유예 상태로 전환하고 신청 시각을 기록)
+    public void requestWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.WITHDRAWAL_PENDING;
+        this.withdrawalRequestedAt = now;
+    }
+
+    // 탈퇴 신청을 철회한다 (활성 상태로 복구)
+    public void cancelWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.ACTIVE;
+        this.withdrawalRequestedAt = null;
     }
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -126,9 +126,20 @@ public class User {
     }
 
     // 탈퇴 신청을 철회한다 (활성 상태로 복구)
-    public void cancelWithdrawal(LocalDateTime now) {
+    public void cancelWithdrawal() {
         this.status = UserStatus.ACTIVE;
         this.withdrawalRequestedAt = null;
     }
 
+    // 탈퇴 확정 — soft-delete + 회원정보 익명화(email·nickname은 UNIQUE라 재가입 재사용 위해 비충돌 값 치환)
+    public void confirmWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.DELETED;
+        this.deleted_At = now;
+        this.email = "deleted_" + id + "@pokade.invalid";
+        this.nickname = "deleted_" + id;
+        this.password = null;
+        this.phoneNumber = null;
+        this.birthDate = null;
+        this.profileImageUrl = null;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
@@ -3,6 +3,7 @@ package com.pokade.domain.user.entity.type;
 public enum UserStatus {
     PENDING,
     ACTIVE,
+    WITHDRAWAL_PENDING,
     SUSPENDED,
     DELETED
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.pokade.domain.user.repository;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,5 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+
+    List<User> findAllByStatusAndWithdrawalRequestedAtBefore(UserStatus status, LocalDateTime cutoff);
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/UserAccessGuard.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/UserAccessGuard.java
@@ -1,0 +1,26 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserAccessGuard implements UserAccessChecker {
+    private final UserRepository userRepository;
+
+
+    @Override
+    public void assertWritable(Long userId) {
+        UserStatus status = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .getStatus();
+        if (status != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE);
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -41,17 +41,17 @@ public class WithdrawalService {
         eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
     }
 
-    // 탈최 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
+    // 탈퇴 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
     @Transactional
-    public void cancelWithdrawal(Long userUd) {
-        User user = userRepository.findById(userUd)
+    public void cancelWithdrawal(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
             throw new BusinessException(ErrorCode.NOT_WITHDRAWAL_PENDING);
         }
 
-        user.cancelWithdrawal(LocalDateTime.now());
-        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userUd));
+        user.cancelWithdrawal();
+        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userId));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -3,6 +3,7 @@ package com.pokade.domain.user.service;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -38,5 +39,19 @@ public class WithdrawalService {
 
         user.requestWithdrawal(LocalDateTime.now());
         eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
+    }
+
+    // 탈최 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
+    @Transactional
+    public void cancelWithdrawal(Long userUd) {
+        User user = userRepository.findById(userUd)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            throw new BusinessException(ErrorCode.NOT_WITHDRAWAL_PENDING);
+        }
+
+        user.cancelWithdrawal(LocalDateTime.now());
+        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userUd));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -1,19 +1,24 @@
 package com.pokade.domain.user.service;
 
+import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.TokenBlacklistStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,10 @@ public class WithdrawalService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
+    private final RefreshTokenStore refreshTokenStore;
+    private final TokenBlacklistStore tokenBlacklistStore;
+
+    private static final int GRACE_PERIOD_DAYS = 7;
 
     // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
     @Transactional
@@ -53,5 +62,23 @@ public class WithdrawalService {
 
         user.cancelWithdrawal();
         eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userId));
+    }
+
+    // 유예(7일) 지난 탈퇴 신청을 확정 = soft-delete·익명화·토큰 무효화·이벤트 발행
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void confirmExpiredWithdrawals() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime cutoff = now.minusDays(GRACE_PERIOD_DAYS);
+
+        List<User> targets = userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
+                UserStatus.WITHDRAWAL_PENDING, cutoff);
+
+        for (User user : targets) {
+            user.confirmWithdrawal(now);
+            refreshTokenStore.delete(user.getId());
+            tokenBlacklistStore.blacklist(user.getId());
+            eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));
+        }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -1,0 +1,42 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawalService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
+    @Transactional
+    public void requestWithdrawal(Long userId, String password) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_NOT_ALLOWED);
+        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        user.requestWithdrawal(LocalDateTime.now());
+        eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalCancelledEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalCancelledEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawalCancelledEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalRequestedEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalRequestedEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawalRequestedEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawnEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawnEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawnEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     // ===== 회원 정지 =====
     ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 고객센터에 문의해주세요."),
+    ACCOUNT_NOT_ACTIVE(HttpStatus.FORBIDDEN, "현재 계정 상태에서는 이용할 수 없는 기능입니다."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
     PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
 
+    // ===== 회원 탈퇴 =====
+    WITHDRAWAL_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 탈퇴 신청을 할 수 없습니다."),
+
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),
 

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -32,10 +32,10 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
-    LOGIN_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS,"로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+    LOGIN_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     TOKEN_STOLEN(HttpStatus.UNAUTHORIZED, "비정상적인 접근이 감지되어 로그아웃되었습니다."),
-    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN,"이메일 인증이 완료되지 않았습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
     EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
@@ -50,6 +50,10 @@ public enum ErrorCode {
 
     // ===== 회원 탈퇴 =====
     WITHDRAWAL_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 탈퇴 신청을 할 수 없습니다."),
+    NOT_WITHDRAWAL_PENDING(HttpStatus.CONFLICT, "탈퇴 진행 중인 계정이 아닙니다."),
+
+    // ===== 회원 정지 =====
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 고객센터에 문의해주세요."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),

--- a/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
+++ b/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
@@ -1,0 +1,5 @@
+package com.pokade.global.port;
+
+public interface UserAccessChecker {
+    void assertWritable (Long userId);
+}

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenBlacklistStore tokenBlacklistStore;
 
 
     // 매 요청마다 실행 — Authorization 헤더의 토큰을 확인해 인증 상태를 세팅
@@ -32,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = jwtTokenProvider.getUserId(token);
                 String role = jwtTokenProvider.getRole(token);
                 // 토큰이 유효하면 인증 객체를 만들어 SecurityContext에 등록
-                if (userId != null && role != null) {
+                if (userId != null && role != null && !tokenBlacklistStore.contains(userId)) {
                     List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);

--- a/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
+++ b/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
@@ -1,0 +1,29 @@
+package com.pokade.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisTokenBlacklistStore implements TokenBlacklistStore {
+
+    private static final String BLACKLIST_KEY_PREFIX = "auth:blacklist:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtProperties jwtProperties;
+
+    // 유저를 블랙리스트에 등록 (TTL = access 만료 - 그 뒤엔 ccess가 자연 만료라 불필요)
+    @Override
+    public void blacklist(Long userId) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_KEY_PREFIX + userId, "1", jwtProperties.accessExpiration()
+        );
+    }
+
+    // 블랙리스트 등록 여부
+    @Override
+    public boolean contains(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/TokenBlacklistStore.java
+++ b/Pokade/src/main/java/com/pokade/global/security/TokenBlacklistStore.java
@@ -1,0 +1,6 @@
+package com.pokade.global.security;
+
+public interface TokenBlacklistStore {
+    void blacklist(Long userId);
+    boolean contains(Long userId);
+}

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS users (
     nickname_changed_at   TIMESTAMP,
     provider              VARCHAR(20) NOT NULL,                -- LOCAL / GOOGLE / KAKAO
     role                  VARCHAR(20) NOT NULL,                -- USER / ADMIN
-    status                VARCHAR(20) NOT NULL,                -- PENDING / ACTIVE / SUSPENDED / DELETED
+    status                VARCHAR(20) NOT NULL,                -- PENDING / ACTIVE / SUSPENDED / WITHDRAWAL_PENDING / DELETED
     profile_image_url     VARCHAR(255),
     birth_date            DATE,
     phone_number          VARCHAR(20),
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS users (
     marketing_opt_in      BOOLEAN NOT NULL DEFAULT FALSE,      -- 선택 동의(마케팅 수신)
     point_balance         INTEGER NOT NULL DEFAULT 0,
     deleted_at            TIMESTAMP,
+    withdrawal_requested_at TIMESTAMP,
     created_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserAccessGuardTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserAccessGuardTest.java
@@ -1,0 +1,74 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccessGuardTest {
+
+    @Mock UserRepository userRepository;
+    @InjectMocks UserAccessGuard userAccessGuard;
+
+    private User userWith(UserStatus status) {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(status).pointBalance(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ACTIVE면 통과")
+    void active_ok() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.ACTIVE)));
+
+        assertThatCode(() -> userAccessGuard.assertWritable(1L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("유예중(WITHDRAWAL_PENDING)이면 ACCOUNT_NOT_ACTIVE")
+    void pending_blocked() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.WITHDRAWAL_PENDING)));
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCOUNT_NOT_ACTIVE);
+    }
+
+    @Test
+    @DisplayName("정지(SUSPENDED)면 ACCOUNT_NOT_ACTIVE")
+    void suspended_blocked() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.SUSPENDED)));
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCOUNT_NOT_ACTIVE);
+    }
+
+    @Test
+    @DisplayName("유저 없으면 USER_NOT_FOUND")
+    void notFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
@@ -1,0 +1,159 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.auth.store.RefreshTokenStore;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalCancelledEvent;
+import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.event.UserWithdrawnEvent;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.TokenBlacklistStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawalServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock RefreshTokenStore refreshTokenStore;
+    @Mock TokenBlacklistStore tokenBlacklistStore;
+    @InjectMocks WithdrawalService withdrawalService;
+
+    private User activeUser() {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+    }
+
+    private User pendingUser() {
+        User u = User.builder()
+                .id(2L).email("bye@pokade.com").password("ENCODED_PW")
+                .nickname("바이").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+        u.requestWithdrawal(LocalDateTime.now().minusDays(8)); // ACTIVE -> WITHDRAWAL_PENDING
+        return u;
+    }
+
+    // ===== 신청 =====
+    @Test
+    @DisplayName("신청: ACTIVE + 올바른 비번이면 유예 전환 + 이벤트 발행")
+    void requestWithdrawal_success() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("rawpw", "ENCODED_PW")).willReturn(true);
+
+        withdrawalService.requestWithdrawal(1L, "rawpw");
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWAL_PENDING);
+        assertThat(user.getWithdrawalRequestedAt()).isNotNull();
+        then(eventPublisher).should().publishEvent(any(UserWithdrawalRequestedEvent.class));
+    }
+
+    @Test
+    @DisplayName("신청: ACTIVE 아니면 WITHDRAWAL_NOT_ALLOWED")
+    void requestWithdrawal_notActive() {
+        User user = pendingUser();
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> withdrawalService.requestWithdrawal(2L, "rawpw"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_NOT_ALLOWED);
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("신청: 비번 불일치면 INVALID_CURRENT_PASSWORD")
+    void requestWithdrawal_wrongPassword() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong", "ENCODED_PW")).willReturn(false);
+
+        assertThatThrownBy(() -> withdrawalService.requestWithdrawal(1L, "wrong"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CURRENT_PASSWORD);
+    }
+
+    // ===== 철회 =====
+    @Test
+    @DisplayName("철회: 유예 상태면 ACTIVE 복구 + 이벤트 발행")
+    void cancelWithdrawal_success() {
+        User user = pendingUser();
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        withdrawalService.cancelWithdrawal(2L);
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getWithdrawalRequestedAt()).isNull();
+        then(eventPublisher).should().publishEvent(any(UserWithdrawalCancelledEvent.class));
+    }
+
+    @Test
+    @DisplayName("철회: 유예 상태 아니면 NOT_WITHDRAWAL_PENDING")
+    void cancelWithdrawal_notPending() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> withdrawalService.cancelWithdrawal(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOT_WITHDRAWAL_PENDING);
+    }
+
+    // ===== 확정 배치 =====
+    @Test
+    @DisplayName("확정: 유예 만료분을 DELETED 익명화 + 토큰 무효화·블랙리스트·이벤트")
+    void confirmExpiredWithdrawals_confirms() {
+        User user = pendingUser();
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
+                eq(UserStatus.WITHDRAWAL_PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(user));
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
+        assertThat(user.getNickname()).isEqualTo("deleted_2");
+        assertThat(user.getPassword()).isNull();
+        then(refreshTokenStore).should().delete(2L);
+        then(tokenBlacklistStore).should().blacklist(2L);
+        then(eventPublisher).should().publishEvent(any(UserWithdrawnEvent.class));
+    }
+
+    @Test
+    @DisplayName("확정: 대상 없으면 아무 것도 안 함")
+    void confirmExpiredWithdrawals_empty() {
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(any(), any()))
+                .willReturn(List.of());
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(refreshTokenStore).should(never()).delete(any());
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -26,7 +26,8 @@ class JwtAuthenticationFilterTest {
 
     private final JwtTokenProvider jwtTokenProvider =
             new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30), Duration.ofDays(14)));
-    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+    private final TokenBlacklistStore tokenBlacklistStore = mock(TokenBlacklistStore.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistStore);
 
     @AfterEach
     void clearContext() {


### PR DESCRIPTION
## 📌 관련 이슈
- close #132

## ✨ 작업 내용
회원 탈퇴(FR-AUTH-13) auth 도메인 구현입니다. **이벤트 방식**으로, 각 도메인 데이터 처리는 리스너로 위임합니다.

- **라이프사이클**: 신청(`DELETE /api/users/me`) → 7일 유예(`WITHDRAWAL_PENDING`) → 철회(`POST /api/users/me/withdrawal/cancel`) → 자동 확정(스케줄러 soft-delete)
- **로그인 게이트**: 유예중 로그인 허용(철회 목적), 정지·삭제는 차단 (`AuthService.login` status 분기)
- **확정 처리**: 회원정보 익명화(email/nickname `deleted_{id}`·PII null) + refresh 무효화 + Redis 블랙리스트(30분) + `UserWithdrawnEvent` 발행
- **cross-domain**: 이벤트 3종 발행(`UserWithdrawalRequested`/`Withdrawn`/`WithdrawalCancelled`, `global/event`) — 각 도메인 리스너는 별도(협조 요청 예정)
- **유예중 쓰기 차단**: 공용 포트 `UserAccessChecker`(`global/port`) 제공 — 각 도메인이 쓰기 앞에서 `assertWritable(userId)` 호출(도메인 간 결합 없이 DIP)
- **단위 테스트 11건**: `WithdrawalServiceTest`(7) + `UserAccessGuardTest`(4)

## 📸 테스트 결과
- `./gradlew test` — `WithdrawalServiceTest` 7건, `UserAccessGuardTest` 4건 통과
- 로컬 e2e: 신청 → 재로그인(게이트 통과) → 철회, 확정 배치 back-date 검증(DELETED·익명화·refresh 삭제·블랙리스트 TTL≈30분·탈퇴 계정 로그인 차단), 유예중/ACTIVE 대조군 무변화·멱등 확인

## 🔍 리뷰 포인트
- `AuthService.login` status 분기 (WITHDRAWAL_PENDING 허용)
- `JwtAuthenticationFilter` 블랙리스트 조회 — 의도된 최소 stateful(status 확인은 서비스 계층)
- 확정 스케줄러 멱등성 + 익명화 UNIQUE 비충돌(`deleted_{id}`) 처리
- 이벤트/포트 위치 `global/event`·`global/port` (도메인 간 직접 참조·순환 방지)

## ⚠️ 배포 전 필수
- 운영 DB 수동 ALTER (prod `ddl-auto: validate` + `sql.init: never`):
  ```sql
  ALTER TABLE users ADD COLUMN withdrawal_requested_at TIMESTAMP;
  ```

## 🔜 후속(별도, 이 PR 범위 밖)
- 각 도메인 이벤트 리스너 구현 + 유예중 쓰기 게이팅 `assertWritable` 적용 (§ 팀 공유)
- 협의: 진행 중 거래 강제취소 기준 / 마스킹 데이터 완전삭제 배치 소유

## ✅ 체크리스트
- [x] 커밋 컨벤션 준수
- [x] 로컬 빌드 / 테스트 성공
- [x] 관련 문서 수정(설계 문서 · 정책.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 비밀번호 확인을 통한 회원 탈퇴 신청 및 철회 기능을 추가했습니다.
  - 탈퇴 신청 후 7일 유예기간이 지나면 계정을 삭제하고 개인정보를 익명화합니다.
  - 탈퇴 완료 계정의 토큰을 차단해 재사용을 방지합니다.

- **개선 사항**
  - 이메일 미인증, 정지, 탈퇴 대기 등 계정 상태별 로그인 처리를 세분화했습니다.
  - 비활성 계정의 주요 변경 작업을 제한합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->