### PR TITLE
Feature] #152 소셜 로그인(OAuth2) Google·Kakao (FR-AUTH-07/08/09)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.pokade.domain.auth.controller;
 
 import com.pokade.domain.auth.dto.TokenPair;
 import com.pokade.domain.auth.dto.request.LoginRequest;
+import com.pokade.domain.auth.dto.request.OAuth2RegisterRequest;
 import com.pokade.domain.auth.dto.request.SignupRequest;
 import com.pokade.domain.auth.dto.response.LoginResponse;
 import com.pokade.domain.auth.dto.response.SignupResponse;
 import com.pokade.domain.auth.service.AuthService;
+import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.global.response.ApiResponse;
 import com.pokade.global.web.RefreshTokenCookieFactory;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final OAuth2LoginService oauth2LoginService;
     private final RefreshTokenCookieFactory refreshTokenCookieFactory;
 
     @PostMapping("/signup")
@@ -66,4 +69,16 @@ public class AuthController {
                 refreshTokenCookieFactory.expired().toString());
         return ApiResponse.ok("로그아웃 성공");
     }
+
+    @PostMapping("/oauth2/register")
+    public ApiResponse<LoginResponse> oauth2Register(
+            @Valid @RequestBody OAuth2RegisterRequest request,
+            HttpServletResponse response
+    ) {
+        TokenPair tokens = oauth2LoginService.register(request.ticket(), request.nickname());
+        response.addHeader(HttpHeaders.SET_COOKIE,
+                refreshTokenCookieFactory.create(tokens.refreshToken()).toString());
+        return ApiResponse.ok("소셜 회원가입이 완료되었습니다.", LoginResponse.of(tokens.accessToken()));
+    }
+
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/OAuth2Outcome.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/OAuth2Outcome.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.auth.dto;
+
+public record OAuth2Outcome() {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/OAuth2Outcome.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/OAuth2Outcome.java
@@ -1,4 +1,18 @@
 package com.pokade.domain.auth.dto;
 
-public record OAuth2Outcome() {
+import com.pokade.domain.user.entity.type.Provider;
+
+public sealed interface OAuth2Outcome {
+
+    // 기존 소셜 계정 -> 로그인 (refresh 토큰만 넘김, access는 FE가 /reissue)
+    record LoggedIn(String refreshToken) implements OAuth2Outcome {
+    }
+
+    // email이 다른 provide로 이미 존재 -> 충돌 거부
+    record Conflict(Provider provider) implements OAuth2Outcome {
+    }
+
+    // 신규 -> 가입 유도(provider, email 담은 서명 티켓)
+    record SignupRequired(String ticket) implements OAuth2Outcome {
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.auth.dto.request;
+
+public record OAuth2RegisterRequest() {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
@@ -1,4 +1,18 @@
 package com.pokade.domain.auth.dto.request;
 
-public record OAuth2RegisterRequest() {
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record OAuth2RegisterRequest(
+        @NotBlank(message = "가입 티켓은 필수입니다.")
+        String ticket,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+        String nickname,
+
+        @AssertTrue(message = "약관에 동의해야 가입할 수 있습니다.")
+        boolean termsAgreed
+) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/AuthService.java
@@ -82,12 +82,7 @@ public class AuthService {
 
         loginAttemptStore.reset(email); // 로그인 성공 시 실패 기록 초기화
 
-        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole().name());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-
-        refreshTokenStore.save(user.getId(), refreshToken);
-
-        return new TokenPair(accessToken, refreshToken);
+        return issueToken(user);
     }
 
     public void logout(String accessToken) {
@@ -141,5 +136,12 @@ public class AuthService {
     @PostConstruct
     void initDummyHash() {
         this.dummyHash = passwordEncoder.encode("timing-guard");
+    }
+
+    public TokenPair issueToken(User user) {
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole().name());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        refreshTokenStore.save(user.getId(), refreshToken);
+        return new TokenPair(accessToken, refreshToken);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/OAuth2LoginService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/OAuth2LoginService.java
@@ -1,4 +1,79 @@
 package com.pokade.domain.auth.service;
 
-public class OAuth2Login {
+import com.pokade.domain.auth.dto.OAuth2Outcome;
+import com.pokade.domain.auth.dto.TokenPair;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2LoginService {
+
+    private final UserRepository userRepository;
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private static final Duration SIGNUP_TICKET_TTL = Duration.ofMinutes(5);
+    private static final String CLAIM_PROVIDER = "provider";
+    private static final String CLAIM_EMAIL = "email";
+
+    // OAUTH2 콜백에서 email, provider로 로그인/충돌/신규를 판정한다.
+    @Transactional(readOnly = true)
+    public OAuth2Outcome resolve(String email, Provider provider) {
+        User user = userRepository.findByEmail(email).orElse(null);
+
+        // 신규 -> 유저 안 만들고 가입 티켓 발급
+        if (user == null) {
+            String ticket = jwtTokenProvider.createSignedTicket(
+                    Map.of(CLAIM_PROVIDER, provider.name(), CLAIM_EMAIL, email),
+                    SIGNUP_TICKET_TTL);
+            return new OAuth2Outcome.SignupRequired(ticket);
+        }
+
+        // email이 다른 provider로 존재 -> 충돌
+        if (user.getProvider() != provider) {
+            return new OAuth2Outcome.Conflict(user.getProvider());
+        }
+
+        switch (user.getStatus()) {
+            case SUSPENDED -> throw new BusinessException(ErrorCode.ACCOUNT_SUSPENDED);
+            case PENDING, DELETED -> throw new BusinessException(ErrorCode.LOGIN_FAILED);
+            case ACTIVE, WITHDRAWAL_PENDING -> {/* 로그인 허용*/}
+        }
+        TokenPair tokens = authService.issueToken(user);
+        return new OAuth2Outcome.LoggedIn(tokens.refreshToken());
+    }
+
+    // 서명 티켓을 검증하고 신규 소셜 유저를 생성한 뒤 토큰을 발급한다.
+    @Transactional
+    public TokenPair register(String ticket, String nickname) {
+        String providerName = jwtTokenProvider.parseSignedTicket(ticket, CLAIM_PROVIDER);
+        String email = jwtTokenProvider.parseSignedTicket(ticket, CLAIM_EMAIL);
+
+        if (providerName == null || email == null) {   // 위조·만료 티켓
+            throw new BusinessException(ErrorCode.INVALID_OAUTH2_TICKET);
+        }
+
+        if (userRepository.existsByEmail(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        User user = userRepository.save(
+                User.createSocialUser(email, nickname, Provider.valueOf(providerName)));
+        return authService.issueToken(user);
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/service/OAuth2LoginService.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/service/OAuth2LoginService.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.auth.service;
+
+public class OAuth2Login {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -96,6 +96,19 @@ public class User {
                 .build();
     }
 
+    public static User createSocialUser(String email, String nickname, Provider provider) {
+        return User.builder()
+                .email(email)
+                .nickname(nickname)
+                .provider(provider)
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .termsAgreedAt(LocalDateTime.now())
+                .marketingOptIn(false)
+                .pointBalance(0)
+                .build();
+    }
+
     public void verifyEmail() {
         this.status = UserStatus.ACTIVE;
     }

--- a/Pokade/src/main/java/com/pokade/global/config/PasswordEncoderConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,4 @@
+package com.pokade.global.config;
+
+public class PasswordEncoderConfig {
+}

--- a/Pokade/src/main/java/com/pokade/global/config/PasswordEncoderConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/PasswordEncoderConfig.java
@@ -1,4 +1,16 @@
 package com.pokade.global.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
 public class PasswordEncoderConfig {
+
+    // 비밀번호 해싱 인코더 (BCrypt)
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -2,6 +2,9 @@ package com.pokade.global.config;
 
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtAuthenticationFilter;
+import com.pokade.global.security.oauth.CookieAuthorizationRequestRepository;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,8 +13,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -28,10 +29,14 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     // 인증 없이 접근을 허용할 경로 목록
     private static final String[] AUTH_WHITELIST = {
             "/api/auth/**",
+            "/api/oauth2/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",
@@ -51,6 +56,14 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/api/oauth2/authorization")
+                                .authorizationRequestRepository(cookieAuthorizationRequestRepository))
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("/api/oauth2/callback/*"))
+                        .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(oAuth2LoginFailureHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
@@ -82,11 +95,5 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
-    }
-
-    // 비밀번호 해싱 인코더 (BCrypt)
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.pokade.global.config;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtAuthenticationFilter;
 import com.pokade.global.security.oauth.CookieAuthorizationRequestRepository;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
 import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
 import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import jakarta.servlet.DispatcherType;
@@ -32,6 +33,7 @@ public class SecurityConfig {
     private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     // 인증 없이 접근을 허용할 경로 목록
     private static final String[] AUTH_WHITELIST = {
@@ -63,7 +65,9 @@ public class SecurityConfig {
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/api/oauth2/callback/*"))
                         .successHandler(oAuth2LoginSuccessHandler)
-                        .failureHandler(oAuth2LoginFailureHandler))
+                        .failureHandler(oAuth2LoginFailureHandler)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService)))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 일치하지 않습니다."),
     LOGIN_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "로그인 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_OAUTH2_TICKET(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 가입 요청입니다."),
     TOKEN_STOLEN(HttpStatus.UNAUTHORIZED, "비정상적인 접근이 감지되어 로그아웃되었습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
     EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증이 완료된 계정입니다."),

--- a/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
+++ b/Pokade/src/main/java/com/pokade/global/security/JwtTokenProvider.java
@@ -5,7 +5,9 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.time.Duration;
 import java.util.Date;
+import java.util.Map;
 
 // JWT access token 발급·검증을 담당하는 컴포넌트
 @Component
@@ -77,5 +79,36 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    // 임의 값을 담은 단명 서명 티켓 발급 (범용 - 쿠키 인증요청, 가입 티켓 공용)
+    public String createSignedTicket(String claim, String value, Duration ttl) {
+        return Jwts.builder()
+                .claim(claim, value)
+                .expiration(new Date(System.currentTimeMillis() + ttl.toMillis()))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 단명 서명 티켓에서 값을 추출 (서명, 만료 검증 실패 시 null)
+    public String parseSignedTicket(String token, String claim) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get(claim, String.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // 여러 값을 담은 단명 서명 티켓 발급 (밤용 - 가입 티켓 등)
+    public String createSignedTicket(Map<String, String> claims, Duration ttl) {
+        var builder = Jwts.builder()
+                .expiration(new Date(System.currentTimeMillis() + ttl.toMillis()));
+        claims.forEach(builder::claim);
+        return builder.signWith(secretKey).compact();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/CookieAuthorizationRequestRepository.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/CookieAuthorizationRequestRepository.java
@@ -1,4 +1,110 @@
 package com.pokade.global.security.oauth;
 
-public class CookieAuthorizationRequestRepository {
+import com.pokade.global.security.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.*;
+import java.time.Duration;
+import java.util.Base64;
+
+@Component
+public class CookieAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final String COOKIE_PATH = "/api/oauth2";
+    private static final Duration COOKIE_TTL = Duration.ofMinutes(3);
+    // 역직렬화 화이트리스트 - 쿠키로 들어온 임의 클래스 역질렬화(가젯 공격) 차단
+    private static final String DESERIALIZE_FILTER = "org.springframework.security.oauth2.**;java.util.**;java.lang.**;java.time.**;java.net.**;!*";
+    private static final String CLAIM_AUTH_REQUEST = "authRequest";
+
+    private final boolean secure;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public CookieAuthorizationRequestRepository(
+            @Value("${app.cookie.secure:false}") boolean secure,
+            JwtTokenProvider jwtTokenProvider) {
+        this.secure = secure;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        Cookie cookie = findCookie(request);
+        return cookie == null ? null : deserialize(cookie.getValue());
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            writeCookie(response, "", Duration.ZERO);
+            return;
+        }
+        writeCookie(response, serialize(authorizationRequest), COOKIE_TTL);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+        if (authorizationRequest != null) {
+            writeCookie(response, "", Duration.ZERO);
+        }
+        return authorizationRequest;
+    }
+
+    // 요청에서 인가요청 쿠키를 찾는다
+    private Cookie findCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (COOKIE_NAME.equals(cookie.getName())) return cookie;
+        }
+        return null;
+    }
+
+    // 인가요청 쿠키를 응답에 심는다 (maxAge=ZERO면 만료)
+    private void writeCookie(HttpServletResponse response, String value, Duration maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(secure)
+                .path(COOKIE_PATH)
+                .maxAge(maxAge)
+                .sameSite("Lax")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    // OAuth2AuthorizationRequest -> Base64 문자열
+    private String serialize(OAuth2AuthorizationRequest authorizationRequest) {
+        try (ByteArrayOutputStream byteBuffer = new ByteArrayOutputStream();
+             ObjectOutputStream objectWriter = new ObjectOutputStream(byteBuffer)) {
+            objectWriter.writeObject(authorizationRequest);
+            objectWriter.flush();
+            String base64 = Base64.getUrlEncoder().encodeToString(byteBuffer.toByteArray());
+            return jwtTokenProvider.createSignedTicket(CLAIM_AUTH_REQUEST, base64, COOKIE_TTL);
+        } catch (IOException e) {
+            throw new IllegalStateException("OAuth2 인가요청 직렬화 실패", e);
+        }
+    }
+
+    // Base64(URL) 문자열 ->  OAuth2AuthorizationRequest (화이트리스트 필터 적용)
+    private OAuth2AuthorizationRequest deserialize(String value) {
+        String base64 = jwtTokenProvider.parseSignedTicket(value, CLAIM_AUTH_REQUEST);
+        if (base64 == null) {
+            return null; // 서명 위조,만료 -> 문 앞에서 거부 (readObject 도달 안 함)
+        }
+        byte[] bytes = Base64.getUrlDecoder().decode(base64);
+        try (ObjectInputStream objectReader = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+            objectReader.setObjectInputFilter(ObjectInputFilter.Config.createFilter(DESERIALIZE_FILTER));
+            return (OAuth2AuthorizationRequest) objectReader.readObject();
+        } catch (IOException | ClassNotFoundException e) {
+            return null;
+        }
+    }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/CookieAuthorizationRequestRepository.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,4 @@
+package com.pokade.global.security.oauth;
+
+public class CookieAuthorizationRequestRepository {
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/CustomOAuth2UserService.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,42 @@
+package com.pokade.global.security.oauth;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService  {
+
+    // provider userinfo를 신원 attribute로 정규화 한다 (Kakao의 중첩 email을 최상위로 평탄화)
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User user = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        if ("kakao".equals(registrationId)) {
+            return flattenKakaoEmail(user, userRequest);
+        }
+        return user; // google 등은 최상위 email이라 그대로
+    }
+
+    // kakao_account.email 을 최상위 email attribute로 끌어올린다.
+    private OAuth2User flattenKakaoEmail(OAuth2User user, OAuth2UserRequest userRequest) {
+        Map<String, Object> attributes = new HashMap<>(user.getAttributes());
+        Object kakaoAccount = attributes.get("kakao_account");
+        if (kakaoAccount instanceof Map<?, ?> account) {
+            Object email = account.get("email");
+            if (email != null) {
+                attributes.put("email", email);
+            }
+        }
+        String nameAttributeKey = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        return new DefaultOAuth2User(user.getAuthorities(), attributes, nameAttributeKey);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
@@ -1,4 +1,34 @@
 package com.pokade.global.security.oauth;
 
-public class OAuth2LoginFailureHandler {
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+    private final String redirectBase;
+
+    public OAuth2LoginFailureHandler(
+            @Value("${app.oauth2.redirect-base}") String redirectBase) {
+        this.redirectBase = redirectBase;
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String reason = "oauth2_failed";
+        if (exception instanceof OAuth2AuthenticationException oauthException) {
+            reason = oauthException.getError().getErrorCode();
+        }
+        response.sendRedirect(redirectBase + "/login?error=" + URLEncoder.encode(reason, StandardCharsets.UTF_8));
+    }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
@@ -1,0 +1,4 @@
+package com.pokade.global.security.oauth;
+
+public class OAuth2LoginFailureHandler {
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -61,9 +61,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                             refreshTokenCookieFactory.create(loggedIn.refreshToken()).toString());
                     redirect(response, "/oauth2/success");
                 }
-                case OAuth2Outcome.Conflict conflict -> redirect(response, "/login?error=email_conflict");
-                case OAuth2Outcome.SignupRequired signup -> redirect(response, "/signup/social?ticket="
-                        + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
+                case OAuth2Outcome.Conflict ignored -> redirect(response, "/login?error=email_conflict");
+                case OAuth2Outcome.SignupRequired signup -> redirect(response, "/signup/social#ticket="
+                                + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
             }
         } catch (BusinessException e) {   // resolve의 상태 가드(정지 등) → 에러 페이지
             redirect(response, "/login?error=" + e.getErrorCode().name().toLowerCase());

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,4 @@
+package com.pokade.global.security.oauth;
+
+public class OAuth2LoginSuccessHandler {
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -1,4 +1,77 @@
 package com.pokade.global.security.oauth;
 
-public class OAuth2LoginSuccessHandler {
+import com.pokade.domain.auth.dto.OAuth2Outcome;
+import com.pokade.domain.auth.service.OAuth2LoginService;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.web.RefreshTokenCookieFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final OAuth2LoginService oauth2LoginService;
+    private final RefreshTokenCookieFactory refreshTokenCookieFactory;
+    private final String redirectBase;
+
+    public OAuth2LoginSuccessHandler(
+            OAuth2LoginService oauth2LoginService,
+            RefreshTokenCookieFactory refreshTokenCookieFactory,
+            @Value("${app.oauth2.redirect-base}") String redirectBase) {
+        this.oauth2LoginService = oauth2LoginService;
+        this.refreshTokenCookieFactory = refreshTokenCookieFactory;
+        this.redirectBase = redirectBase;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        String email = token.getPrincipal().getAttribute("email");
+
+        if (email == null) {
+            redirect(response, "/login?error=email_required");
+            return;
+        }
+
+        Provider provider;
+        try {
+            provider = Provider.valueOf(token.getAuthorizedClientRegistrationId().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            redirect(response, "/login?error=unsupported_provider");
+            return;
+        }
+
+        try {
+            OAuth2Outcome outcome = oauth2LoginService.resolve(email, provider);
+            switch (outcome) {
+                case OAuth2Outcome.LoggedIn loggedIn -> {
+                    response.addHeader(HttpHeaders.SET_COOKIE,
+                            refreshTokenCookieFactory.create(loggedIn.refreshToken()).toString());
+                    redirect(response, "/oauth2/success");
+                }
+                case OAuth2Outcome.Conflict conflict -> redirect(response, "/login?error=email_conflict");
+                case OAuth2Outcome.SignupRequired signup -> redirect(response, "/signup/social?ticket="
+                        + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
+            }
+        } catch (BusinessException e) {   // resolve의 상태 가드(정지 등) → 에러 페이지
+            redirect(response, "/login?error=" + e.getErrorCode().name().toLowerCase());
+        }
+
+    }
+
+    private void redirect(HttpServletResponse response, String path) throws IOException {
+        response.sendRedirect(redirectBase + path);
+    }
 }

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -41,10 +41,21 @@ spring:
           starttls:
             enable: true
 
+  # 운영: Google OAuth credential은 기본값 없이 주입 강제 (미설정 시 부팅 실패 = fail-fast)
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+
 # 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
 app:
   cookie:
     secure: true
+  oauth2:
+    redirect-base: ${APP_OAUTH2_REDIRECT_BASE:https://www.pokade.store}
 
 pokade:
   ai:

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -49,6 +49,9 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+          kakao: # ← 추가
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
 
 # 운영: refresh 쿠키 Secure 플래그 on (HTTPS 전송 강제) — dev는 기본값 false 유지
 app:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -19,6 +19,21 @@ spring:
               - email
               - profile
             redirect-uri: "{baseUrl}/api/oauth2/callback/{registrationId}"
+          kakao: # ← 추가
+            client-id: ${KAKAO_CLIENT_ID:dummy}
+            client-secret: ${KAKAO_CLIENT_SECRET:dummy}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/api/oauth2/callback/{registrationId}"
+            client-authentication-method: client_secret_post
+            scope:
+              - account_email
+            client-name: Kakao
+        provider: # ← 추가 (registration과 같은 레벨)
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
   jpa:
     open-in-view: false
     properties:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -8,7 +8,17 @@ spring:
       - optional:file:.env[.properties]
       - optional:file:Pokade/.env[.properties]
       - optional:file:BE/Pokade/.env[.properties]
-
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:dummy}
+            client-secret: ${GOOGLE_CLIENT_SECRET:dummy}
+            scope:
+              - email
+              - profile
+            redirect-uri: "{baseUrl}/api/oauth2/callback/{registrationId}"
   jpa:
     open-in-view: false
     properties:
@@ -28,3 +38,9 @@ jwt:
   secret: ${JWT_SECRET}            # .env(spring.config.import)로 주입 — 미설정 시 부팅 실패(fail-fast)
   access-expiration: 30m
   refresh-expiration: 14d      # 추가 (Spring Duration이 14d = 14일로 파싱)
+
+app:
+  cookie:
+    secure: ${APP_COOKIE_SECURE:false} # 이미 코드가 참조 중인 값을 명시적으로 노출
+  oauth2:
+    redirect-base: ${APP_OAUTH2_REDIRECT_BASE:http://localhost:3000}


### PR DESCRIPTION
## 📌 관련 이슈
- #152

## ✨ 작업 내용
- 백엔드 주도 OAuth2(Spring `oauth2Login`)로 Google·Kakao 소셜 로그인 구현
- 엔드포인트 URI 리매핑: `/api/oauth2/authorization/{provider}`, `/api/oauth2/callback/{provider}`, `POST /api/auth/oauth2/register`
- 무세션(stateless) 대응: 쿠키 기반 `AuthorizationRequestRepository` (JWT 서명봉인 + 역직렬화 화이트리스트)
- 콜백 3갈래 분기(sealed `OAuth2Outcome`): 로그인 / 이메일 타-provider 충돌 / 신규가입 유도
- 신규가입: 서명 단명 티켓(provider·email) → 닉네임+약관 → ACTIVE·무비번 유저 생성
- 토큰 발급 공통화(`issueToken`) — login·oauth·register 재사용
- Kakao: 커스텀 provider 설정 + `CustomOAuth2UserService`로 `kakao_account.email` 평탄화
- `PasswordEncoder` 설정 분리(순환참조 해소), 운영 credential fail-fast

## 📸 스크린샷 / 테스트 결과
- 로컬(dev) 실제 관통 테스트
  - Google: 이메일 충돌 / 신규→`/register`→유저 생성 / 재로그인→refresh 쿠키→FE 세션 성립 3갈래 성공
  - Kakao: 신규 갈래 + 중첩 이메일 평탄화 성공 (ticket에 email·provider 정상)
  - `@SpringBootTest` 컨텍스트 로드(빈 조립) 성공

## 🔍 리뷰 포인트
- 무세션이라 OAuth2 state를 쿠키로 왕복시키는 `CookieAuthorizationRequestRepository` — JWT 서명으로 위조 차단 + `ObjectInputFilter`로 역직렬화 방어(심층방어)
- `sealed OAuth2Outcome` + switch로 3갈래 처리(누락 시 컴파일 에러로 강제)
- Kakao 중첩 이메일 평탄화 방식(`CustomOAuth2UserService`)
- 리다이렉트 경로(`/oauth2/success` 등)는 FE 라우팅과 최종 확정 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (부팅·관통 수동 검증 / 자동화 테스트는 후속)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (Pokade는 스펙 문서 없이 구현 — 해당 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - Google 및 Kakao OAuth2 로그인을 지원합니다.
  - 기존 계정은 로그인하고, 신규 사용자는 가입 티켓과 닉네임을 통해 회원가입할 수 있습니다.
  - 로그인 및 회원가입 후 액세스 토큰과 리프레시 토큰을 발급합니다.
- **개선 사항**
  - OAuth2 인증 성공·실패 결과에 따라 적절한 화면으로 안내합니다.
  - 가입 티켓의 만료와 유효성을 검증하고, 닉네임·이메일 중복 및 약관 동의를 확인합니다.
  - 인증 요청과 토큰 쿠키의 보안을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->