### PR TITLE
[Fix] #172 워치리스트/알림 컨트롤러 테스트 OAuth2 목킹 누락 수정

### DIFF
--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.notification.controller;
 
+import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.NotificationType;
 import com.pokade.domain.notification.service.NotificationService;
@@ -9,6 +10,10 @@ import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
 import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CookieAuthorizationRequestRepository;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -54,6 +59,21 @@ class NotificationControllerTest {
 
     @MockitoBean
     private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private OAuth2LoginService oAuth2LoginService;
+
+    @MockitoBean
+    private CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.watchlist.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.service.WatchlistService;
@@ -10,6 +11,10 @@ import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
 import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CookieAuthorizationRequestRepository;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -59,6 +64,21 @@ class WatchlistControllerTest {
 
     @MockitoBean
     private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private OAuth2LoginService oAuth2LoginService;
+
+    @MockitoBean
+    private CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
## 📌 관련 이슈
- #172 

## ✨ 작업 내용
- WatchlistControllerTest, NotificationControllerTest에 SecurityConfig 실제 의존 빈 목킹 추가
  (CookieAuthorizationRequestRepository, OAuth2LoginSuccessHandler, OAuth2LoginFailureHandler, CustomOAuth2UserService) 

## 📸 스크린샷 / 테스트 결과
- WatchlistControllerTest 6/6, NotificationControllerTest 4/4 전부 통과

## 🔍 리뷰 포인트
- 기존 테스트 로직(요청/응답 검증)은 전혀 안 건드리고, @MockitoBean 선언 4개만 추가한 순수 설정 변경입니다
- SecurityConfig를 확인해서 실제 생성자 의존성 4개를 정확히 찾아 목킹했습니다 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 성공
- [x] 불필요한 주석/로그 제거
- [ ] 관련 문서 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 알림 및 관심 목록 API 테스트에 인증·보안 관련 테스트 구성을 추가했습니다.
  * OAuth2 로그인과 인증 성공·실패 시나리오를 안정적으로 검증할 수 있습니다.
  * 기존 알림 및 관심 목록 API 동작에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->