### PR TITLE
[Feature] #151 워치리스트 등록/조회/삭제 기능

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
@@ -1,0 +1,48 @@
+package com.pokade.domain.watchlist.controller;
+
+import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
+import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.service.WatchlistService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/watchlist")
+@RequiredArgsConstructor
+public class WatchlistController {
+
+    private final WatchlistService watchlistService;
+
+    @PostMapping
+    public ApiResponse<WatchlistResponse> addWatchlist(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody WatchlistCreateRequest request
+    ) {
+        return ApiResponse.ok("워치리스트에 등록되었습니다.", watchlistService.addWatchlist(userId, request));
+    }
+
+    @GetMapping
+    public ApiResponse<List<WatchlistResponse>> getWatchlist(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok(watchlistService.getWatchlist(userId));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteWatchlist(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        watchlistService.deleteWatchlist(userId, id);
+        return ApiResponse.ok("워치리스트에서 삭제되었습니다.");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCreateRequest.java
@@ -1,0 +1,18 @@
+package com.pokade.domain.watchlist.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record WatchlistCreateRequest(
+        @NotNull(message = "cardId는 필수입니다.")
+        Long cardId,
+
+        Long variantId,
+
+        @Positive(message = "targetBuyPrice는 0보다 커야 합니다.")
+        Integer targetBuyPrice,
+
+        @Positive(message = "targetSellPrice는 0보다 커야 합니다.")
+        Integer targetSellPrice
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -1,0 +1,28 @@
+package com.pokade.domain.watchlist.dto;
+
+import com.pokade.domain.watchlist.entity.Watchlist;
+
+import java.time.LocalDateTime;
+
+public record WatchlistResponse(
+        Long id,
+        Long cardId,
+        Long variantId,
+        Integer targetBuyPrice,
+        Integer targetSellPrice,
+        boolean isNotified,
+        LocalDateTime createdAt
+) {
+
+    public static WatchlistResponse of(Watchlist watchlist) {
+        return new WatchlistResponse(
+                watchlist.getId(),
+                watchlist.getCardId(),
+                watchlist.getVariantId(),
+                watchlist.getTargetBuyPrice(),
+                watchlist.getTargetSellPrice(),
+                watchlist.isNotified(),
+                watchlist.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -30,6 +30,7 @@ public class Watchlist {
     @Column(name = "card_id", nullable = false)
     private Long cardId;
 
+    // null이면 대표 변형 기준
     @Column(name = "variant_id")
     private Long variantId;
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -1,0 +1,62 @@
+package com.pokade.domain.watchlist.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "watchlist")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Watchlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "card_id", nullable = false)
+    private Long cardId;
+
+    @Column(name = "variant_id")
+    private Long variantId;
+
+    @Column(name = "target_buy_price")
+    private Integer targetBuyPrice;
+
+    @Column(name = "target_sell_price")
+    private Integer targetSellPrice;
+
+    @Column(name = "is_notified", nullable = false)
+    private boolean isNotified;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Watchlist(Long userId, Long cardId, Long variantId, Integer targetBuyPrice, Integer targetSellPrice) {
+        this.userId = userId;
+        this.cardId = cardId;
+        this.variantId = variantId;
+        this.targetBuyPrice = targetBuyPrice;
+        this.targetSellPrice = targetSellPrice;
+        this.isNotified = false;
+    }
+
+    public void markAsNotified() {
+        this.isNotified = true;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -1,0 +1,18 @@
+package com.pokade.domain.watchlist.repository;
+
+import com.pokade.domain.watchlist.entity.Watchlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
+
+    List<Watchlist> findByUserId(Long userId);
+
+    boolean existsByUserIdAndCardId(Long userId, Long cardId);
+
+    long countByUserId(Long userId);
+
+    Optional<Watchlist> findByIdAndUserId(Long id, Long userId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -1,0 +1,64 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
+import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WatchlistService {
+
+    private static final long WATCHLIST_LIMIT = 20;
+
+    private final WatchlistRepository watchlistRepository;
+
+    @Transactional
+    public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
+        if (request.targetBuyPrice() == null && request.targetSellPrice() == null) {
+            throw new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED);
+        }
+
+        if (watchlistRepository.existsByUserIdAndCardId(userId, request.cardId())) {
+            throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
+        }
+
+        if (watchlistRepository.countByUserId(userId) >= WATCHLIST_LIMIT) {
+            throw new BusinessException(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
+        }
+
+        Watchlist watchlist = Watchlist.builder()
+                .userId(userId)
+                .cardId(request.cardId())
+                .variantId(request.variantId())
+                .targetBuyPrice(request.targetBuyPrice())
+                .targetSellPrice(request.targetSellPrice())
+                .build();
+
+        Watchlist saved = watchlistRepository.save(watchlist);
+        return WatchlistResponse.of(saved);
+    }
+
+    public List<WatchlistResponse> getWatchlist(Long userId) {
+        return watchlistRepository.findByUserId(userId)
+                .stream()
+                .map(WatchlistResponse::of)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteWatchlist(Long userId, Long watchlistId) {
+        Watchlist watchlist = watchlistRepository.findByIdAndUserId(watchlistId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
+
+        watchlistRepository.delete(watchlist);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
     GRADE_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "진단 결과를 찾을 수 없습니다."),
     PRIMARY_VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 변형이 지정되지 않은 카드입니다."),
+    WATCHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "워치리스트 항목을 찾을 수 없습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
     TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다."),
@@ -65,7 +67,13 @@ public enum ErrorCode {
     DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 처리 중 오류가 발생했습니다."),
 
     // ===== 카드 도메인 임시 Rate Limit (팀 공통 정책 확정 시 제거) =====
-    CARD_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "카드 API 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
+    CARD_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "카드 API 요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
+    // ===== 워치리스트 도메인 =====
+    DUPLICATE_WATCHLIST(HttpStatus.CONFLICT, "이미 등록된 카드입니다."),
+    TARGET_PRICE_REQUIRED(HttpStatus.BAD_REQUEST, "목표 구매가 또는 판매가 중 하나는 입력해야 합니다."),
+    WATCHLIST_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "워치리스트는 최대 20개까지 등록할 수 있습니다."),
+    NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "이미 읽음 처리된 알림입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -1,0 +1,148 @@
+package com.pokade.domain.watchlist.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
+import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.service.WatchlistService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(WatchlistController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class WatchlistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private WatchlistService watchlistService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    private RequestPostProcessor userId(Long userId) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    @Test
+    void 등록에_성공하면_200과_등록된_항목을_반환한다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
+        WatchlistResponse response = new WatchlistResponse(
+                1L, 1L, null, 10000, null, false, LocalDateTime.now());
+
+        given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.cardId").value(1L))
+                .andExpect(jsonPath("$.data.targetBuyPrice").value(10000));
+    }
+
+    @Test
+    void 목표가가_둘_다_없으면_400을_반환한다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, null);
+
+        given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED));
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TARGET_PRICE_REQUIRED"));
+    }
+
+    @Test
+    void 이미_등록된_카드면_409를_반환한다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
+
+        given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.DUPLICATE_WATCHLIST));
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_WATCHLIST"));
+    }
+
+    @Test
+    void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
+        WatchlistResponse response = new WatchlistResponse(
+                1L, 1L, null, 10000, null, false, LocalDateTime.now());
+
+        given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/watchlist").with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
+    }
+
+    @Test
+    void 삭제에_성공하면_200을_반환한다() throws Exception {
+        willDoNothing().given(watchlistService).deleteWatchlist(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/watchlist/1").with(userId(100L)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 존재하지_않는_항목_삭제시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND))
+                .given(watchlistService).deleteWatchlist(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/watchlist/999").with(userId(100L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("WATCHLIST_NOT_FOUND"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
@@ -1,0 +1,116 @@
+package com.pokade.domain.watchlist.repository;
+
+import com.pokade.domain.watchlist.entity.Watchlist;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WatchlistRepositoryTest {
+
+    @Autowired
+    private WatchlistRepository watchlistRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void findByUserId는_해당_유저가_등록한_항목을_모두_조회한다() {
+        Long userId = insertUser("findbyuserid@test.com");
+        Long cardA = insertCard("watch-find-a");
+        Long cardB = insertCard("watch-find-b");
+        saveWatchlist(userId, cardA, 1000, null);
+        saveWatchlist(userId, cardB, null, 2000);
+
+        List<Watchlist> found = watchlistRepository.findByUserId(userId);
+
+        assertThat(found).hasSize(2);
+        assertThat(found).extracting(Watchlist::getCardId).containsExactlyInAnyOrder(cardA, cardB);
+    }
+
+    @Test
+    void existsByUserIdAndCardId는_등록된_조합이면_true_아니면_false() {
+        Long userId = insertUser("exists@test.com");
+        Long cardId = insertCard("watch-exists");
+        Long otherCardId = insertCard("watch-exists-other");
+        saveWatchlist(userId, cardId, 1000, null);
+
+        assertThat(watchlistRepository.existsByUserIdAndCardId(userId, cardId)).isTrue();
+        assertThat(watchlistRepository.existsByUserIdAndCardId(userId, otherCardId)).isFalse();
+    }
+
+    @Test
+    void countByUserId는_등록_개수만큼_정확히_카운트된다() {
+        Long userId = insertUser("count@test.com");
+        Long otherUserId = insertUser("count-other@test.com");
+        saveWatchlist(userId, insertCard("watch-count-a"), 1000, null);
+        saveWatchlist(userId, insertCard("watch-count-b"), 1000, null);
+
+        assertThat(watchlistRepository.countByUserId(userId)).isEqualTo(2);
+        assertThat(watchlistRepository.countByUserId(otherUserId)).isEqualTo(0);
+    }
+
+    @Test
+    void findByIdAndUserId는_본인_소유_항목만_조회된다() {
+        Long ownerId = insertUser("owner@test.com");
+        Long otherUserId = insertUser("other@test.com");
+        Watchlist saved = saveWatchlist(ownerId, insertCard("watch-owned"), 1000, null);
+
+        Optional<Watchlist> ownedResult = watchlistRepository.findByIdAndUserId(saved.getId(), ownerId);
+        Optional<Watchlist> otherResult = watchlistRepository.findByIdAndUserId(saved.getId(), otherUserId);
+
+        assertThat(ownedResult).isPresent();
+        assertThat(otherResult).isEmpty();
+    }
+
+    @Test
+    void 같은_유저가_같은_카드로_두번_저장하면_UNIQUE_제약으로_예외가_발생한다() {
+        Long userId = insertUser("dup@test.com");
+        Long cardId = insertCard("watch-dup");
+        saveWatchlist(userId, cardId, 1000, null);
+        entityManager.flush();
+
+        assertThatThrownBy(() -> {
+            saveWatchlist(userId, cardId, 2000, null);
+            entityManager.flush();
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private Watchlist saveWatchlist(Long userId, Long cardId, Integer targetBuyPrice, Integer targetSellPrice) {
+        return watchlistRepository.save(
+                Watchlist.builder()
+                        .userId(userId)
+                        .cardId(cardId)
+                        .targetBuyPrice(targetBuyPrice)
+                        .targetSellPrice(targetSellPrice)
+                        .build()
+        );
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Repo Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -1,0 +1,136 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
+import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistServiceTest {
+
+    @Mock WatchlistRepository watchlistRepository;
+    @InjectMocks WatchlistService watchlistService;
+
+    private Watchlist watchlist(Long userId, Long cardId) {
+        return Watchlist.builder()
+                .userId(userId).cardId(cardId).variantId(null)
+                .targetBuyPrice(1000).targetSellPrice(null)
+                .build();
+    }
+
+    // ===== 등록 =====
+    @Test
+    @DisplayName("등록: 목표가 둘 다 null이면 TARGET_PRICE_REQUIRED")
+    void addWatchlist_targetPriceRequired() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, null);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TARGET_PRICE_REQUIRED);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 이미 등록된 카드면 DUPLICATE_WATCHLIST")
+    void addWatchlist_duplicate() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(true);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_WATCHLIST);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 20개 이미 등록했으면 WATCHLIST_LIMIT_EXCEEDED")
+    void addWatchlist_limitExceeded() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(20L);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 검증 통과하면 저장 후 WatchlistResponse 반환")
+    void addWatchlist_success() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        then(watchlistRepository).should().save(any(Watchlist.class));
+        assertThat(response.cardId()).isEqualTo(1L);
+        assertThat(response.variantId()).isEqualTo(2L);
+        assertThat(response.targetBuyPrice()).isEqualTo(1000);
+    }
+
+    // ===== 목록 조회 =====
+    @Test
+    @DisplayName("목록 조회: 등록된 워치리스트 없으면 빈 리스트")
+    void getWatchlist_empty() {
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of());
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 등록된 워치리스트 개수만큼 반환")
+    void getWatchlist_success() {
+        given(watchlistRepository.findByUserId(1L))
+                .willReturn(List.of(watchlist(1L, 10L), watchlist(1L, 20L)));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result).hasSize(2);
+    }
+
+    // ===== 삭제 =====
+    @Test
+    @DisplayName("삭제: 존재하지 않으면 WATCHLIST_NOT_FOUND")
+    void deleteWatchlist_notFound() {
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> watchlistService.deleteWatchlist(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WATCHLIST_NOT_FOUND);
+        then(watchlistRepository).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("삭제: 정상 케이스면 repository.delete() 호출")
+    void deleteWatchlist_success() {
+        Watchlist target = watchlist(1L, 10L);
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        watchlistService.deleteWatchlist(1L, 1L);
+
+        then(watchlistRepository).should().delete(target);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -89,6 +89,34 @@ class WatchlistServiceTest {
         assertThat(response.targetBuyPrice()).isEqualTo(1000);
     }
 
+    @Test
+    @DisplayName("등록: variantId가 null이어도 정상 등록된다")
+    void addWatchlist_success_variantIdNull() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.variantId()).isNull();
+        assertThat(response.targetBuyPrice()).isEqualTo(10000);
+    }
+
+    @Test
+    @DisplayName("등록: targetSellPrice만 있어도 정상 등록된다")
+    void addWatchlist_success_targetSellPriceOnly() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, 5000);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.targetBuyPrice()).isNull();
+        assertThat(response.targetSellPrice()).isEqualTo(5000);
+    }
+
     // ===== 목록 조회 =====
     @Test
     @DisplayName("목록 조회: 등록된 워치리스트 없으면 빈 리스트")


### PR DESCRIPTION
## 📌 관련 이슈
- #151 

## ✨ 작업 내용
- FR-WATCH-01~03 구현 (등록/조회/삭제)
- domain/watchlist 패키지 신규, ErrorCode 6종 추가(NOTIFICATION_* 2종은 다음 이슈용 사전 추가)
- 목표가 필수 검증, 중복 등록 방지(409), 20개 제한(409), 삭제는 소유권 무관 404 통일

## 📸 스크린샷 / 테스트 결과
- 로컬 dev 프로파일 기동 확인, `./gradlew test` 전체 통과 (기존 도메인 회귀 없음)
- Repository/Service/Controller 3개 레이어 테스트 작성 완료

## 🔍 리뷰 포인트
- ErrorCode.java(공유 파일)에 신규 섹션으로만 추가, 기존 항목 미변경
- 알림 자동 생성 로직은 범위 밖 (다음 이슈)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관심 목록을 등록, 조회, 삭제할 수 있습니다.
  * 목표 매수·매도 가격을 설정하고 가격 알림 상태를 확인할 수 있습니다.
  * 관심 목록은 사용자별 최대 20개까지 저장되며, 중복 등록을 방지합니다.
  * 등록 시 필수 항목과 목표 가격 입력값을 검증합니다.

* **오류 처리**
  * 관심 목록 미존재, 중복 등록, 한도 초과, 목표 가격 누락 상황에 대한 안내를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->