### PR TITLE
[Feature] #189 시세 파트 기간 코드 변경

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/ChartPeriod.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/ChartPeriod.java
@@ -4,9 +4,10 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 
 public enum ChartPeriod {
+    DAYS_7("7d", 7),
     DAYS_30("30d", 30),
     DAYS_90("90d", 90),
-    YEAR_1("1y", 365);
+    DAYS_180("180d", 180);
 
     private final String code;
     private final int days;

--- a/Pokade/src/main/java/com/pokade/domain/price/StatsPeriod.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/StatsPeriod.java
@@ -3,7 +3,7 @@ package com.pokade.domain.price;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 
-// card_prices의 change_*_pct 컬럼에 대응하는 기간 코드. ChartPeriod(30d/90d/1y, 체결 이력 조회용)와는
+// card_prices의 change_*_pct 컬럼에 대응하는 기간 코드. ChartPeriod(7d/30d/90d/180d, 체결 이력 조회용)와는
 // 별개 개념이라 값 구성이 다르다 - 혼용하지 않는다.
 public enum StatsPeriod {
     DAYS_1("1d"),

--- a/Pokade/src/test/java/com/pokade/domain/price/ChartPeriodTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/ChartPeriodTest.java
@@ -12,20 +12,22 @@ import com.pokade.global.exception.ErrorCode;
 class ChartPeriodTest {
 
     @Test
-    @DisplayName("t1 30d, 90d, 1y 코드는 각각 30일, 90일, 365일에 대응하는 기간으로 해석된다")
+    @DisplayName("t1 7d, 30d, 90d, 180d 코드는 각각 7일, 30일, 90일, 180일에 대응하는 기간으로 해석된다")
     void t1() {
+        assertThat(ChartPeriod.from("7d")).isEqualTo(ChartPeriod.DAYS_7);
+        assertThat(ChartPeriod.from("7d").getDays()).isEqualTo(7);
         assertThat(ChartPeriod.from("30d")).isEqualTo(ChartPeriod.DAYS_30);
         assertThat(ChartPeriod.from("30d").getDays()).isEqualTo(30);
         assertThat(ChartPeriod.from("90d")).isEqualTo(ChartPeriod.DAYS_90);
         assertThat(ChartPeriod.from("90d").getDays()).isEqualTo(90);
-        assertThat(ChartPeriod.from("1y")).isEqualTo(ChartPeriod.YEAR_1);
-        assertThat(ChartPeriod.from("1y").getDays()).isEqualTo(365);
+        assertThat(ChartPeriod.from("180d")).isEqualTo(ChartPeriod.DAYS_180);
+        assertThat(ChartPeriod.from("180d").getDays()).isEqualTo(180);
     }
 
     @Test
     @DisplayName("t2 정의되지 않은 코드는 INVALID_PERIOD 예외가 발생한다")
     void t2() {
-        assertThatThrownBy(() -> ChartPeriod.from("7d"))
+        assertThatThrownBy(() -> ChartPeriod.from("1y"))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_PERIOD);

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -112,10 +112,10 @@ class PriceControllerTest {
 
     @Test
     void 차트_조회시_존재하지_않는_카드면_404를_반환한다() throws Exception {
-        given(priceService.getPriceChart(999L, "1y"))
+        given(priceService.getPriceChart(999L, "180d"))
                 .willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND));
 
-        mockMvc.perform(get("/api/prices/999/chart").param("period", "1y"))
+        mockMvc.perform(get("/api/prices/999/chart").param("period", "180d"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("CARD_NOT_FOUND"));
     }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -105,7 +105,7 @@ class PriceServiceTest {
     void t3() {
         given(cardRepository.existsById(999L)).willReturn(false);
 
-        assertThatThrownBy(() -> priceService.getPriceChart(999L, "1y"))
+        assertThatThrownBy(() -> priceService.getPriceChart(999L, "180d"))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.CARD_NOT_FOUND);
@@ -117,7 +117,7 @@ class PriceServiceTest {
     void t4() {
         given(cardRepository.existsById(1L)).willReturn(true);
 
-        assertThatThrownBy(() -> priceService.getPriceChart(1L, "7d"))
+        assertThatThrownBy(() -> priceService.getPriceChart(1L, "1y"))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_PERIOD);


### PR DESCRIPTION
## 📌 관련 이슈
- #189 

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- `GET /api/prices/{cardId}/chart`의 `ChartPeriod`를 `30d/90d/1y` → **`7d/30d/90d/180d`**로 변경
- 프론트 차트 기간 토글이 7일/30일/90일/180일로 바뀌는 것에 맞춘 백엔드 대응
- `card_prices`의 등락률 기준 시점(1d/7d/14d/30d/90d/180d)과 겹치는 구간을 맞춰서, 실거래 차트와 등락률 역산 차트(`grade-chart`)가 같은 시점 그리드를 공유할 수 있게 함

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- `GET /api/prices/7/chart?period=180d` → 200 정상 응답
- `GET /api/prices/7/chart?period=1y` → 400 `INVALID_PERIOD` (기존 값 제거 확인)
- `ChartPeriodTest`, `PriceServiceTest`, `PriceControllerTest` 전체 통과

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- `1y` 값이 제거되는 breaking change라 프론트와 배포 순서를 맞춰야 함 (프론트도 같은 값으로 이미 변경됨)
- `180d`가 `card_prices`  최대 기간으로 설정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 가격 차트 조회 기간에 7일 및 180일 옵션이 추가되었습니다.
  * 기존 1년 옵션은 제거되었으며, 30일 및 90일 옵션은 유지됩니다.

* **버그 수정**
  * 가격 통계 기간 안내가 실제 제공되는 기간과 일치하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->