### PR TITLE
fix: #145 배포 컨테이너 타임존을 Asia/Seoul로 지정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
             docker run -d --name pokade-app --network host --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
+              -e TZ=Asia/Seoul \
               -e OPENAI_API_KEY="$OPENAI_API_KEY" \
               ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
         env:

--- a/Pokade/Dockerfile
+++ b/Pokade/Dockerfile
@@ -11,6 +11,8 @@ RUN ./gradlew clean bootJar -x test --no-daemon
 FROM eclipse-temurin:21-jre AS runtime
 WORKDIR /app
 
+ENV TZ=Asia/Seoul
+
 COPY --from=build /app/build/libs/*.jar app.jar
 
 EXPOSE 8080


### PR DESCRIPTION
## 📌 관련 이슈
- #145

## ✨ 작업 내용
- `Dockerfile` runtime 스테이지에 `ENV TZ=Asia/Seoul` 추가 — 이미지 기본 타임존을 KST로 고정해 로컬 `docker run` 시에도 실서버와 동일하게 동작
- `deploy.yml`의 `docker run`에 `-e TZ=Asia/Seoul` 추가 — 이미지 재빌드를 기다리지 않고 다음 배포부터 즉시 적용

두 곳 모두 지정한 이유는, Dockerfile만 수정하면 CI 재빌드 전까지 증상이 남고 deploy.yml만 수정하면 로컬에서 컨테이너를 띄울 때 다시 UTC가 되기 때문입니다. `-e`가 `--env-file`보다 우선하므로 서버의 `.env`에 TZ가 추가되더라도 이 값이 적용됩니다.

애플리케이션 코드 변경은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 환경의 시간대를 서울 시간(Asia/Seoul)으로 설정했습니다.
  * 애플리케이션 로그와 예약 작업의 시간이 일관되게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->