### PR TITLE
[Fix] 탈퇴 정리 리스너의 @TransactionalEventListener+@Transactional 조합 오류 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/UserWithdrawalCleanupListener.java
@@ -9,6 +9,7 @@ import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -27,7 +28,7 @@ public class UserWithdrawalCleanupListener {
     private final TradeRepository tradeRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onUserWithdrawn(UserWithdrawnEvent event) {
         Long userId = event.userId();
 


### PR DESCRIPTION
## 📌 관련 이슈
- 이슈 없음.

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- 탈퇴 정리 리스너의 @TransactionalEventListener+@Transactional 조합 오류 수정

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사용자 탈퇴 후 정리 작업이 별도의 트랜잭션에서 안정적으로 실행되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->