### PR TITLE
[Feat]#187 회원 응답에 탈퇴 신청 시각(withdrawalRequestedAt) 노출

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
@@ -5,6 +5,8 @@ import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 
+import java.time.LocalDateTime;
+
 public record UserResponse(
         Long userId,
         String email,
@@ -13,7 +15,8 @@ public record UserResponse(
         UserStatus status,
         String profileImageUrl,
         Integer pointBalance,
-        Provider provider
+        Provider provider,
+        LocalDateTime withdrawalRequestedAt
 ) {
     public static UserResponse from(User user) {
         return new UserResponse(
@@ -24,7 +27,8 @@ public record UserResponse(
                 user.getStatus(),
                 user.getProfileImageUrl(),
                 user.getPointBalance(),
-                user.getProvider()
+                user.getProvider(),
+                user.getWithdrawalRequestedAt()
         );
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -12,6 +12,10 @@ import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
 import com.pokade.global.security.JwtTokenProvider;
 import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +31,7 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.util.List;
 
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -51,6 +56,14 @@ class UserControllerTest {
     private TokenBlacklistStore tokenBlacklistStore;                 // JwtAuthenticationFilter가 요구
     @MockitoBean
     private WithdrawalService withdrawalService;                     // UserController가 요구
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;          // SecurityConfig가 요구
+    @MockitoBean
+    private RedisAuthorizationRequestRepository authorizationRequestRepository; // SecurityConfig가 요구
 
     private RequestPostProcessor userId(Long userId) {
         Authentication auth = new UsernamePasswordAuthenticationToken(
@@ -63,7 +76,7 @@ class UserControllerTest {
     void getMyInfo_success() throws Exception {
         UserResponse res = new UserResponse(
                 1L, "user@pokade.com", "트레이너김",
-                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30, Provider.LOCAL);
+                Role.USER, UserStatus.ACTIVE, "https://img/x.png", 30, Provider.LOCAL, null);
         given(userService.getMyInfo(1L)).willReturn(res);
 
         mockMvc.perform(get("/api/users/me").with(userId(1L)))
@@ -74,7 +87,8 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.role").value("USER"))
                 .andExpect(jsonPath("$.data.status").value("ACTIVE"))
                 .andExpect(jsonPath("$.data.pointBalance").value(30))
-                .andExpect(jsonPath("$.data.provider").value("LOCAL"));
+                .andExpect(jsonPath("$.data.provider").value("LOCAL"))
+                .andExpect(jsonPath("$.data.withdrawalRequestedAt").value(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #187 

## ✨ 작업 내용
`UserResponse`에 `withdrawalRequestedAt`(탈퇴 신청 시각) 필드 추가 → `GET /api/users/me` 응답에 노출. ACTIVE 계정은 null.

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- UserControllerTest 2/2 통과

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- `UserResponse`: 필드 추가 + `from()`에서 `user.getWithdrawalRequestedAt()` 매핑
- `UserControllerTest`: 생성자 인자 변경 반영. `@Import(SecurityConfig)` 슬라이스가 요구하는 목 빈(`RedisAuthorizationRequestRepository` + OAuth 핸들러 3종) 누락분 보강 + `withdrawalRequestedAt=null` 검증 추가

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 사용자 정보 응답에 회원 탈퇴 요청 시각이 포함됩니다.
  - 탈퇴 요청을 하지 않은 경우 해당 값은 비어 있는 상태로 제공됩니다.
  - 이를 통해 클라이언트에서 탈퇴 요청 상태와 시점을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->