### PR TITLE
[Fix] #143 탈퇴 확정 익명화 닉네임 충돌로 인한 영구 확정 실패 해결

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -136,11 +136,11 @@ public class User {
     }
 
     // 탈퇴 확정 — soft-delete + 회원정보 익명화(email·nickname은 UNIQUE라 재가입 재사용 위해 비충돌 값 치환)
-    public void confirmWithdrawal(LocalDateTime now) {
+    public void confirmWithdrawal(LocalDateTime now, String anonToken) {
         this.status = UserStatus.DELETED;
         this.deleted_At = now;
-        this.email = "deleted_" + id + "@pokade.invalid";
-        this.nickname = "deleted_" + id;
+        this.email = "deleted_" + anonToken + "@pokade.invalid";
+        this.nickname = "deleted_" + anonToken;
         this.password = null;
         this.phoneNumber = null;
         this.birthDate = null;

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
@@ -3,6 +3,7 @@ package com.pokade.domain.user.service;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.domain.user.support.AnonymizationTokenGenerator;
 import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +20,7 @@ public class WithdrawalConfirmer {
 
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final AnonymizationTokenGenerator anonTokenGenerator;
 
     // 유저 한 명의 탈퇴를 확정한다 (건별 독립 트랜잭션). 실제 확정하면 true, 그새 철회/확정돼 건너뛰면 false
     @Transactional
@@ -29,8 +30,9 @@ public class WithdrawalConfirmer {
         if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
             return false; // 멱등 skip - 그새 철회(ACTIVE)됐거나 이미 확정 (DELETED)
         }
-        String anonToken = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        String anonToken = anonTokenGenerator.generate();
         user.confirmWithdrawal(LocalDateTime.now(), anonToken);
+        userRepository.flush();
         eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
         return true;
     }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -28,7 +29,8 @@ public class WithdrawalConfirmer {
         if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
             return false; // 멱등 skip - 그새 철회(ACTIVE)됐거나 이미 확정 (DELETED)
         }
-        user.confirmWithdrawal(LocalDateTime.now());
+        String anonToken = UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        user.confirmWithdrawal(LocalDateTime.now(), anonToken);
         eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
         return true;
     }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalService.java
@@ -12,6 +12,7 @@ import com.pokade.global.security.TokenBlacklistStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -30,9 +31,11 @@ public class WithdrawalService {
     private final ApplicationEventPublisher eventPublisher;
     private final RefreshTokenStore refreshTokenStore;
     private final TokenBlacklistStore tokenBlacklistStore;
+    private final WithdrawalConfirmer withdrawalConfirmer;
 
     private static final int GRACE_PERIOD_DAYS = 7;
-    private final WithdrawalConfirmer withdrawalConfirmer;
+    private static final int MAX_ANON_RETRY = 3;
+
 
     // 탈퇴 신청한다 (ACTIVE + 비밀번호 확인 후 유예 상태로 전환, 이벤트 발행)
     @Transactional
@@ -76,15 +79,24 @@ public class WithdrawalService {
                 .map(User::getId)
                 .toList();
         for (Long userId : targetIds) {
-            boolean confirmed;
-            try {
-                confirmed = withdrawalConfirmer.confirm(userId); // DB 확정(건별 트랜잭션)
-            } catch (Exception e) {
-                log.error("탈퇴 확정 실패 - 다음 대상 계속 진행 (userId={})", userId, e);
-                continue;
+            boolean confirmed = false;
+            int attempts = 0;
+            while (true) {
+                try {
+                    confirmed = withdrawalConfirmer.confirm(userId); // 매 호출 새 토큰 + 새 트랜잭션
+                    break;
+                } catch (DataIntegrityViolationException e) {         // 익명화 토큰 UNIQUE 충돌 → 새 토큰으로 재시도
+                    if (++attempts >= MAX_ANON_RETRY) {
+                        log.error("탈퇴 확정 실패 - 익명화 토큰 충돌 재시도 초과 (userId={})", userId, e);
+                        break; // confirmed=false 유지, 남으면 다음 배치가 또 재시도(자가치유)
+                    }
+                } catch (Exception e) {
+                    log.error("탈퇴 확정 실패 - 다음 대상 계속 진행 (userId={})", userId, e);
+                    break;
+                }
             }
             if (!confirmed) {
-                continue; // 그새 철회/이미 확정 -> 정리 불필요
+                continue; // 확정 안 됨(그새 철회/이미 확정 or 재시도 초과) → 토큰 정리 불필요
             }
             try {
                 refreshTokenStore.delete(userId); // refresh token 삭제

--- a/Pokade/src/main/java/com/pokade/domain/user/support/AnonymizationTokenGenerator.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/support/AnonymizationTokenGenerator.java
@@ -1,0 +1,13 @@
+package com.pokade.domain.user.support;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class AnonymizationTokenGenerator {
+
+    public String generate() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
+++ b/Pokade/src/main/java/com/pokade/global/port/UserAccessChecker.java
@@ -1,5 +1,5 @@
 package com.pokade.global.port;
 
 public interface UserAccessChecker {
-    void assertWritable (Long userId);
+    void assertWritable(Long userId);
 }

--- a/Pokade/src/test/java/com/pokade/domain/ai/controller/AiGradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/controller/AiGradeControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import com.pokade.domain.ai.service.AiGradeService;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 
 /**
  * 인증 필터(addFilters=false)를 꺼둔 상태라 @AuthenticationPrincipal은 항상 null로 주입된다.
@@ -34,6 +35,9 @@ class AiGradeControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
 
     @Test
     @DisplayName("인증 없이 진단 결과를 조회하면 401을 반환한다")

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -29,6 +29,7 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 
 @WebMvcTest(CardController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -45,6 +46,9 @@ class CardControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
 
     @Test
     @DisplayName("t1 쿼리 파라미터로 카드를 검색하면 200과 페이지 결과를 반환한다")

--- a/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
@@ -14,6 +14,7 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -61,6 +62,9 @@ class ListingControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -10,6 +10,7 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -44,6 +45,9 @@ class PriceControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
 
     @Test
     void 체결_내역이_있으면_200과_최신순_목록을_반환한다() throws Exception {

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -10,6 +10,7 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -54,6 +55,9 @@ class TradeControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -5,11 +5,13 @@ import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.service.UserService;
+import com.pokade.domain.user.service.WithdrawalService;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +47,10 @@ class UserControllerTest {
     private JwtTokenProvider jwtTokenProvider;                 // 실제 JwtAuthenticationFilter가 요구
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // SecurityConfig가 요구
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;                 // JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private WithdrawalService withdrawalService;                     // UserController가 요구
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(

--- a/Pokade/src/test/java/com/pokade/domain/user/repository/UserOptimisticLockTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/repository/UserOptimisticLockTest.java
@@ -70,7 +70,7 @@ class UserOptimisticLockTest extends AbstractIntegrationTest {
             });
 
             // 3) 배치가 낡은 스냅샷(version=0)으로 확정(DELETED+익명화)을 시도 → version 불일치로 거부된다
-            staleBatchView.confirmWithdrawal(LocalDateTime.now());
+            staleBatchView.confirmWithdrawal(LocalDateTime.now(), "anontoken12");
             assertThatThrownBy(() ->
                     requiresNew.executeWithoutResult(status -> userRepository.saveAndFlush(staleBatchView))
             ).isInstanceOf(ObjectOptimisticLockingFailureException.class);
@@ -106,7 +106,7 @@ class UserOptimisticLockTest extends AbstractIntegrationTest {
             // 확정을 dirty-checking으로 커밋 (배치와 동일한 경로)
             requiresNew.executeWithoutResult(status -> {
                 User loaded = entityManager.find(User.class, userId);
-                loaded.confirmWithdrawal(LocalDateTime.now());
+                loaded.confirmWithdrawal(LocalDateTime.now(), "anontoken12");
                 entityManager.flush();
             });
 

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
@@ -6,6 +6,7 @@ import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.domain.user.support.AnonymizationTokenGenerator;
 import com.pokade.global.security.TokenBlacklistStore;
 import com.pokade.support.AbstractIntegrationTest;
 import jakarta.persistence.EntityManager;
@@ -30,7 +31,7 @@ import static org.mockito.Mockito.never;
  * Redis 스토어(RefreshTokenStore·TokenBlacklistStore)만 목으로 두고 호출 여부만 본다.
  */
 @DataJpaTest
-@Import({WithdrawalService.class, WithdrawalConfirmer.class})
+@Import({WithdrawalService.class, WithdrawalConfirmer.class, AnonymizationTokenGenerator.class})
 class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
@@ -59,8 +59,8 @@ class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
         em.clear();
         User after = userRepository.findById(id).orElseThrow();
         assertThat(after.getStatus()).isEqualTo(UserStatus.DELETED);
-        assertThat(after.getEmail()).isEqualTo("deleted_" + id + "@pokade.invalid");
-        assertThat(after.getNickname()).isEqualTo("deleted_" + id);
+        assertThat(after.getEmail()).matches("deleted_[0-9a-f]{12}@pokade\\.invalid");
+        assertThat(after.getNickname()).matches("deleted_[0-9a-f]{12}");
         assertThat(after.getPassword()).isNull();
         assertThat(after.getVersion()).isEqualTo(1L); // 실제 DB 컬럼으로 낙관적 락 버전 증가
         then(refreshTokenStore).should().delete(id);

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.domain.user.support.AnonymizationTokenGenerator;
 import com.pokade.global.event.UserWithdrawnEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +29,7 @@ class WithdrawalConfirmerTest {
 
     @Mock UserRepository userRepository;
     @Mock ApplicationEventPublisher eventPublisher;
+    @Mock AnonymizationTokenGenerator anonTokenGenerator;
     @InjectMocks WithdrawalConfirmer withdrawalConfirmer;
 
     private User userWithStatus(long id, UserStatus status) {
@@ -43,6 +45,7 @@ class WithdrawalConfirmerTest {
     void confirm_pending_confirmsAndReturnsTrue() {
         User user = userWithStatus(2L, UserStatus.WITHDRAWAL_PENDING);
         given(userRepository.findById(2L)).willReturn(Optional.of(user));
+        given(anonTokenGenerator.generate()).willReturn("a1b2c3d4e5f6"); // 12자리 hex 스텁
 
         boolean result = withdrawalConfirmer.confirm(2L);
 

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
@@ -48,8 +48,8 @@ class WithdrawalConfirmerTest {
 
         assertThat(result).isTrue();
         assertThat(user.getStatus()).isEqualTo(UserStatus.DELETED);
-        assertThat(user.getEmail()).isEqualTo("deleted_2@pokade.invalid");
-        assertThat(user.getNickname()).isEqualTo("deleted_2");
+        assertThat(user.getEmail()).matches("deleted_[0-9a-f]{12}@pokade\\.invalid");
+        assertThat(user.getNickname()).matches("deleted_[0-9a-f]{12}");
         assertThat(user.getPassword()).isNull();
         ArgumentCaptor<UserWithdrawnEvent> captor = ArgumentCaptor.forClass(UserWithdrawnEvent.class);
         then(eventPublisher).should().publishEvent(captor.capture());

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class WithdrawalServiceTest {
@@ -196,5 +198,37 @@ class WithdrawalServiceTest {
                 .build();
         u.requestWithdrawal(LocalDateTime.now().minusDays(8));
         return u;
+    }
+
+    @Test
+    @DisplayName("확정 배치: 익명화 토큰 충돌(UNIQUE) 시 새 토큰으로 재시도해 확정한다")
+    void confirmExpired_retriesOnTokenCollision() {
+        User target = pendingUser(); // id=2, WITHDRAWAL_PENDING
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(eq(UserStatus.WITHDRAWAL_PENDING), any()))
+                .willReturn(List.of(target));
+        given(withdrawalConfirmer.confirm(2L))
+                .willThrow(new DataIntegrityViolationException("unique"))  // 1차: 충돌
+                .willReturn(true);                                          // 2차: 성공
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(withdrawalConfirmer).should(times(2)).confirm(2L);   // 재시도 발생
+        then(refreshTokenStore).should().delete(2L);              // 최종 정리 수행
+        then(tokenBlacklistStore).should().blacklist(2L);
+    }
+
+    @Test
+    @DisplayName("확정 배치: 재시도 초과 시 건너뛴다(정리 미수행 → 다음 배치 자가치유)")
+    void confirmExpired_givesUpAfterMaxRetries() {
+        User target = pendingUser();
+        given(userRepository.findAllByStatusAndWithdrawalRequestedAtBefore(eq(UserStatus.WITHDRAWAL_PENDING), any()))
+                .willReturn(List.of(target));
+        given(withdrawalConfirmer.confirm(2L))
+                .willThrow(new DataIntegrityViolationException("unique"));  // 항상 충돌
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        then(withdrawalConfirmer).should(times(3)).confirm(2L);   // MAX_ANON_RETRY 만큼만 시도
+        then(refreshTokenStore).should(never()).delete(2L);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/support/AnonymizationTokenGeneratorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/support/AnonymizationTokenGeneratorTest.java
@@ -1,0 +1,12 @@
+package com.pokade.domain.user.support;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class AnonymizationTokenGeneratorTest {
+    @Test
+    void generate_는_12자리_hex를_반환한다() {
+        assertThat(new AnonymizationTokenGenerator().generate()).matches("[0-9a-f]{12}");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #143

## ✨ 작업 내용
- 탈퇴 확정 익명화 값을 `deleted_{id}` → `deleted_{UUID 12자}`로 **랜덤화** (닉네임/이메일 UNIQUE 충돌로 특정 유저 확정이 영구 실패하던 문제 해결)
- `confirmWithdrawal(now, anonToken)` 시그니처 변경 — 토큰은 `WithdrawalConfirmer`에서 생성해 주입 (엔티티 결정성 유지)
- (별개) 컨트롤러 슬라이스 테스트 6개에 누락된 목 빈 추가 — `TokenBlacklistStore`(#49)·`WithdrawalService`(#132) 미목킹으로 컨텍스트 로딩 실패하던 기존 결함 수정

## 📸 스크린샷 / 테스트 결과
- `SPRING_PROFILES_ACTIVE=dev DB_HOST=localhost ./gradlew clean test` → **397개 전부 통과**

## 🔍 리뷰 포인트
- **입력 예약(`deleted_` 거부) 대신 랜덤화 채택**: 입력 예약은 탐침으로 익명화 스킴이 노출되고, 랜덤은 예측 불가라 표적 선점(griefing)·탈퇴 열거까지 차단. 충돌 시엔 건별 트랜잭션 롤백으로 다음 배치에서 자가치유

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 회원 탈퇴 확정 시 개인정보가 고유 익명 토큰을 기반으로 안전하게 익명화됩니다.
  * 익명화된 이메일과 닉네임의 형식이 일관되게 적용됩니다.

* **테스트**
  * 탈퇴 및 익명화 동작 검증을 새로운 토큰 형식에 맞게 업데이트했습니다.
  * 관련 컨트롤러 테스트의 인증·보안 의존성 설정을 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->