### PR TITLE
chore: develop → main 자동 배포 반영

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
@@ -14,6 +14,7 @@ import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +31,11 @@ public class ListingService {
     private final ListingRepository listingRepository;
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
+    private final UserAccessChecker userAccessChecker;
 
     @Transactional
     public ListingResponse createListing(Long sellerId, ListingCreateRequest request) {
+        userAccessChecker.assertWritable(sellerId);
         validateNotDuplicate(sellerId, request.cardId(), request.variantId());
 
         Listing listing = Listing.builder()
@@ -89,6 +92,7 @@ public class ListingService {
 
     @Transactional
     public ListingResponse updatePrice(Long sellerId, Long listingId, ListingUpdateRequest request) {
+        userAccessChecker.assertWritable(sellerId);
         Listing listing = getOwnedListing(sellerId, listingId);
 
         listing.changePrice(request.price());

--- a/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
@@ -26,4 +26,10 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
     List<Trade> findCompletedTradesSince(@Param("cardId") Long cardId,
                                           @Param("status") TradeStatus status,
                                           @Param("from") LocalDateTime from);
+
+    // 회원탈퇴 확정 정리용: 탈퇴한 유저가 구매자 또는 판매자(매물 소유자)로 참여 중인 미종결 거래 조회
+    @Query("SELECT t FROM Trade t JOIN FETCH t.listing l "
+            + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status IN :statuses")
+    List<Trade> findByParticipantIdAndStatusIn(@Param("userId") Long userId,
+                                                @Param("statuses") List<TradeStatus> statuses);
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -13,6 +13,7 @@ import com.pokade.domain.trade.repository.PaymentRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class TradeService {
     private final TradeRepository tradeRepository;
     private final PaymentRepository paymentRepository;
     private final CardRepository cardRepository;
+    private final UserAccessChecker userAccessChecker;
 
     private TradeResponse toResponse(Trade trade) {
         String cardName = cardRepository.findById(trade.getListing().getCardId())
@@ -36,8 +38,11 @@ public class TradeService {
 
     @Transactional
     public TradeResponse createTrade(Long buyerId, TradeCreateRequest request) {
+        userAccessChecker.assertWritable(buyerId);
+
         Listing listing = listingRepository.findById(request.listingId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.LISTING_NOT_FOUND));
+        userAccessChecker.assertWritable(listing.getSellerId());
 
         if (listing.getSellerId().equals(buyerId)) {
             throw new BusinessException(ErrorCode.SELF_PURCHASE_NOT_ALLOWED);
@@ -84,6 +89,8 @@ public class TradeService {
 
     @Transactional
     public TradeResponse confirmTrade(Long buyerId, Long tradeId) {
+        userAccessChecker.assertWritable(buyerId);
+
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 
@@ -98,6 +105,8 @@ public class TradeService {
 
     @Transactional
     public TradeResponse cancelTrade(Long userId, Long tradeId) {
+        userAccessChecker.assertWritable(userId);
+
         Trade trade = tradeRepository.findById(tradeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
 

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListener.java
@@ -1,0 +1,40 @@
+package com.pokade.domain.trade.service;
+
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.global.event.UserWithdrawnEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+// 회원탈퇴가 확정된 유저의 매물/거래를 정리한다. 탈퇴 확정 트랜잭션이 커밋된 뒤에만 동작해야
+// (그새 철회되는 등으로) 탈퇴 자체가 롤백된 경우 매물/거래를 잘못 취소하지 않는다.
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawalCleanupListener {
+
+    private static final List<TradeStatus> UNSETTLED_STATUSES = List.of(TradeStatus.PENDING, TradeStatus.MATCHED);
+
+    private final ListingRepository listingRepository;
+    private final TradeRepository tradeRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    public void onUserWithdrawn(UserWithdrawnEvent event) {
+        Long userId = event.userId();
+
+        List<Listing> activeListings = listingRepository.findBySellerIdAndStatus(userId, ListingStatus.ACTIVE);
+        activeListings.forEach(Listing::cancel);
+
+        List<Trade> unsettledTrades = tradeRepository.findByParticipantIdAndStatusIn(userId, UNSETTLED_STATUSES);
+        unsettledTrades.forEach(Trade::cancel);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
@@ -1,0 +1,101 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.dto.ListingResponse;
+import com.pokade.domain.listing.dto.ListingUpdateRequest;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ListingServiceTest {
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private CardVariantRepository cardVariantRepository;
+
+    @Mock
+    private UserAccessChecker userAccessChecker;
+
+    @InjectMocks
+    private ListingService listingService;
+
+    @Test
+    void 매물_등록시_판매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        ListingCreateRequest request = new ListingCreateRequest(1L, null, 10000, ListingGrade.A);
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(100L);
+
+        assertThatThrownBy(() -> listingService.createListing(100L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(listingRepository, never()).save(any());
+    }
+
+    @Test
+    void 매물_등록시_판매자_계정이_활성이면_정상_등록된다() {
+        ListingCreateRequest request = new ListingCreateRequest(1L, null, 10000, ListingGrade.A);
+        given(listingRepository.existsBySellerIdAndCardIdAndVariantIdAndStatus(
+                anyLong(), any(), any(), any())).willReturn(false);
+        given(listingRepository.save(any(Listing.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        ListingResponse response = listingService.createListing(100L, request);
+
+        assertThat(response.sellerId()).isEqualTo(100L);
+        assertThat(response.price()).isEqualTo(10000);
+    }
+
+    @Test
+    void 가격_수정시_판매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(100L);
+
+        assertThatThrownBy(() -> listingService.updatePrice(100L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(listingRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void 가격_수정시_판매자_계정이_활성이면_정상_수정된다() {
+        Listing listing = Listing.builder()
+                .cardId(1L)
+                .sellerId(100L)
+                .price(10000)
+                .build();
+        given(listingRepository.findById(1L)).willReturn(Optional.of(listing));
+
+        ListingResponse response = listingService.updatePrice(100L, 1L, new ListingUpdateRequest(20000));
+
+        assertThat(response.price()).isEqualTo(20000);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.trade.service;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
@@ -21,7 +22,13 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TradeServiceTest {
@@ -56,6 +63,46 @@ class TradeServiceTest {
                 .buyerId(buyerId)
                 .price(10000)
                 .build();
+    }
+
+    @Test
+    void 즉시구매시_구매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(200L);
+
+        assertThatThrownBy(() -> tradeService.createTrade(200L, new TradeCreateRequest(1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(listingRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    void 즉시구매시_판매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(listingRepository.findById(1L)).willReturn(Optional.of(trade.getListing()));
+        willDoNothing().given(userAccessChecker).assertWritable(200L);
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(100L);
+
+        assertThatThrownBy(() -> tradeService.createTrade(200L, new TradeCreateRequest(1L)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(listingRepository, never()).markAsTrading(any());
+    }
+
+    @Test
+    void 즉시구매시_구매자_판매자_모두_활성이면_거래가_생성된다() {
+        Listing listing = tradeOf(100L, 200L).getListing();
+        given(listingRepository.findById(1L)).willReturn(Optional.of(listing));
+        given(listingRepository.markAsTrading(any())).willReturn(1);
+        given(tradeRepository.save(any(Trade.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        TradeResponse response = tradeService.createTrade(200L, new TradeCreateRequest(1L));
+
+        assertThat(response.buyerId()).isEqualTo(200L);
+        assertThat(response.status()).isEqualTo(TradeStatus.PENDING);
     }
 
     @Test
@@ -98,6 +145,18 @@ class TradeServiceTest {
     }
 
     @Test
+    void 확정시_구매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(200L);
+
+        assertThatThrownBy(() -> tradeService.confirmTrade(200L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(tradeRepository, never()).findById(anyLong());
+    }
+
+    @Test
     void 구매자가_확정하면_거래상태가_COMPLETED로_바뀐다() {
         Trade trade = tradeOf(100L, 200L);
         given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
@@ -135,6 +194,18 @@ class TradeServiceTest {
         assertThatThrownBy(() -> tradeService.confirmTrade(200L, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TRADE_STATUS);
+    }
+
+    @Test
+    void 취소시_액션_주체_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
+        willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
+                .given(userAccessChecker).assertWritable(200L);
+
+        assertThatThrownBy(() -> tradeService.cancelTrade(200L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCOUNT_NOT_ACTIVE);
+
+        verify(tradeRepository, never()).findById(anyLong());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -10,6 +10,7 @@ import com.pokade.domain.trade.repository.PaymentRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,6 +37,9 @@ class TradeServiceTest {
 
     @Mock
     private CardRepository cardRepository;
+
+    @Mock
+    private UserAccessChecker userAccessChecker;
 
     @InjectMocks
     private TradeService tradeService;

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListenerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListenerTest.java
@@ -1,0 +1,80 @@
+package com.pokade.domain.trade.service;
+
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.global.event.UserWithdrawnEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserWithdrawalCleanupListenerTest {
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private TradeRepository tradeRepository;
+
+    @InjectMocks
+    private UserWithdrawalCleanupListener listener;
+
+    private Listing activeListingOf(Long sellerId) {
+        return Listing.builder()
+                .cardId(1L)
+                .sellerId(sellerId)
+                .price(10000)
+                .build();
+    }
+
+    private Trade pendingTradeOf(Long sellerId, Long buyerId) {
+        Listing listing = activeListingOf(sellerId);
+        return Trade.builder()
+                .listing(listing)
+                .buyerId(buyerId)
+                .price(10000)
+                .build();
+    }
+
+    @Test
+    void 탈퇴한_유저의_ACTIVE_매물이_전부_취소된다() {
+        Long userId = 100L;
+        Listing listing1 = activeListingOf(userId);
+        Listing listing2 = activeListingOf(userId);
+        given(listingRepository.findBySellerIdAndStatus(userId, ListingStatus.ACTIVE))
+                .willReturn(List.of(listing1, listing2));
+        given(tradeRepository.findByParticipantIdAndStatusIn(eq(userId), eq(List.of(TradeStatus.PENDING, TradeStatus.MATCHED))))
+                .willReturn(List.of());
+
+        listener.onUserWithdrawn(new UserWithdrawnEvent(userId));
+
+        assertThat(listing1.getStatus()).isEqualTo(ListingStatus.CANCELLED);
+        assertThat(listing2.getStatus()).isEqualTo(ListingStatus.CANCELLED);
+    }
+
+    @Test
+    void 탈퇴한_유저가_참여한_미종결_거래가_전부_취소된다() {
+        Long userId = 200L;
+        Trade tradeAsBuyer = pendingTradeOf(100L, userId);
+        given(listingRepository.findBySellerIdAndStatus(userId, ListingStatus.ACTIVE))
+                .willReturn(List.of());
+        given(tradeRepository.findByParticipantIdAndStatusIn(eq(userId), eq(List.of(TradeStatus.PENDING, TradeStatus.MATCHED))))
+                .willReturn(List.of(tradeAsBuyer));
+
+        listener.onUserWithdrawn(new UserWithdrawnEvent(userId));
+
+        assertThat(tradeAsBuyer.getStatus()).isEqualTo(TradeStatus.CANCELLED);
+    }
+}


### PR DESCRIPTION
develop에 push된 변경사항을 main으로 자동 승격합니다. 빌드가 통과했으므로 자동 병합됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회원 탈퇴 시 진행 중인 매물과 미정산 거래가 자동으로 취소됩니다.

* **버그 수정**
  * 비활성 계정은 매물 등록·가격 수정 및 거래 생성·확정·취소를 진행할 수 없습니다.
  * 권한이 없는 작업을 사전에 차단해 불필요한 상태 변경을 방지합니다.

* **테스트**
  * 활성·비활성 계정별 매물 및 거래 처리와 회원 탈퇴 후 정리 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->