### PR TITLE
[Fix] 배포 소셜 로그인 redirect_uri가 http로 생성되어 실패

### DIFF
--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -48,6 +48,7 @@ spring:
 server:
   tomcat:
     max-swallow-size: 70MB     # 요청 용량 초과로 거부될 때 Tomcat이 남은 본문을 완전히 버릴 수 있도록 요청 한도와 맞춤(기본 2MB로는 413 응답 전에 연결이 끊김)
+  forward-headers-strategy: framework
 
 jwt:
   secret: ${JWT_SECRET}            # .env(spring.config.import)로 주입 — 미설정 시 부팅 실패(fail-fast)


### PR DESCRIPTION
## 📌 관련 이슈
- #202

## ✨ 작업 내용
- `server.forward-headers-strategy: framework` 추가 — 리버스 프록시(nginx) 뒤에서 `X-Forwarded-Proto`를 반영해 `{baseUrl}`을 https로 계산
- redirect_uri가 http로 생성돼 카카오(KOE006)·구글(redirect_uri_mismatch) 로그인이 막히던 문제 해결

## 📸 스크린샷 / 테스트 결과
- 로컬 일반 요청 → `redirect_uri=http://localhost:8080/...` (회귀 없음)
- 프록시 헤더 흉내(`X-Forwarded-Proto: https`) → `redirect_uri=https://api.pokade.store/...` (수정 동작 확인)

## 🔍 리뷰 포인트
- 배포 후 nginx가 `X-Forwarded-Proto`를 넘기는지에 따라 nginx `proxy_set_header X-Forwarded-Proto $scheme;` 한 줄이 추가로 필요할 수 있음 (배포 프로브로 판정)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 프록시 환경에서 전달된 헤더가 올바르게 처리되도록 서버 설정을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->