### PR TITLE
[Feature] #197 시세 없는 매물 참고 시세 제공 엔드포인트 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardPriceRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardPriceRepository.java
@@ -1,8 +1,12 @@
 package com.pokade.domain.card.repository;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.pokade.domain.card.entity.CardPrice;
 
@@ -10,4 +14,21 @@ public interface CardPriceRepository extends JpaRepository<CardPrice, Long> {
 
     Optional<CardPrice> findByVariantIdAndPriceTypeAndGradeAndCompany(
             Long variantId, String priceType, String grade, String company);
+
+    // 검색 목록의 "가격 정보 없음" fallback용 - 여러 판본의 비등급(raw) 시세를 한 번에 조회(가격 요약 배치 조회용).
+    @Query("SELECT cp.variant.id AS variantId, cp.market AS market, cp.currency AS currency FROM CardPrice cp "
+            + "WHERE cp.variant.id IN :variantIds AND cp.priceType = :priceType AND cp.grade = :grade AND cp.company = :company")
+    List<VariantMarketPriceView> findMarketPricesByVariantIds(
+            @Param("variantIds") List<Long> variantIds,
+            @Param("priceType") String priceType,
+            @Param("grade") String grade,
+            @Param("company") String company);
+
+    interface VariantMarketPriceView {
+        Long getVariantId();
+
+        BigDecimal getMarket();
+
+        String getCurrency();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/CardPriceSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/CardPriceSummaryResponse.java
@@ -1,10 +1,17 @@
 package com.pokade.domain.price.dto;
 
+import java.math.BigDecimal;
+
 public record CardPriceSummaryResponse(
         Long cardId,
         Integer buyPrice,
         Integer sellPrice,
         Integer recentTradePrice,
-        String currency
+        String currency,
+        // card_prices의 비등급(raw) 시세 - buyPrice/recentTradePrice가 둘 다 없을 때 프론트의 fallback 표시용.
+        // buyPrice/sellPrice/recentTradePrice는 항상 KRW(currency 필드)지만, marketPrice는 Scrydex 동기화 원본
+        // 통화(USD/JPY 등)라 별도 marketPriceCurrency로 표시한다.
+        BigDecimal marketPrice,
+        String marketPriceCurrency
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -50,6 +50,10 @@ public class PriceService {
     private static final int STATS_PERIOD_DAYS = 7;
     private static final ListingGrade STATS_GRADE = ListingGrade.S;
     private static final int RANKING_LIMIT = 10;
+    // CardUpsertService가 Scrydex 동기화 시 raw NM 시세를 저장하는 키와 동일해야 한다(card_prices 조회 fallback용).
+    private static final String RAW_PRICE_TYPE = "raw";
+    private static final String RAW_GRADE = "";
+    private static final String RAW_COMPANY = "";
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
@@ -122,13 +126,27 @@ public class PriceService {
                                 PriceTradeStatsRepository.CardPriceView::getCardId,
                                 PriceTradeStatsRepository.CardPriceView::getPrice));
 
+        // buyPrice/recentTradePrice가 둘 다 없는 카드용 fallback - Scrydex 동기화 비등급(raw) 시세.
+        // 우리 플랫폼 거래 이력이 없는 대다수 카드(직접 거래된 적 없는 카드)도 "가격 정보 없음" 대신 참고 시세를 보여주기 위함.
+        Map<Long, CardPriceRepository.VariantMarketPriceView> marketPriceByVariant = variantIds.isEmpty()
+                ? Map.of()
+                : cardPriceRepository
+                        .findMarketPricesByVariantIds(variantIds, RAW_PRICE_TYPE, RAW_GRADE, RAW_COMPANY).stream()
+                        .collect(Collectors.toMap(
+                                CardPriceRepository.VariantMarketPriceView::getVariantId,
+                                view -> view));
+
         return distinctCardIds.stream()
                 .map(cardId -> {
                     Long variantId = primaryVariantByCard.get(cardId);
                     Integer buyPrice = variantId != null ? buyPriceByVariant.get(variantId) : null;
                     Integer sellPrice = variantId != null ? sellPriceByVariant.get(variantId) : null;
                     Integer recentTradePrice = recentTradePriceByCard.get(cardId);
-                    return new CardPriceSummaryResponse(cardId, buyPrice, sellPrice, recentTradePrice, CURRENCY);
+                    CardPriceRepository.VariantMarketPriceView marketPrice =
+                            variantId != null ? marketPriceByVariant.get(variantId) : null;
+                    return new CardPriceSummaryResponse(cardId, buyPrice, sellPrice, recentTradePrice, CURRENCY,
+                            marketPrice != null ? marketPrice.getMarket() : null,
+                            marketPrice != null ? marketPrice.getCurrency() : null);
                 })
                 .toList();
     }

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -140,8 +140,8 @@ class PriceControllerTest {
     @Test
     void 배치_요약_조회시_cardIds에_해당하는_요약_목록을_반환한다() throws Exception {
         List<CardPriceSummaryResponse> summaries = List.of(
-                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW"),
-                new CardPriceSummaryResponse(2L, null, 2000000, null, "KRW")
+                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null),
+                new CardPriceSummaryResponse(2L, null, 2000000, null, "KRW", null, null)
         );
         given(priceService.getSummaries(List.of(1L, 2L), null, false)).willReturn(summaries);
 
@@ -175,7 +175,7 @@ class PriceControllerTest {
     @Test
     void 배치_요약_조회시_grade를_지정하면_해당_등급의_요약만_반환한다() throws Exception {
         List<CardPriceSummaryResponse> summaries = List.of(
-                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW")
+                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null)
         );
         given(priceService.getSummaries(List.of(1L), ListingGrade.S, false)).willReturn(summaries);
 
@@ -195,7 +195,7 @@ class PriceControllerTest {
     @Test
     void 배치_요약_조회시_includeRecentTradePrice가_true면_최근_체결가를_함께_반환한다() throws Exception {
         List<CardPriceSummaryResponse> summaries = List.of(
-                new CardPriceSummaryResponse(1L, null, null, 2950000, "KRW")
+                new CardPriceSummaryResponse(1L, null, null, 2950000, "KRW", null, null)
         );
         given(priceService.getSummaries(List.of(1L), null, true)).willReturn(summaries);
 
@@ -208,13 +208,28 @@ class PriceControllerTest {
     @Test
     void 배치_요약_조회시_includeRecentTradePrice_미지정이면_최근_체결가없이_조회한다() throws Exception {
         List<CardPriceSummaryResponse> summaries = List.of(
-                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW")
+                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null)
         );
         given(priceService.getSummaries(List.of(1L), null, false)).willReturn(summaries);
 
         mockMvc.perform(get("/api/prices/summaries").param("cardIds", "1"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].recentTradePrice").value(nullValue()));
+    }
+
+    @Test
+    void 배치_요약_조회시_buyPrice와_recentTradePrice가_없으면_marketPrice를_함께_반환한다() throws Exception {
+        List<CardPriceSummaryResponse> summaries = List.of(
+                new CardPriceSummaryResponse(1L, null, null, null, "KRW", new BigDecimal("25.60"), "USD")
+        );
+        given(priceService.getSummaries(List.of(1L), ListingGrade.S, true)).willReturn(summaries);
+
+        mockMvc.perform(get("/api/prices/summaries")
+                        .param("cardIds", "1").param("grade", "S").param("includeRecentTradePrice", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].buyPrice").value(nullValue()))
+                .andExpect(jsonPath("$.data[0].marketPrice").value(25.60))
+                .andExpect(jsonPath("$.data[0].marketPriceCurrency").value("USD"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -142,9 +142,9 @@ class PriceServiceTest {
         List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L, 2L, 3L), null, false);
 
         assertThat(result).hasSize(3);
-        assertThat(result.get(0)).isEqualTo(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW"));
-        assertThat(result.get(1)).isEqualTo(new CardPriceSummaryResponse(2L, null, 2000000, null, "KRW"));
-        assertThat(result.get(2)).isEqualTo(new CardPriceSummaryResponse(3L, null, null, null, "KRW"));
+        assertThat(result.get(0)).isEqualTo(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null));
+        assertThat(result.get(1)).isEqualTo(new CardPriceSummaryResponse(2L, null, 2000000, null, "KRW", null, null));
+        assertThat(result.get(2)).isEqualTo(new CardPriceSummaryResponse(3L, null, null, null, "KRW", null, null));
     }
 
     @Test
@@ -258,7 +258,7 @@ class PriceServiceTest {
 
         List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), ListingGrade.S, false);
 
-        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW"));
+        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null));
     }
 
     @Test
@@ -273,7 +273,7 @@ class PriceServiceTest {
 
         List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), ListingGrade.A, false);
 
-        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, null, null, null, "KRW"));
+        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, null, null, null, "KRW", null, null));
     }
 
     @Test
@@ -290,7 +290,7 @@ class PriceServiceTest {
 
         List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), null, true);
 
-        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, null, null, 2950000, "KRW"));
+        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, null, null, 2950000, "KRW", null, null));
     }
 
     @Test
@@ -305,8 +305,65 @@ class PriceServiceTest {
 
         List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), null, false);
 
-        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW"));
+        assertThat(result).containsExactly(new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", null, null));
         verify(priceTradeStatsRepository, never()).findRecentCompletedTradePricesByCardIds(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("t31 buyPrice와 recentTradePrice가 둘 다 없으면 card_prices의 비등급(raw) 시세를 fallback으로 반환한다")
+    void t31() {
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L)))
+                .willReturn(List.of(primaryVariantIdView(1L, 10L)));
+        given(listingRepository.findLowestActivePricesByVariantIds(List.of(10L), ListingStatus.ACTIVE, ListingGrade.S))
+                .willReturn(List.of());
+        given(buyOfferRepository.findHighestActivePricesByVariantIds(List.of(10L)))
+                .willReturn(List.of());
+        given(priceTradeStatsRepository.findRecentCompletedTradePricesByCardIds(List.of(1L), ListingGrade.S, TradeStatus.COMPLETED))
+                .willReturn(List.of());
+        given(cardPriceRepository.findMarketPricesByVariantIds(List.of(10L), "raw", "", ""))
+                .willReturn(List.of(variantMarketPriceView(10L, new BigDecimal("25.60"), "USD")));
+
+        List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), ListingGrade.S, true);
+
+        assertThat(result).containsExactly(
+                new CardPriceSummaryResponse(1L, null, null, null, "KRW", new BigDecimal("25.60"), "USD"));
+    }
+
+    @Test
+    @DisplayName("t32 buyPrice가 있으면 card_prices raw 시세를 조회하더라도 marketPrice는 무시되지 않고 함께 채워진다")
+    void t32() {
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L)))
+                .willReturn(List.of(primaryVariantIdView(1L, 10L)));
+        given(listingRepository.findLowestActivePricesByVariantIds(List.of(10L), ListingStatus.ACTIVE, null))
+                .willReturn(List.of(listingPriceView(10L, 3000000)));
+        given(buyOfferRepository.findHighestActivePricesByVariantIds(List.of(10L)))
+                .willReturn(List.of());
+        given(cardPriceRepository.findMarketPricesByVariantIds(List.of(10L), "raw", "", ""))
+                .willReturn(List.of(variantMarketPriceView(10L, new BigDecimal("25.60"), "USD")));
+
+        List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), null, false);
+
+        assertThat(result).containsExactly(
+                new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", new BigDecimal("25.60"), "USD"));
+    }
+
+    private CardPriceRepository.VariantMarketPriceView variantMarketPriceView(Long variantId, BigDecimal market, String currency) {
+        return new CardPriceRepository.VariantMarketPriceView() {
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+
+            @Override
+            public BigDecimal getMarket() {
+                return market;
+            }
+
+            @Override
+            public String getCurrency() {
+                return currency;
+            }
+        };
     }
 
     private CardVariantRepository.PrimaryVariantIdView primaryVariantIdView(Long cardId, Long variantId) {


### PR DESCRIPTION
## 📌 관련 이슈
- #197 

## ✨ 작업 내용

- GET /api/prices/summaries 응답에 marketPrice/marketPriceCurrency 필드 추가 — S등급 매물가·최근 체결가가 둘 다 없는 카드도 참고 시세를 내려줄 수 있도록 함
- CardPriceRepository에 findMarketPricesByVariantIds() 배치 조회 메서드 추가 — 여러 판본의 card_prices 비등급(raw, Scrydex 동기화 값) 시세를 한 번에 조회
- PriceService.getSummaries()에서 price_type='raw', grade='', company='' 기준으로 marketPrice를 조회해 응답에 항상 포함 (buyPrice 유무와 무관하게 채워짐 — 표시 우선순위 결정은 프론트 쪼겨서 별도 진행)
- CardPriceSummaryResponse에 marketPrice(BigDecimal), marketPriceCurrency(String) 필드 추가

## 📸 스크린샷 / 테스트 결과

- PriceServiceTest 32건 전부 통과 (marketPrice fallback 케이스 t31/t32 신규 추가)
- 로컬 기동 후 실제 API 응답 확인:
GET /api/prices/summaries?cardIds=1309,1310,1&grade=S&includeRecentTradePrice=true

{"cardId":1309,"buyPrice":null,"recentTradePrice":null,"marketPrice":0.05,"marketPriceCurrency":"USD"}   ← 거래 이력 없는 카드, fallback 정상
{"cardId":1310,"buyPrice":null,"recentTradePrice":null,"marketPrice":0.07,"marketPriceCurrency":"USD"}   ← 거래 이력 없는 카드, fallback 정상
{"cardId":1,   "buyPrice":3050000,"recentTradePrice":3100000,"marketPrice":null}                          ← 매물/체결 있는 카드는 기존과 동일

## 🔍 리뷰 포인트

- marketPrice는 등급(S/A/B 등) 구분 없이 raw(비등급) 시세만 조회합니다 — Scrydex 동기화 데이터 대부분이 raw만 있고, card_prices 행은 거의 없어서, raw 기준으로 잡아야 실제로 커버되는 카드가 많아진다고 판단했습니다. 
- cp.variant.id JPQL 경로 조회는 단위 테스트(Mockito, 리포지토리 모킹)로만 검증했고, 실제 DB 대상으로는 로컬 curl 확인만 했습니다 
- PriceControllerTest는 이 변경과 무관하게 로컬에서 OAuth2 설정(GOOGLE_CLIENT_ID 등) 문제로 전부 실패하는 상태였습니다(수정 전 브랜치에서도 동일하게 재현) — 이번 PR 범위 밖이라 별도로 안 건드렸습니다.

## ✅ 체크리스트

- [ ] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (PriceServiceTest 32건 통과, 위 curl 검증)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (CLAUDE.md 세션 요약 미반영 — 필요하면 추가하겠습니다)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카드 시세 요약에 원본 시장가와 통화 정보가 추가되었습니다.
  * 활성 매물가, 매수 제안가, 최근 거래가가 없는 경우 원본 시장가를 대신 제공합니다.
  * 카드별 가격 유형, 등급, 회사 조건에 따른 시장가를 조회할 수 있습니다.

* **테스트**
  * 시장가 우선순위와 대체 제공 시나리오를 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->