### PR TITLE
[Feature] #156 알림 목록 조회/읽음 처리 기능

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.notification.controller;
+
+import com.pokade.domain.notification.dto.NotificationResponse;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ApiResponse<List<NotificationResponse>> getNotifications(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok(notificationService.getNotifications(userId));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ApiResponse<Void> markAsRead(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        notificationService.markAsRead(userId, id);
+        return ApiResponse.ok("알림을 읽음 처리했습니다.");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.notification.dto;
+
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long id,
+        NotificationType type,
+        String message,
+        boolean isRead,
+        LocalDateTime createdAt
+) {
+
+    public static NotificationResponse of(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getMessage(),
+                notification.isRead(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
@@ -1,0 +1,66 @@
+package com.pokade.domain.notification.entity;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(length = 255)
+    private String message;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Notification(Long userId, NotificationType type, String message) {
+        this.userId = userId;
+        this.type = type;
+        this.message = message;
+        this.isRead = false;
+    }
+
+    public void markAsRead() {
+        requireUnread();
+        this.isRead = true;
+    }
+
+    private void requireUnread() {
+        if (this.isRead) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_ALREADY_READ);
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
@@ -1,0 +1,8 @@
+package com.pokade.domain.notification.entity;
+
+// schema.sql 주석에 "등"이라고 돼있어 추후 알림 종류가 추가될 수 있음
+public enum NotificationType {
+    PRICE_TARGET,
+    TRADE_CONFIRMED,
+    LISTING_STALE
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.pokade.domain.notification.repository;
+
+import com.pokade.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Notification> findByIdAndUserId(Long id, Long userId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -1,0 +1,35 @@
+package com.pokade.domain.notification.service;
+
+import com.pokade.domain.notification.dto.NotificationResponse;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public List<NotificationResponse> getNotifications(Long userId) {
+        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(NotificationResponse::of)
+                .toList();
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        notification.markAsRead();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,103 @@
+package com.pokade.domain.notification.controller;
+
+import com.pokade.domain.notification.dto.NotificationResponse;
+import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    private RequestPostProcessor userId(Long userId) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    @Test
+    void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
+        NotificationResponse response = new NotificationResponse(
+                1L, NotificationType.PRICE_TARGET, "메시지", false, LocalDateTime.now());
+
+        given(notificationService.getNotifications(100L)).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/notifications").with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].id").value(1L));
+    }
+
+    @Test
+    void 읽음_처리에_성공하면_200을_반환한다() throws Exception {
+        willDoNothing().given(notificationService).markAsRead(anyLong(), anyLong());
+
+        mockMvc.perform(patch("/api/notifications/1/read").with(userId(100L)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 존재하지_않는_알림_읽음_처리시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND))
+                .given(notificationService).markAsRead(anyLong(), anyLong());
+
+        mockMvc.perform(patch("/api/notifications/999/read").with(userId(100L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOTIFICATION_NOT_FOUND"));
+    }
+
+    @Test
+    void 이미_읽은_알림_읽음_처리시_400을_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.NOTIFICATION_ALREADY_READ))
+                .given(notificationService).markAsRead(anyLong(), anyLong());
+
+        mockMvc.perform(patch("/api/notifications/1/read").with(userId(100L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("NOTIFICATION_ALREADY_READ"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
@@ -79,6 +80,8 @@ class NotificationControllerTest {
 
         mockMvc.perform(patch("/api/notifications/1/read").with(userId(100L)))
                 .andExpect(status().isOk());
+
+        then(notificationService).should().markAsRead(100L, 1L);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/notification/entity/NotificationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/entity/NotificationTest.java
@@ -1,0 +1,39 @@
+package com.pokade.domain.notification.entity;
+
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationTest {
+
+    private Notification notification() {
+        return Notification.builder()
+                .userId(1L).type(NotificationType.PRICE_TARGET).message("메시지")
+                .build();
+    }
+
+    @Test
+    @DisplayName("markAsRead: 처음 호출하면 isRead가 true로 바뀐다")
+    void markAsRead_success() {
+        Notification notification = notification();
+
+        notification.markAsRead();
+
+        assertThat(notification.isRead()).isTrue();
+    }
+
+    @Test
+    @DisplayName("markAsRead: 이미 읽음 상태에서 다시 호출하면 NOTIFICATION_ALREADY_READ")
+    void markAsRead_alreadyRead() {
+        Notification notification = notification();
+        notification.markAsRead();
+
+        assertThatThrownBy(notification::markAsRead)
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTIFICATION_ALREADY_READ);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.pokade.domain.notification.repository;
+
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void findByUserIdOrderByCreatedAtDesc는_같은_유저의_알림을_최신순으로_조회한다() {
+        Long userId = insertUser("order@test.com");
+        Notification first = saveNotification(userId, NotificationType.PRICE_TARGET, "first");
+        Notification second = saveNotification(userId, NotificationType.TRADE_CONFIRMED, "second");
+        Notification third = saveNotification(userId, NotificationType.LISTING_STALE, "third");
+
+        List<Notification> found = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        assertThat(found).extracting(Notification::getId)
+                .containsExactly(third.getId(), second.getId(), first.getId());
+    }
+
+    @Test
+    void findByUserIdOrderByCreatedAtDesc는_다른_유저의_알림과_섞이지_않는다() {
+        Long userId = insertUser("mine@test.com");
+        Long otherUserId = insertUser("other@test.com");
+        saveNotification(userId, NotificationType.PRICE_TARGET, "mine");
+        saveNotification(otherUserId, NotificationType.PRICE_TARGET, "other");
+
+        List<Notification> found = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+
+        assertThat(found).hasSize(1);
+        assertThat(found.get(0).getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void findByIdAndUserId는_본인_소유_알림만_조회된다() {
+        Long ownerId = insertUser("owner@test.com");
+        Long otherUserId = insertUser("other2@test.com");
+        Notification saved = saveNotification(ownerId, NotificationType.PRICE_TARGET, "owned");
+
+        Optional<Notification> ownedResult = notificationRepository.findByIdAndUserId(saved.getId(), ownerId);
+        Optional<Notification> otherResult = notificationRepository.findByIdAndUserId(saved.getId(), otherUserId);
+
+        assertThat(ownedResult).isPresent();
+        assertThat(otherResult).isEmpty();
+    }
+
+    private Notification saveNotification(Long userId, NotificationType type, String message) {
+        Notification saved = notificationRepository.save(
+                Notification.builder()
+                        .userId(userId)
+                        .type(type)
+                        .message(message)
+                        .build()
+        );
+        entityManager.flush();
+        return saved;
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,81 @@
+package com.pokade.domain.notification.service;
+
+import com.pokade.domain.notification.dto.NotificationResponse;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock NotificationRepository notificationRepository;
+    @InjectMocks NotificationService notificationService;
+
+    private Notification notification(Long userId) {
+        return Notification.builder()
+                .userId(userId).type(NotificationType.PRICE_TARGET).message("메시지")
+                .build();
+    }
+
+    // ===== 목록 조회 =====
+    @Test
+    @DisplayName("목록 조회: 알림이 없으면 빈 리스트 반환")
+    void getNotifications_empty() {
+        given(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of());
+
+        List<NotificationResponse> result = notificationService.getNotifications(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 알림 개수만큼 NotificationResponse 리스트 반환")
+    void getNotifications_success() {
+        given(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L))
+                .willReturn(List.of(notification(1L), notification(1L)));
+
+        List<NotificationResponse> result = notificationService.getNotifications(1L);
+
+        assertThat(result).hasSize(2);
+    }
+
+    // ===== 읽음 처리 =====
+    @Test
+    @DisplayName("읽음 처리: 존재하지 않으면 NOTIFICATION_NOT_FOUND")
+    void markAsRead_notFound() {
+        given(notificationRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("읽음 처리: 정상 케이스면 notification.markAsRead()가 호출된다")
+    void markAsRead_success() {
+        Notification target = Mockito.spy(notification(1L));
+        given(notificationRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        notificationService.markAsRead(1L, 1L);
+
+        then(target).should().markAsRead();
+        assertThat(target.isRead()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #156 

## ✨ 작업 내용
- FR-WATCH-04~05 구현 (조회/읽음 처리)
- domain/notification 패키지 신규 (entity/enum/repository/dto/service/controller)
- 읽음 상태 검증은 엔티티(Notification.markAsRead())가 직접 책임지는 구조 (Listing.cancel() 패턴과 동일)

## 📸 스크린샷 / 테스트 결과
- `./gradlew test` 전체 통과, watchlist+notification 34개 테스트 포함 회귀 없음
- Repository/Service/Controller + 엔티티 단위 테스트까지 4종 작성

## 🔍 리뷰 포인트
- ErrorCode(NOTIFICATION_NOT_FOUND, NOTIFICATION_ALREADY_READ)는 이전 PR(#153)에서 이미 추가돼 있어 이번 PR엔 변경 없음
- markAsRead()의 "이미 읽음" 검증을 Service가 아닌 엔티티에서 처리 — Listing.cancel()/requireActive() 패턴을 그대로 따름
- NotificationRepositoryTest의 최신순 정렬 테스트가 타임스탬프 기반이라, 극단적으로 같은 시각에 저장되면 순서가 흔들릴 여지 있음 — 필요시 id 기준 2차 정렬 논의


## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자별 알림 목록을 최신순으로 조회할 수 있습니다.
  * 알림을 읽음 상태로 변경할 수 있습니다.
  * 가격 목표, 거래 완료, 등록 만료 알림 유형을 지원합니다.
  * 이미 읽은 알림이나 존재하지 않는 알림 처리 시 적절한 오류를 제공합니다.

* **테스트**
  * 알림 조회, 읽음 처리 및 오류 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->