### PR TITLE
[Feature] #176 챗봇 택배/상태/불량 키워드 감지 시 고객센터 연락처 안내

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/chat/service/ChatService.java
+++ b/Pokade/src/main/java/com/pokade/domain/chat/service/ChatService.java
@@ -94,6 +94,16 @@ public class ChatService {
             "시세|가격|얼마|올랐|내렸|급등|급락|변동률|거래(가|내역)?|매물|판매가|구매가",
             Pattern.CASE_INSENSITIVE);
 
+    // 배송/검수 관련 문의는 챗봇(시세 안내 전용)이 아니라 사람이 직접 확인해야 하는 사안이라, LLM 호출 없이
+    // 바로 고객센터 연락처로 안내한다.
+    private static final Pattern SUPPORT_ESCALATION_PATTERN = Pattern.compile(
+            "택배|상태|불량",
+            Pattern.CASE_INSENSITIVE);
+
+    private static final String SUPPORT_ESCALATION_MESSAGE =
+            "택배 상태나 카드 불량 관련 문의는 챗봇이 바로 확인해드리기 어려워요. "
+            + "010-2222-2222로 문자 주시면 담당자가 확인 후 도와드릴게요.";
+
     private static final String INJECTION_BLOCKED_MESSAGE =
             "죄송합니다, 저는 카드 시세 조회/설명만 답변할 수 있어요. 궁금한 카드명이나 시세를 물어봐주세요.";
 
@@ -140,6 +150,13 @@ public class ChatService {
         if (INJECTION_PATTERN.matcher(message).find()) {
             log.info("챗봇 프롬프트 인젝션 패턴 탐지 - LLM 호출 생략, 이력 미저장: sessionId={}", sessionId);
             return new ChatQueryResponse(sessionId, INJECTION_BLOCKED_MESSAGE, null);
+        }
+
+        if (SUPPORT_ESCALATION_PATTERN.matcher(message).find()) {
+            log.info("챗봇 고객센터 이관 키워드 탐지 - LLM 호출 생략: sessionId={}", sessionId);
+            saveMessage(sessionId, principalUserId, ChatRole.USER, message);
+            saveMessage(sessionId, principalUserId, ChatRole.ASSISTANT, SUPPORT_ESCALATION_MESSAGE);
+            return new ChatQueryResponse(sessionId, SUPPORT_ESCALATION_MESSAGE, null);
         }
 
         boolean isInvestmentQuestion = INVESTMENT_PATTERN.matcher(message).find();


### PR DESCRIPTION
## 📌 관련 이슈
- #176

## ✨ 작업 내용
- ChatService.queryChat()에 SUPPORT_ESCALATION_PATTERN(택배|상태|불량) 추가
- 프롬프트 인젝션 차단 패턴과 동일하게 LLM 호출 전 정규식으로 조기 감지, 매칭 시 고객센터 연락처(010-2222-2222) 안내 메시지를 즉시 반환
- 인젝션 차단과 달리 정상적인 문의 응답이므로 USER/ASSISTANT 메시지 모두 이력에 저장

## 📸 스크린샷 / 테스트 결과
- 로컬에서 프론트 /chat 페이지로 "택배가 왔는데 상태가 불량이에요" 전송 후 고객센터 안내 메시지가 정상 반환되는 것을 확인

## 🔍 리뷰 포인트
- "상태"가 단독으로도 매칭되는 넓은 패턴이라, "카드 상태 등급이 어때요" 같은 일반 문의도 이 분기로 빠질 수 있습니다. 필요하면 좀 더 좁은 패턴(예: 택배/불량과 조합)으로 조정 가능합니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 배송, 검수, 불량 관련 문의를 자동으로 감지합니다.
  * 해당 문의에는 즉시 고객센터 안내를 제공하고, 대화 내용을 저장합니다.
  * 지원 이관 대상 문의는 별도의 AI 응답 생성 없이 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->