### PR TITLE
chore: develop → main 자동 배포 반영

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -71,8 +71,13 @@ public class AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
 
-        if (user.getStatus() != UserStatus.ACTIVE) {
-            throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED); // 미인증은 실패로 안 셈
+        switch (user.getStatus()) {
+            case PENDING -> throw new BusinessException(ErrorCode.EMAIL_NOT_VERIFIED);
+            case SUSPENDED -> throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+            case DELETED -> throw new BusinessException(ErrorCode.LOGIN_FAILED);
+            case ACTIVE, WITHDRAWAL_PENDING -> {
+                // 로그인 허용
+            }
         }
 
         loginAttemptStore.reset(email); // 로그인 성공 시 실패 기록 초기화

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -109,30 +109,33 @@ public class AuthService {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
-
-        if (refreshTokenStore.compareAndRotate(userId, refreshToken, newRefreshToken)) {
-            String newAccessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-            return new TokenPair(newAccessToken, newRefreshToken); // Option X: refresh 재
-        }
-
-        if (refreshTokenStore.matchesGrace(userId, refreshToken)) { // 직전 refresh(동시요청) -> 새 access만
-            String accessToken = jwtTokenProvider.createAccessToken(userId, findRole(userId));
-            return new TokenPair(accessToken, null); // Option Y: refresh 재발급,재세팅 안 함
-        }
-
-        refreshTokenStore.delete(userId); // 키는 있는데 어느 것과도 불일치 -> 탈취 의심, 전면 폐기
-        throw new BusinessException(ErrorCode.TOKEN_STOLEN);
-    }
-
-
-    private String findRole(Long userId) {
-        return userRepository.findById(userId)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> {
                     refreshTokenStore.delete(userId);
                     return new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
-                })
-                .getRole().name();
+                });
+
+        // 로그인 가능한 상태 (ACTIVE 유예)만 재발급 허용 - SUSPENDED / DELETED / PENDING 은 저장 refresh 폐기 후 거부
+        if (user.getStatus() != UserStatus.ACTIVE && user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            refreshTokenStore.delete(userId);
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String role = user.getRole().name();
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        if (refreshTokenStore.compareAndRotate(userId, refreshToken, newRefreshToken)) {
+            String newAccessToken = jwtTokenProvider.createAccessToken(userId, role);
+            return new TokenPair(newAccessToken, newRefreshToken);
+        }
+
+        if (refreshTokenStore.matchesGrace(userId, refreshToken)) {
+            String accessToken = jwtTokenProvider.createAccessToken(userId, role);
+            return new TokenPair(accessToken, null); // Option Y : refresh 세팅 안함
+        }
+
+        refreshTokenStore.delete(userId);
+        throw new BusinessException(ErrorCode.TOKEN_STOLEN);
     }
 
     @PostConstruct

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -45,4 +45,10 @@ public class UserController {
         withdrawalService.requestWithdrawal(userId, request.password());
         return ApiResponse.ok("탈퇴 신청이 접수되었습니다.");
     }
+
+    @PostMapping("/me/withdrawal/cancel")
+    public ApiResponse<Void> cancelWithdrawal(@AuthenticationPrincipal Long userId) {
+        withdrawalService.cancelWithdrawal(userId);
+        return ApiResponse.ok("탈퇴 신청이 철회되었습니다.");
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -2,8 +2,10 @@ package com.pokade.domain.user.controller;
 
 import com.pokade.domain.user.dto.request.NicknameUpdateRequest;
 import com.pokade.domain.user.dto.request.PasswordUpdateRequest;
+import com.pokade.domain.user.dto.request.WithdrawalRequest;
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.service.UserService;
+import com.pokade.domain.user.service.WithdrawalService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final WithdrawalService withdrawalService;
 
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
@@ -34,5 +37,12 @@ public class UserController {
                                             @Valid @RequestBody PasswordUpdateRequest request) {
         userService.changePassword(userId, request.currentPassword(), request.newPassword());
         return ApiResponse.ok("비밀번호가 변경되었습니다.");
+    }
+
+    @DeleteMapping("/me")
+    public ApiResponse<Void> requestWithdrawal(@AuthenticationPrincipal Long userId,
+                                               @Valid @RequestBody WithdrawalRequest request) {
+        withdrawalService.requestWithdrawal(userId, request.password());
+        return ApiResponse.ok("탈퇴 신청이 접수되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/request/WithdrawalRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/request/WithdrawalRequest.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WithdrawalRequest(
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -78,6 +78,10 @@ public class User {
     @Column(name = "updated_at")
     private LocalDateTime updated_At;
 
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
     public static User createLocalUser(String email, String encodedPassword, String nickname) {
         return User.builder()
                 .email(email)

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -67,6 +67,9 @@ public class User {
     @Column(name = "deleted_at")
     private LocalDateTime deleted_At;
 
+    @Column(name = "withdrawal_requested_at")
+    private LocalDateTime withdrawalRequestedAt;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime created_At;
@@ -114,6 +117,18 @@ public class User {
     // 비밀번호를 변경한다 (인코딩된 값)
     public void changePassword(String encodedPassword) {
         this.password = encodedPassword;
+    }
+
+    // 탈퇴를 신청한다 (유예 상태로 전환하고 신청 시각을 기록)
+    public void requestWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.WITHDRAWAL_PENDING;
+        this.withdrawalRequestedAt = now;
+    }
+
+    // 탈퇴 신청을 철회한다 (활성 상태로 복구)
+    public void cancelWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.ACTIVE;
+        this.withdrawalRequestedAt = null;
     }
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -126,9 +126,20 @@ public class User {
     }
 
     // 탈퇴 신청을 철회한다 (활성 상태로 복구)
-    public void cancelWithdrawal(LocalDateTime now) {
+    public void cancelWithdrawal() {
         this.status = UserStatus.ACTIVE;
         this.withdrawalRequestedAt = null;
     }
 
+    // 탈퇴 확정 — soft-delete + 회원정보 익명화(email·nickname은 UNIQUE라 재가입 재사용 위해 비충돌 값 치환)
+    public void confirmWithdrawal(LocalDateTime now) {
+        this.status = UserStatus.DELETED;
+        this.deleted_At = now;
+        this.email = "deleted_" + id + "@pokade.invalid";
+        this.nickname = "deleted_" + id;
+        this.password = null;
+        this.phoneNumber = null;
+        this.birthDate = null;
+        this.profileImageUrl = null;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/type/UserStatus.java
@@ -3,6 +3,7 @@ package com.pokade.domain.user.entity.type;
 public enum UserStatus {
     PENDING,
     ACTIVE,
+    WITHDRAWAL_PENDING,
     SUSPENDED,
     DELETED
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
@@ -1,9 +1,12 @@
 package com.pokade.domain.user.repository;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,5 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
 
     Optional<User> findByEmail(String email);
+
+
+    List<User> findAllByStatusAndWithdrawalRequestedAtBefore(UserStatus status, LocalDateTime cutoff);
 
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/UserAccessGuard.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/UserAccessGuard.java
@@ -1,0 +1,26 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserAccessGuard implements UserAccessChecker {
+    private final UserRepository userRepository;
+
+
+    @Override
+    public void assertWritable(Long userId) {
+        UserStatus status = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .getStatus();
+        if (status != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE);
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
@@ -1,0 +1,35 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawnEvent;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class WithdrawalConfirmer {
+
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 유저 한 명의 탈퇴를 확정한다 (건별 독립 트랜잭션). 실제 확정하면 true, 그새 철회/확정돼 건너뛰면 false
+    @Transactional
+    public boolean confirm(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            return false; // 멱등 skip - 그새 철회(ACTIVE)됐거나 이미 확정 (DELETED)
+        }
+        user.confirmWithdrawal(LocalDateTime.now());
+        eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
+        return true;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -41,17 +41,17 @@ public class WithdrawalService {
         eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
     }
 
-    // 탈최 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
+    // 탈퇴 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
     @Transactional
-    public void cancelWithdrawal(Long userUd) {
-        User user = userRepository.findById(userUd)
+    public void cancelWithdrawal(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
             throw new BusinessException(ErrorCode.NOT_WITHDRAWAL_PENDING);
         }
 
-        user.cancelWithdrawal(LocalDateTime.now());
-        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userUd));
+        user.cancelWithdrawal();
+        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userId));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -3,6 +3,7 @@ package com.pokade.domain.user.service;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -38,5 +39,19 @@ public class WithdrawalService {
 
         user.requestWithdrawal(LocalDateTime.now());
         eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
+    }
+
+    // 탈최 신청을 철회한다(유예 상태에서만, 활성 복구 + 이벤트 발생)
+    @Transactional
+    public void cancelWithdrawal(Long userUd) {
+        User user = userRepository.findById(userUd)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
+            throw new BusinessException(ErrorCode.NOT_WITHDRAWAL_PENDING);
+        }
+
+        user.cancelWithdrawal(LocalDateTime.now());
+        eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userUd));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -1,19 +1,24 @@
 package com.pokade.domain.user.service;
 
+import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.TokenBlacklistStore;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,10 @@ public class WithdrawalService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
+    private final RefreshTokenStore refreshTokenStore;
+    private final TokenBlacklistStore tokenBlacklistStore;
+
+    private static final int GRACE_PERIOD_DAYS = 7;
 
     // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
     @Transactional
@@ -53,5 +62,23 @@ public class WithdrawalService {
 
         user.cancelWithdrawal();
         eventPublisher.publishEvent(new UserWithdrawalCancelledEvent(userId));
+    }
+
+    // 유예(7일) 지난 탈퇴 신청을 확정 = soft-delete·익명화·토큰 무효화·이벤트 발행
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void confirmExpiredWithdrawals() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime cutoff = now.minusDays(GRACE_PERIOD_DAYS);
+
+        List<User> targets = userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
+                UserStatus.WITHDRAWAL_PENDING, cutoff);
+
+        for (User user : targets) {
+            user.confirmWithdrawal(now);
+            refreshTokenStore.delete(user.getId());
+            tokenBlacklistStore.blacklist(user.getId());
+            eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));
+        }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -6,11 +6,11 @@ import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
-import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.TokenBlacklistStore;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WithdrawalService {
@@ -31,6 +32,7 @@ public class WithdrawalService {
     private final TokenBlacklistStore tokenBlacklistStore;
 
     private static final int GRACE_PERIOD_DAYS = 7;
+    private final WithdrawalConfirmer withdrawalConfirmer;
 
     // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
     @Transactional
@@ -66,19 +68,23 @@ public class WithdrawalService {
 
     // 유예(7일) 지난 탈퇴 신청을 확정 = soft-delete·익명화·토큰 무효화·이벤트 발행
     @Scheduled(cron = "0 0 4 * * *")
-    @Transactional
     public void confirmExpiredWithdrawals() {
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime cutoff = now.minusDays(GRACE_PERIOD_DAYS);
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(GRACE_PERIOD_DAYS);
 
-        List<User> targets = userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
-                UserStatus.WITHDRAWAL_PENDING, cutoff);
+        List<Long> targetIds = userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(UserStatus.WITHDRAWAL_PENDING, cutoff)
+                .stream()
+                .map(User::getId)
+                .toList();
 
-        for (User user : targets) {
-            user.confirmWithdrawal(now);
-            refreshTokenStore.delete(user.getId());
-            tokenBlacklistStore.blacklist(user.getId());
-            eventPublisher.publishEvent(new UserWithdrawnEvent(user.getId()));
+        for (Long userId : targetIds) {
+            try {
+                if (withdrawalConfirmer.confirm(userId)) {
+                    refreshTokenStore.delete(userId);
+                    tokenBlacklistStore.blacklist(userId);
+                }
+            } catch (Exception e) {
+                log.error("탈퇴 확정 실패 - 다음 대상 계속 진행 (userId={})", userId, e);
+            }
         }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -1,0 +1,42 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawalService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
+
+    // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
+    @Transactional
+    public void requestWithdrawal(Long userId, String password) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.WITHDRAWAL_NOT_ALLOWED);
+        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_CURRENT_PASSWORD);
+        }
+
+        user.requestWithdrawal(LocalDateTime.now());
+        eventPublisher.publishEvent(new UserWithdrawalRequestedEvent(userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -75,15 +75,23 @@ public class WithdrawalService {
                 .stream()
                 .map(User::getId)
                 .toList();
-
         for (Long userId : targetIds) {
+            boolean confirmed;
             try {
-                if (withdrawalConfirmer.confirm(userId)) {
-                    refreshTokenStore.delete(userId);
-                    tokenBlacklistStore.blacklist(userId);
-                }
+                confirmed = withdrawalConfirmer.confirm(userId); // DB 확정(건별 트랜잭션)
             } catch (Exception e) {
                 log.error("탈퇴 확정 실패 - 다음 대상 계속 진행 (userId={})", userId, e);
+                continue;
+            }
+            if (!confirmed) {
+                continue; // 그새 철회/이미 확정 -> 정리 불필요
+            }
+            try {
+                refreshTokenStore.delete(userId); // refresh token 삭제
+                tokenBlacklistStore.blacklist(userId); // access token blacklist 처리
+            } catch (Exception e) {
+                // 확정(DB)은 됐으나 토큰 정리 실패 → 운영 보정 대상(기존 access가 만료 전까지 유효)
+                log.error("탈퇴 확정됨(DB) - 토큰 정리 실패, 보정 필요 (userId={})", userId, e);
             }
         }
     }

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalCancelledEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalCancelledEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawalCancelledEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalRequestedEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawalRequestedEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawalRequestedEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/event/UserWithdrawnEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/UserWithdrawnEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record UserWithdrawnEvent(Long userId) {
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     // ===== 회원 정지 =====
     ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 고객센터에 문의해주세요."),
+    ACCOUNT_NOT_ACTIVE(HttpStatus.FORBIDDEN, "현재 계정 상태에서는 이용할 수 없는 기능입니다."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
     PASSWORD_CHANGE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "소셜 로그인 계정은 비밀번호를 변경할 수 없습니다."),
 
+    // ===== 회원 탈퇴 =====
+    WITHDRAWAL_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 탈퇴 신청을 할 수 없습니다."),
+
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),
 

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -32,10 +32,10 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
-    LOGIN_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS,"로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+    LOGIN_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     TOKEN_STOLEN(HttpStatus.UNAUTHORIZED, "비정상적인 접근이 감지되어 로그아웃되었습니다."),
-    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN,"이메일 인증이 완료되지 않았습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),
     EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "인증 코드 발송에 실패했습니다."),
     EMAIL_SEND_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
@@ -50,6 +50,10 @@ public enum ErrorCode {
 
     // ===== 회원 탈퇴 =====
     WITHDRAWAL_NOT_ALLOWED(HttpStatus.CONFLICT, "현재 상태에서는 탈퇴 신청을 할 수 없습니다."),
+    NOT_WITHDRAWAL_PENDING(HttpStatus.CONFLICT, "탈퇴 진행 중인 계정이 아닙니다."),
+
+    // ===== 회원 정지 =====
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 고객센터에 문의해주세요."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),

--- a/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
+++ b/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
@@ -1,0 +1,5 @@
+package com.pokade.global.port;
+
+public interface UserAccessChecker {
+    void assertWritable (Long userId);
+}

--- a/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenBlacklistStore tokenBlacklistStore;
 
 
     // 매 요청마다 실행 — Authorization 헤더의 토큰을 확인해 인증 상태를 세팅
@@ -32,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Long userId = jwtTokenProvider.getUserId(token);
                 String role = jwtTokenProvider.getRole(token);
                 // 토큰이 유효하면 인증 객체를 만들어 SecurityContext에 등록
-                if (userId != null && role != null) {
+                if (userId != null && role != null && !tokenBlacklistStore.contains(userId)) {
                     List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
                     UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, authorities);

--- a/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
+++ b/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
@@ -1,9 +1,12 @@
 package com.pokade.global.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RedisTokenBlacklistStore implements TokenBlacklistStore {
@@ -13,7 +16,7 @@ public class RedisTokenBlacklistStore implements TokenBlacklistStore {
     private final StringRedisTemplate redisTemplate;
     private final JwtProperties jwtProperties;
 
-    // 유저를 블랙리스트에 등록 (TTL = access 만료 - 그 뒤엔 ccess가 자연 만료라 불필요)
+    // 유저를 블랙리스트에 등록 (TTL = access 만료 - 그 뒤엔 access가 자연 만료라 불필요)
     @Override
     public void blacklist(Long userId) {
         redisTemplate.opsForValue().set(
@@ -24,6 +27,11 @@ public class RedisTokenBlacklistStore implements TokenBlacklistStore {
     // 블랙리스트 등록 여부
     @Override
     public boolean contains(Long userId) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + userId));
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + userId));
+        } catch (DataAccessException e) {
+            log.warn("블랙리스트 조회 실패 - fail-open 처리 (userId={})", userId, e);
+            return false;
+        }
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
+++ b/Pokade/src/main/java/com/pokade/global/security/RedisTokenBlacklistStore.java
@@ -1,0 +1,29 @@
+package com.pokade.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisTokenBlacklistStore implements TokenBlacklistStore {
+
+    private static final String BLACKLIST_KEY_PREFIX = "auth:blacklist:";
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtProperties jwtProperties;
+
+    // 유저를 블랙리스트에 등록 (TTL = access 만료 - 그 뒤엔 ccess가 자연 만료라 불필요)
+    @Override
+    public void blacklist(Long userId) {
+        redisTemplate.opsForValue().set(
+                BLACKLIST_KEY_PREFIX + userId, "1", jwtProperties.accessExpiration()
+        );
+    }
+
+    // 블랙리스트 등록 여부
+    @Override
+    public boolean contains(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_KEY_PREFIX + userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/TokenBlacklistStore.java
+++ b/Pokade/src/main/java/com/pokade/global/security/TokenBlacklistStore.java
@@ -1,0 +1,6 @@
+package com.pokade.global.security;
+
+public interface TokenBlacklistStore {
+    void blacklist(Long userId);
+    boolean contains(Long userId);
+}

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS users (
     nickname_changed_at   TIMESTAMP,
     provider              VARCHAR(20) NOT NULL,                -- LOCAL / GOOGLE / KAKAO
     role                  VARCHAR(20) NOT NULL,                -- USER / ADMIN
-    status                VARCHAR(20) NOT NULL,                -- PENDING / ACTIVE / SUSPENDED / DELETED
+    status                VARCHAR(20) NOT NULL,                -- PENDING / ACTIVE / SUSPENDED / WITHDRAWAL_PENDING / DELETED
     profile_image_url     VARCHAR(255),
     birth_date            DATE,
     phone_number          VARCHAR(20),
@@ -124,6 +124,7 @@ CREATE TABLE IF NOT EXISTS users (
     marketing_opt_in      BOOLEAN NOT NULL DEFAULT FALSE,      -- 선택 동의(마케팅 수신)
     point_balance         INTEGER NOT NULL DEFAULT 0,
     deleted_at            TIMESTAMP,
+    withdrawal_requested_at TIMESTAMP,
     created_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -126,7 +126,8 @@ CREATE TABLE IF NOT EXISTS users (
     deleted_at            TIMESTAMP,
     withdrawal_requested_at TIMESTAMP,
     created_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at            TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    version               BIGINT NOT NULL DEFAULT 0
 );
 -- 참고: email_verifications는 DB 테이블로 만들지 않음 - Redis TTL로만 관리(정책 확정)
 

--- a/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/service/AuthServiceTest.java
@@ -188,6 +188,53 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("정지(SUSPENDED) 회원이면 ACCOUNT_SUSPENDED 예외를 던지고 토큰을 발급·저장하지 않는다")
+    void login_suspended() {
+        String email = "suspended@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.SUSPENDED)));
+        given(passwordEncoder.matches("pokade1234", "ENCODED_PW")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest(email, "pokade1234")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCOUNT_SUSPENDED);
+
+        then(refreshTokenStore).should(never()).save(any(), any());
+        then(loginAttemptStore).should(never()).reset(email);
+    }
+
+    @Test
+    @DisplayName("탈퇴 확정(DELETED) 회원이면 계정 존재를 숨기려 LOGIN_FAILED 예외를 던지고 토큰을 발급·저장하지 않는다")
+    void login_deleted() {
+        String email = "deleted@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.DELETED)));
+        given(passwordEncoder.matches("pokade1234", "ENCODED_PW")).willReturn(true);
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest(email, "pokade1234")))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.LOGIN_FAILED);
+
+        then(refreshTokenStore).should(never()).save(any(), any());
+        then(loginAttemptStore).should(never()).reset(email);
+    }
+
+    @Test
+    @DisplayName("탈퇴 유예(WITHDRAWAL_PENDING) 회원은 철회를 위해 로그인이 허용되어 토큰을 발급받는다")
+    void login_withdrawalPending_allowed() {
+        String email = "bye@pokade.com";
+        given(userRepository.findByEmail(email)).willReturn(Optional.of(userWithStatus(email, UserStatus.WITHDRAWAL_PENDING)));
+        given(passwordEncoder.matches("pokade1234", "ENCODED_PW")).willReturn(true);
+        given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("refresh-token");
+
+        TokenPair result = authService.login(new LoginRequest(email, "pokade1234"));
+
+        assertThat(result.accessToken()).isEqualTo("access-token");
+        assertThat(result.refreshToken()).isEqualTo("refresh-token");
+        then(refreshTokenStore).should().save(1L, "refresh-token");
+        then(loginAttemptStore).should().reset(email);
+    }
+
+    @Test
     @DisplayName("저장된 refresh와 일치하면 원자 회전(compareAndRotate)하고 새 access+새 refresh를 반환한다")
     void reissue_success() {
         String oldRefresh = "old-refresh";
@@ -235,6 +282,7 @@ class AuthServiceTest {
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("user@pokade.com", UserStatus.ACTIVE)));
         given(jwtTokenProvider.createRefreshToken(1L)).willReturn("unused-new");
         given(refreshTokenStore.compareAndRotate(1L, presented, "unused-new")).willReturn(false);
         given(refreshTokenStore.matchesGrace(1L, presented)).willReturn(false);
@@ -268,13 +316,11 @@ class AuthServiceTest {
 
     @Test
     @DisplayName("refresh는 유효하나 유저가 존재하지 않으면 INVALID_REFRESH_TOKEN 예외를 던지고 저장 토큰을 삭제한다")
-    void reissue_userDeleted() {
+    void reissue_userNotFound() {
         String presented = "current-refresh";
         given(jwtTokenProvider.isValid(presented)).willReturn(true);
         given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
         given(refreshTokenStore.exists(1L)).willReturn(true);
-        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
-        given(refreshTokenStore.compareAndRotate(1L, presented, "new-refresh")).willReturn(true);
         given(userRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> authService.reissue(presented))
@@ -282,6 +328,58 @@ class AuthServiceTest {
                 .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
 
         then(refreshTokenStore).should().delete(1L);
+    }
+
+    @Test
+    @DisplayName("정지(SUSPENDED) 회원이면 재발급을 거부하고(INVALID) 저장 refresh를 폐기한다")
+    void reissue_suspended_rejectedAndPurged() {
+        String presented = "current-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("s@pokade.com", UserStatus.SUSPENDED)));
+
+        assertThatThrownBy(() -> authService.reissue(presented))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+        then(refreshTokenStore).should().delete(1L);            // 남은 refresh 능동 폐기
+        then(refreshTokenStore).should(never()).compareAndRotate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("탈퇴 확정(DELETED) 회원이면 재발급을 거부하고(INVALID) 저장 refresh를 폐기한다(배치 Redis 정리 유실 자가치유)")
+    void reissue_deleted_rejectedAndPurged() {
+        String presented = "current-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("d@pokade.com", UserStatus.DELETED)));
+
+        assertThatThrownBy(() -> authService.reissue(presented))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+
+        then(refreshTokenStore).should().delete(1L);
+        then(refreshTokenStore).should(never()).compareAndRotate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("탈퇴 유예(WITHDRAWAL_PENDING) 회원은 재발급이 허용된다(유예 중 세션 유지)")
+    void reissue_withdrawalPending_allowed() {
+        String presented = "old-refresh";
+        given(jwtTokenProvider.isValid(presented)).willReturn(true);
+        given(jwtTokenProvider.getUserId(presented)).willReturn(1L);
+        given(refreshTokenStore.exists(1L)).willReturn(true);
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithStatus("bye@pokade.com", UserStatus.WITHDRAWAL_PENDING)));
+        given(jwtTokenProvider.createRefreshToken(1L)).willReturn("new-refresh");
+        given(refreshTokenStore.compareAndRotate(1L, presented, "new-refresh")).willReturn(true);
+        given(jwtTokenProvider.createAccessToken(1L, "USER")).willReturn("new-access");
+
+        TokenPair result = authService.reissue(presented);
+
+        assertThat(result.accessToken()).isEqualTo("new-access");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/user/repository/UserOptimisticLockTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/repository/UserOptimisticLockTest.java
@@ -1,0 +1,139 @@
+package com.pokade.domain.user.repository;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.support.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * User 낙관적 락(@Version) 검증.
+ * 확정 배치(WithdrawalService.confirmExpiredWithdrawals)와 유저 철회(cancelWithdrawal)가
+ * 같은 행을 동시에 건드릴 때 발생하는 갱신 유실(lost update)을 @Version이 막는지 확인한다.
+ * 실제 두 트랜잭션 경합을 재현하려면 커밋된 데이터가 필요하므로 REQUIRES_NEW로 별도 트랜잭션을 쓴다.
+ */
+@DataJpaTest
+class UserOptimisticLockTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("확정 배치가 그새 철회(ACTIVE)된 유저를 낡은 스냅샷으로 덮어쓰려 하면 OptimisticLockException으로 막힌다")
+    void 철회와_확정_경합_시_낙관적_락이_갱신유실을_막는다() {
+        TransactionTemplate requiresNew = new TransactionTemplate(transactionManager);
+        requiresNew.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        // 유예중(WITHDRAWAL_PENDING) 유저를 커밋해 둔다. version = 0
+        Long userId = requiresNew.execute(status -> {
+            User user = pendingUser("optlock-race@pokade.test", "옵락경합");
+            entityManager.persist(user);
+            entityManager.flush();
+            return user.getId();
+        });
+
+        try {
+            // 1) 확정 배치가 읽은 시점의 "낡은 스냅샷"(version=0)을 detach 해서 트랜잭션 밖으로 들고 나온다
+            User staleBatchView = requiresNew.execute(status -> {
+                User loaded = entityManager.find(User.class, userId);
+                entityManager.detach(loaded);
+                return loaded;
+            });
+            assertThat(staleBatchView.getVersion()).isZero();
+
+            // 2) 그 사이 유저가 철회 → ACTIVE 로 커밋된다. DB version 0 -> 1
+            requiresNew.executeWithoutResult(status -> {
+                User loaded = entityManager.find(User.class, userId);
+                loaded.cancelWithdrawal();
+                entityManager.flush();
+            });
+
+            // 3) 배치가 낡은 스냅샷(version=0)으로 확정(DELETED+익명화)을 시도 → version 불일치로 거부된다
+            staleBatchView.confirmWithdrawal(LocalDateTime.now());
+            assertThatThrownBy(() ->
+                    requiresNew.executeWithoutResult(status -> userRepository.saveAndFlush(staleBatchView))
+            ).isInstanceOf(ObjectOptimisticLockingFailureException.class);
+
+            // 4) 철회가 유지된다 — 계정이 삭제/익명화되지 않았음을 확인
+            User after = requiresNew.execute(status -> entityManager.find(User.class, userId));
+            assertThat(after.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(after.getEmail()).doesNotStartWith("deleted_");
+        } finally {
+            requiresNew.executeWithoutResult(status -> {
+                User u = entityManager.find(User.class, userId);
+                if (u != null) {
+                    entityManager.remove(u);
+                }
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("경합이 없으면 확정이 정상 처리되고 version이 1 증가한다")
+    void 경합이_없으면_확정이_정상처리되고_version이_증가한다() {
+        TransactionTemplate requiresNew = new TransactionTemplate(transactionManager);
+        requiresNew.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+
+        Long userId = requiresNew.execute(status -> {
+            User user = pendingUser("optlock-happy@pokade.test", "옵락정상");
+            entityManager.persist(user);
+            entityManager.flush();
+            return user.getId();
+        });
+
+        try {
+            // 확정을 dirty-checking으로 커밋 (배치와 동일한 경로)
+            requiresNew.executeWithoutResult(status -> {
+                User loaded = entityManager.find(User.class, userId);
+                loaded.confirmWithdrawal(LocalDateTime.now());
+                entityManager.flush();
+            });
+
+            User after = requiresNew.execute(status -> entityManager.find(User.class, userId));
+            assertThat(after.getStatus()).isEqualTo(UserStatus.DELETED);
+            assertThat(after.getVersion()).isEqualTo(1L);
+            assertThat(after.getEmail()).startsWith("deleted_");
+        } finally {
+            requiresNew.executeWithoutResult(status -> {
+                User u = entityManager.find(User.class, userId);
+                if (u != null) {
+                    entityManager.remove(u);
+                }
+            });
+        }
+    }
+
+    // 유예중(WITHDRAWAL_PENDING) 유저 — ACTIVE로 만든 뒤 도메인 메서드로 상태 전이
+    private User pendingUser(String email, String nickname) {
+        User u = User.builder()
+                .email(email).password("ENCODED_PW")
+                .nickname(nickname).role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE)
+                .termsAgreedAt(LocalDateTime.now())
+                .pointBalance(0)
+                .build();
+        u.requestWithdrawal(LocalDateTime.now().minusDays(8));
+        return u;
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserAccessGuardTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserAccessGuardTest.java
@@ -1,0 +1,74 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccessGuardTest {
+
+    @Mock UserRepository userRepository;
+    @InjectMocks UserAccessGuard userAccessGuard;
+
+    private User userWith(UserStatus status) {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(status).pointBalance(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("ACTIVE면 통과")
+    void active_ok() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.ACTIVE)));
+
+        assertThatCode(() -> userAccessGuard.assertWritable(1L)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("유예중(WITHDRAWAL_PENDING)이면 ACCOUNT_NOT_ACTIVE")
+    void pending_blocked() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.WITHDRAWAL_PENDING)));
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCOUNT_NOT_ACTIVE);
+    }
+
+    @Test
+    @DisplayName("정지(SUSPENDED)면 ACCOUNT_NOT_ACTIVE")
+    void suspended_blocked() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.SUSPENDED)));
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCOUNT_NOT_ACTIVE);
+    }
+
+    @Test
+    @DisplayName("유저 없으면 USER_NOT_FOUND")
+    void notFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userAccessGuard.assertWritable(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.auth.store.RefreshTokenStore;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.support.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+/**
+ * 회원 탈퇴 확정 배치를 "실제 Spring 빈 배선 + 실제 DB + 실제 쿼리"로 검증한다.
+ * 단위 테스트가 목으로 가렸던 부분(빈 주입/트랜잭션 프록시/파생 쿼리/실제 UPDATE·version)을 확인한다.
+ * Redis 스토어(RefreshTokenStore·TokenBlacklistStore)만 목으로 두고 호출 여부만 본다.
+ */
+@DataJpaTest
+@Import({WithdrawalService.class, WithdrawalConfirmer.class})
+class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private WithdrawalService withdrawalService;
+    @Autowired
+    private UserRepository userRepository;
+    @PersistenceContext
+    private EntityManager em;
+
+    @MockitoBean
+    private PasswordEncoder passwordEncoder;        // WithdrawalService 생성자 의존만 충족(이 테스트에선 미사용)
+    @MockitoBean
+    private RefreshTokenStore refreshTokenStore;    // Redis 없이 — 호출 여부만 검증
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    @Test
+    @DisplayName("실제 빈·DB: 유예 만료 유저를 배치가 DELETED 익명화하고 version을 올리며 토큰 정리를 호출한다")
+    void confirmExpired_realBeansAndDb() {
+        Long id = persistPending("e2e-expired@pokade.test", "만료대상", 8);
+
+        // 실제 WithdrawalService → WithdrawalConfirmer 배선을 그대로 실행
+        withdrawalService.confirmExpiredWithdrawals();
+
+        em.flush();
+        em.clear();
+        User after = userRepository.findById(id).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(after.getEmail()).isEqualTo("deleted_" + id + "@pokade.invalid");
+        assertThat(after.getNickname()).isEqualTo("deleted_" + id);
+        assertThat(after.getPassword()).isNull();
+        assertThat(after.getVersion()).isEqualTo(1L); // 실제 DB 컬럼으로 낙관적 락 버전 증가
+        then(refreshTokenStore).should().delete(id);
+        then(tokenBlacklistStore).should().blacklist(id);
+    }
+
+    @Test
+    @DisplayName("실제 파생 쿼리: 유예 미경과(3일) 유저는 배치 대상에서 제외되어 그대로 유지된다")
+    void confirmExpired_gracePeriodBoundary() {
+        Long expiredId = persistPending("e2e-exp@pokade.test", "만료", 8);   // 8일 전 신청 → 대상
+        Long freshId = persistPending("e2e-fresh@pokade.test", "신선", 3);   // 3일 전 신청 → 유예 중
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        em.flush();
+        em.clear();
+        assertThat(userRepository.findById(expiredId).orElseThrow().getStatus())
+                .isEqualTo(UserStatus.DELETED);
+        assertThat(userRepository.findById(freshId).orElseThrow().getStatus())
+                .isEqualTo(UserStatus.WITHDRAWAL_PENDING);
+        then(refreshTokenStore).should().delete(expiredId);
+        then(refreshTokenStore).should(never()).delete(freshId);
+    }
+
+    // ACTIVE로 만든 뒤 도메인 메서드로 유예 전환 (requestedDaysAgo일 전 신청으로 기록)
+    private Long persistPending(String email, String nickname, int requestedDaysAgo) {
+        User u = User.builder()
+                .email(email).password("ENCODED_PW")
+                .nickname(nickname).role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE)
+                .termsAgreedAt(LocalDateTime.now())
+                .pointBalance(0)
+                .build();
+        u.requestWithdrawal(LocalDateTime.now().minusDays(requestedDaysAgo));
+        userRepository.save(u);
+        em.flush();
+        return u.getId();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
@@ -1,0 +1,80 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawnEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawalConfirmerTest {
+
+    @Mock UserRepository userRepository;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @InjectMocks WithdrawalConfirmer withdrawalConfirmer;
+
+    private User userWithStatus(long id, UserStatus status) {
+        return User.builder()
+                .id(id).email("bye@pokade.com").password("ENCODED_PW")
+                .nickname("바이").role(Role.USER).provider(Provider.LOCAL)
+                .status(status).pointBalance(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("유예(WITHDRAWAL_PENDING)면 DELETED 익명화 + 이벤트 발행 후 true를 반환한다")
+    void confirm_pending_confirmsAndReturnsTrue() {
+        User user = userWithStatus(2L, UserStatus.WITHDRAWAL_PENDING);
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        boolean result = withdrawalConfirmer.confirm(2L);
+
+        assertThat(result).isTrue();
+        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
+        assertThat(user.getNickname()).isEqualTo("deleted_2");
+        assertThat(user.getPassword()).isNull();
+        then(eventPublisher).should().publishEvent(any(UserWithdrawnEvent.class));
+    }
+
+    @Test
+    @DisplayName("그새 철회돼 ACTIVE면 확정하지 않고 false를 반환한다(경합 보호·멱등)")
+    void confirm_active_skipsAndReturnsFalse() {
+        User user = userWithStatus(2L, UserStatus.ACTIVE);
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        boolean result = withdrawalConfirmer.confirm(2L);
+
+        assertThat(result).isFalse();
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE); // 상태 안 바뀜
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("이미 확정된 DELETED면 다시 확정하지 않고 false를 반환한다(배치 재실행 안전)")
+    void confirm_deleted_skipsAndReturnsFalse() {
+        User user = userWithStatus(2L, UserStatus.DELETED);
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        boolean result = withdrawalConfirmer.confirm(2L);
+
+        assertThat(result).isFalse();
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
@@ -9,6 +9,7 @@ import com.pokade.global.event.UserWithdrawnEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -50,7 +51,9 @@ class WithdrawalConfirmerTest {
         assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
         assertThat(user.getNickname()).isEqualTo("deleted_2");
         assertThat(user.getPassword()).isNull();
-        then(eventPublisher).should().publishEvent(any(UserWithdrawnEvent.class));
+        ArgumentCaptor<UserWithdrawnEvent> captor = ArgumentCaptor.forClass(UserWithdrawnEvent.class);
+        then(eventPublisher).should().publishEvent(captor.capture());
+        assertThat(captor.getValue().userId()).isEqualTo(2L); // payload userId까지 검증
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
@@ -8,7 +8,6 @@ import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.global.event.UserWithdrawalCancelledEvent;
 import com.pokade.global.event.UserWithdrawalRequestedEvent;
-import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.TokenBlacklistStore;
@@ -41,6 +40,7 @@ class WithdrawalServiceTest {
     @Mock ApplicationEventPublisher eventPublisher;
     @Mock RefreshTokenStore refreshTokenStore;
     @Mock TokenBlacklistStore tokenBlacklistStore;
+    @Mock WithdrawalConfirmer withdrawalConfirmer;
     @InjectMocks WithdrawalService withdrawalService;
 
     private User activeUser() {
@@ -125,35 +125,76 @@ class WithdrawalServiceTest {
                 .extracting("errorCode").isEqualTo(ErrorCode.NOT_WITHDRAWAL_PENDING);
     }
 
-    // ===== 확정 배치 =====
+    // ===== 확정 배치(오케스트레이션) =====
+    // 실제 확정(DB 익명화·이벤트)은 WithdrawalConfirmer 책임 → WithdrawalConfirmerTest에서 검증.
+    // 여기서는 스케줄러가 "건별 위임 + 커밋 성공(true)일 때만 Redis 정리 + 실패 격리"를 하는지만 본다.
     @Test
-    @DisplayName("확정: 유예 만료분을 DELETED 익명화 + 토큰 무효화·블랙리스트·이벤트")
-    void confirmExpiredWithdrawals_confirms() {
-        User user = pendingUser();
+    @DisplayName("확정: 위임이 성공(true)하면 그 유저의 refresh 삭제 + 블랙리스트 등록")
+    void confirmExpiredWithdrawals_confirmsThenCleansRedis() {
+        User user = pendingUser(); // id=2
         given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
                 eq(UserStatus.WITHDRAWAL_PENDING), any(LocalDateTime.class)))
                 .willReturn(List.of(user));
+        given(withdrawalConfirmer.confirm(2L)).willReturn(true);
 
         withdrawalService.confirmExpiredWithdrawals();
 
-        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
-        assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
-        assertThat(user.getNickname()).isEqualTo("deleted_2");
-        assertThat(user.getPassword()).isNull();
+        then(withdrawalConfirmer).should().confirm(2L);
         then(refreshTokenStore).should().delete(2L);
         then(tokenBlacklistStore).should().blacklist(2L);
-        then(eventPublisher).should().publishEvent(any(UserWithdrawnEvent.class));
     }
 
     @Test
-    @DisplayName("확정: 대상 없으면 아무 것도 안 함")
+    @DisplayName("확정: 위임이 skip(false)이면 Redis를 건드리지 않는다(그새 철회된 유저 보호)")
+    void confirmExpiredWithdrawals_skipsRedisWhenNotConfirmed() {
+        User user = pendingUser(); // id=2
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(any(), any()))
+                .willReturn(List.of(user));
+        given(withdrawalConfirmer.confirm(2L)).willReturn(false);
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(refreshTokenStore).should(never()).delete(any());
+        then(tokenBlacklistStore).should(never()).blacklist(any());
+    }
+
+    @Test
+    @DisplayName("확정: 대상 없으면 위임·Redis 모두 호출하지 않는다")
     void confirmExpiredWithdrawals_empty() {
         given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(any(), any()))
                 .willReturn(List.of());
 
         withdrawalService.confirmExpiredWithdrawals();
 
+        then(withdrawalConfirmer).should(never()).confirm(any());
         then(refreshTokenStore).should(never()).delete(any());
-        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("확정: 한 건이 실패해도 다음 대상은 계속 확정한다(건별 격리)")
+    void confirmExpiredWithdrawals_isolatesFailure() {
+        User first = pendingUser();                              // id=2 — 실패할 대상
+        User second = pendingUserWithId(3L, "bye2@pokade.com", "바이2"); // id=3 — 계속되어야 함
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(any(), any()))
+                .willReturn(List.of(first, second));
+        given(withdrawalConfirmer.confirm(2L)).willThrow(new RuntimeException("DB 순단"));
+        given(withdrawalConfirmer.confirm(3L)).willReturn(true);
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(withdrawalConfirmer).should().confirm(3L);         // 실패 후에도 다음 대상 처리됨
+        then(refreshTokenStore).should(never()).delete(2L);     // 실패 건은 Redis 정리 안 함
+        then(refreshTokenStore).should().delete(3L);
+        then(tokenBlacklistStore).should().blacklist(3L);
+    }
+
+    private User pendingUserWithId(long id, String email, String nickname) {
+        User u = User.builder()
+                .id(id).email(email).password("ENCODED_PW")
+                .nickname(nickname).role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+        u.requestWithdrawal(LocalDateTime.now().minusDays(8));
+        return u;
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
@@ -1,0 +1,159 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.auth.store.RefreshTokenStore;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.UserWithdrawalCancelledEvent;
+import com.pokade.global.event.UserWithdrawalRequestedEvent;
+import com.pokade.global.event.UserWithdrawnEvent;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.TokenBlacklistStore;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawalServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock RefreshTokenStore refreshTokenStore;
+    @Mock TokenBlacklistStore tokenBlacklistStore;
+    @InjectMocks WithdrawalService withdrawalService;
+
+    private User activeUser() {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+    }
+
+    private User pendingUser() {
+        User u = User.builder()
+                .id(2L).email("bye@pokade.com").password("ENCODED_PW")
+                .nickname("바이").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+        u.requestWithdrawal(LocalDateTime.now().minusDays(8)); // ACTIVE -> WITHDRAWAL_PENDING
+        return u;
+    }
+
+    // ===== 신청 =====
+    @Test
+    @DisplayName("신청: ACTIVE + 올바른 비번이면 유예 전환 + 이벤트 발행")
+    void requestWithdrawal_success() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("rawpw", "ENCODED_PW")).willReturn(true);
+
+        withdrawalService.requestWithdrawal(1L, "rawpw");
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWAL_PENDING);
+        assertThat(user.getWithdrawalRequestedAt()).isNotNull();
+        then(eventPublisher).should().publishEvent(any(UserWithdrawalRequestedEvent.class));
+    }
+
+    @Test
+    @DisplayName("신청: ACTIVE 아니면 WITHDRAWAL_NOT_ALLOWED")
+    void requestWithdrawal_notActive() {
+        User user = pendingUser();
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> withdrawalService.requestWithdrawal(2L, "rawpw"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WITHDRAWAL_NOT_ALLOWED);
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("신청: 비번 불일치면 INVALID_CURRENT_PASSWORD")
+    void requestWithdrawal_wrongPassword() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrong", "ENCODED_PW")).willReturn(false);
+
+        assertThatThrownBy(() -> withdrawalService.requestWithdrawal(1L, "wrong"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_CURRENT_PASSWORD);
+    }
+
+    // ===== 철회 =====
+    @Test
+    @DisplayName("철회: 유예 상태면 ACTIVE 복구 + 이벤트 발행")
+    void cancelWithdrawal_success() {
+        User user = pendingUser();
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+
+        withdrawalService.cancelWithdrawal(2L);
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getWithdrawalRequestedAt()).isNull();
+        then(eventPublisher).should().publishEvent(any(UserWithdrawalCancelledEvent.class));
+    }
+
+    @Test
+    @DisplayName("철회: 유예 상태 아니면 NOT_WITHDRAWAL_PENDING")
+    void cancelWithdrawal_notPending() {
+        User user = activeUser();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> withdrawalService.cancelWithdrawal(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOT_WITHDRAWAL_PENDING);
+    }
+
+    // ===== 확정 배치 =====
+    @Test
+    @DisplayName("확정: 유예 만료분을 DELETED 익명화 + 토큰 무효화·블랙리스트·이벤트")
+    void confirmExpiredWithdrawals_confirms() {
+        User user = pendingUser();
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(
+                eq(UserStatus.WITHDRAWAL_PENDING), any(LocalDateTime.class)))
+                .willReturn(List.of(user));
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
+        assertThat(user.getNickname()).isEqualTo("deleted_2");
+        assertThat(user.getPassword()).isNull();
+        then(refreshTokenStore).should().delete(2L);
+        then(tokenBlacklistStore).should().blacklist(2L);
+        then(eventPublisher).should().publishEvent(any(UserWithdrawnEvent.class));
+    }
+
+    @Test
+    @DisplayName("확정: 대상 없으면 아무 것도 안 함")
+    void confirmExpiredWithdrawals_empty() {
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(any(), any()))
+                .willReturn(List.of());
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(refreshTokenStore).should(never()).delete(any());
+        then(eventPublisher).should(never()).publishEvent(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -26,7 +26,8 @@ class JwtAuthenticationFilterTest {
 
     private final JwtTokenProvider jwtTokenProvider =
             new JwtTokenProvider(new JwtProperties(SECRET, Duration.ofMinutes(30), Duration.ofDays(14)));
-    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider);
+    private final TokenBlacklistStore tokenBlacklistStore = mock(TokenBlacklistStore.class);
+    private final JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistStore);
 
     @AfterEach
     void clearContext() {

--- a/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/JwtAuthenticationFilterTest.java
@@ -124,6 +124,22 @@ class JwtAuthenticationFilterTest {
         verify(chain).doFilter(request, response);
     }
 
+    @Test
+    @DisplayName("토큰은 유효해도 블랙리스트에 등록된 userId면 인증하지 않고 통과한다")
+    void doFilterInternal_skipsAuthenticationWhenBlacklisted() throws Exception {
+        String token = jwtTokenProvider.createAccessToken(42L, "USER");
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+        given(request.getHeader("Authorization")).willReturn("Bearer " + token);
+        given(tokenBlacklistStore.contains(42L)).willReturn(true);
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
     // 같은 시크릿으로 서명하되 클레임을 임의 구성한 토큰 생성 (role=null이면 role 클레임 생략)
     private String signedToken(String subject, String role) {
         SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes());

--- a/Pokade/src/test/java/com/pokade/global/security/RedisTokenBlacklistStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/RedisTokenBlacklistStoreTest.java
@@ -1,0 +1,73 @@
+package com.pokade.global.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class RedisTokenBlacklistStoreTest {
+
+    private static final String KEY = "auth:blacklist:1";
+    private static final Duration ACCESS_TTL = Duration.ofMinutes(30);
+
+    @Mock
+    StringRedisTemplate redisTemplate;
+    @Mock
+    ValueOperations<String, String> valueOperations;
+
+    RedisTokenBlacklistStore store;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties("secret", ACCESS_TTL, Duration.ofDays(14));
+        store = new RedisTokenBlacklistStore(redisTemplate, jwtProperties);
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 있으면 true")
+    void contains_true() {
+        given(redisTemplate.hasKey(KEY)).willReturn(true);
+
+        assertThat(store.contains(1L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 없으면 false")
+    void contains_false() {
+        given(redisTemplate.hasKey(KEY)).willReturn(false);
+
+        assertThat(store.contains(1L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Redis 조회 실패 시 fail-open — 예외를 던지지 않고 false 반환")
+    void contains_failOpen_onRedisError() {
+        given(redisTemplate.hasKey(KEY)).willThrow(new DataAccessResourceFailureException("Redis down"));
+
+        assertThatCode(() -> assertThat(store.contains(1L)).isFalse())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("등록 시 access 만료(30분) TTL로 저장")
+    void blacklist_setsKeyWithAccessTtl() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        store.blacklist(1L);
+
+        then(valueOperations).should().set(KEY, "1", ACCESS_TTL);
+    }
+}


### PR DESCRIPTION
develop에 push된 변경사항을 main으로 자동 승격합니다. 빌드가 통과했으므로 자동 병합됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 비밀번호 확인 후 회원 탈퇴를 신청하거나 철회할 수 있습니다.
  - 탈퇴 신청 후 7일이 지나면 계정이 자동 확정 탈퇴 처리됩니다.
  - 확정 탈퇴 시 개인정보가 익명화되고 관련 토큰이 정리됩니다.
- **개선**
  - 정지·삭제·탈퇴 대기 상태에 따라 로그인 및 토큰 재발급이 안전하게 제한됩니다.
  - 탈퇴한 계정의 기존 인증 토큰은 더 이상 사용할 수 없습니다.
  - 활성 계정만 주요 정보 변경 기능을 이용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->