### PR TITLE
chore: develop → main 자동 배포 반영

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/controller/CardController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
+import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.service.CardService;
 import com.pokade.global.response.ApiResponse;
@@ -52,5 +53,10 @@ public class CardController {
     @GetMapping("/{id}/related")
     public ApiResponse<List<CardResponse>> related(@PathVariable Long id) {
         return ApiResponse.ok(cardService.getRelated(id));
+    }
+
+    @GetMapping("/facets")
+    public ApiResponse<CardFacetsResponse> facets() {
+        return ApiResponse.ok(cardService.getFacets());
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
@@ -26,14 +26,14 @@ public record CardDetailResponse(
         List<VariantSummary> variants
 ) {
 
-    public static CardDetailResponse of(Card card, List<CardVariant> variants, Map<Long, List<String>> gradesByVariantId, String nameKo, List<String> types) {
+    public static CardDetailResponse of(Card card, List<CardVariant> variants, Map<Long, List<String>> gradesByVariantId, String nameKo, List<String> types, String rarity) {
         return new CardDetailResponse(
                 card.getId(),
                 card.getExternalId(),
                 card.getName(),
                 nameKo,
                 card.getSetName(),
-                card.getRarity(),
+                rarity,
                 card.getSupertype(),
                 types,
                 card.getArtist(),

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
@@ -26,7 +26,7 @@ public record CardDetailResponse(
         List<VariantSummary> variants
 ) {
 
-    public static CardDetailResponse of(Card card, List<CardVariant> variants, Map<Long, List<String>> gradesByVariantId, String nameKo) {
+    public static CardDetailResponse of(Card card, List<CardVariant> variants, Map<Long, List<String>> gradesByVariantId, String nameKo, List<String> types) {
         return new CardDetailResponse(
                 card.getId(),
                 card.getExternalId(),
@@ -35,7 +35,7 @@ public record CardDetailResponse(
                 card.getSetName(),
                 card.getRarity(),
                 card.getSupertype(),
-                card.getTypes(),
+                types,
                 card.getArtist(),
                 card.getPrintedNumber(),
                 card.getImageSmall(),

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardFacetsResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardFacetsResponse.java
@@ -1,0 +1,17 @@
+package com.pokade.domain.card.dto;
+
+import java.util.List;
+
+public record CardFacetsResponse(
+        List<String> types,
+        List<String> rarities,
+        List<ExpansionFacet> expansions
+) {
+
+    public record ExpansionFacet(String id, String name) {
+    }
+
+    public static CardFacetsResponse of(List<String> types, List<String> rarities, List<ExpansionFacet> expansions) {
+        return new CardFacetsResponse(types, rarities, expansions);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -19,7 +19,7 @@ public record CardResponse(
         List<String> grades
 ) {
 
-    public static CardResponse from(Card card, List<String> grades, String nameKo) {
+    public static CardResponse from(Card card, List<String> grades, String nameKo, List<String> types) {
         return new CardResponse(
                 card.getId(),
                 card.getExternalId(),
@@ -28,7 +28,7 @@ public record CardResponse(
                 card.getSetName(),
                 card.getRarity(),
                 card.getSupertype(),
-                card.getTypes(),
+                types,
                 card.getImageSmall(),
                 card.getImageMedium(),
                 card.getExpansion() != null ? card.getExpansion().getId() : null,

--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -19,14 +19,14 @@ public record CardResponse(
         List<String> grades
 ) {
 
-    public static CardResponse from(Card card, List<String> grades, String nameKo, List<String> types) {
+    public static CardResponse from(Card card, List<String> grades, String nameKo, List<String> types, String rarity) {
         return new CardResponse(
                 card.getId(),
                 card.getExternalId(),
                 card.getName(),
                 nameKo,
                 card.getSetName(),
-                card.getRarity(),
+                rarity,
                 card.getSupertype(),
                 types,
                 card.getImageSmall(),

--- a/Pokade/src/main/java/com/pokade/domain/card/entity/Expansion.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/entity/Expansion.java
@@ -56,4 +56,13 @@ public class Expansion {
 
     @Column(name = "synced_at", nullable = false)
     private LocalDateTime syncedAt;
+
+    /**
+     * 과거에 translation 없이 먼저 동기화된 기존 세트를 위한 백필 전용 메서드.
+     * 호출 시점에 이미 translation이 있는지 여부는 호출부(CardUpsertService)에서 판단하고,
+     * 이 메서드는 값을 그대로 반영만 한다.
+     */
+    public void applyTranslationBackfill(String translation) {
+        this.translation = translation;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -189,9 +189,18 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     @Query(value = "SELECT DISTINCT unnest(types) FROM cards ORDER BY 1", nativeQuery = true)
     List<String> findDistinctTypes();
 
-    /** 필터 옵션(Facet) API용 - 현재 cards에 실제로 존재하는 rarity_code 전체를 조회한다. */
-    @Query(value = "SELECT DISTINCT rarity_code FROM cards WHERE rarity_code IS NOT NULL ORDER BY 1", nativeQuery = true)
-    List<String> findDistinctRarityCodes();
+    /**
+     * 필터 옵션(Facet) API용 - 현재 cards에 실제로 존재하는 (rarity_code, rarity) 조합 전체를 조회한다.
+     * CardRarityResolver.resolve()가 매핑 실패 시 원본 rarity로 폴백해야 하므로 rarity도 함께 조회하고,
+     * rarity_code가 null인 카드도 원본 rarity로 폴백 노출되어야 하므로 WHERE로 제외하지 않는다.
+     */
+    @Query(value = "SELECT DISTINCT rarity_code AS rarityCode, rarity AS rarity FROM cards ORDER BY 1", nativeQuery = true)
+    List<CardRarityView> findDistinctRarityCodes();
+
+    interface CardRarityView {
+        String getRarityCode();
+        String getRarity();
+    }
 
     @Query(value = """
             SELECT c.* FROM cards c

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -185,6 +185,14 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     Optional<Card> findByExternalId(String externalId);
 
+    /** 필터 옵션(Facet) API용 - 현재 cards에 실제로 존재하는 타입 값 전체(원본 텍스트, 다국어 혼재)를 조회한다. */
+    @Query(value = "SELECT DISTINCT unnest(types) FROM cards ORDER BY 1", nativeQuery = true)
+    List<String> findDistinctTypes();
+
+    /** 필터 옵션(Facet) API용 - 현재 cards에 실제로 존재하는 rarity_code 전체를 조회한다. */
+    @Query(value = "SELECT DISTINCT rarity_code FROM cards WHERE rarity_code IS NOT NULL ORDER BY 1", nativeQuery = true)
+    List<String> findDistinctRarityCodes();
+
     @Query(value = """
             SELECT c.* FROM cards c
             JOIN cards src ON src.id = :id

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -156,8 +156,8 @@ public class CardService {
     public CardFacetsResponse getFacets() {
         Set<String> types = new TreeSet<>(CardTypeEnResolver.resolve(cardRepository.findDistinctTypes()));
         Set<String> rarities = new TreeSet<>();
-        for (String rarityCode : cardRepository.findDistinctRarityCodes()) {
-            rarities.add(CardRarityResolver.resolve(rarityCode, rarityCode));
+        for (CardRepository.CardRarityView view : cardRepository.findDistinctRarityCodes()) {
+            rarities.add(CardRarityResolver.resolve(view.getRarityCode(), view.getRarity()));
         }
         List<CardFacetsResponse.ExpansionFacet> expansions = expansionRepository.findAll().stream()
                 .map(expansion -> new CardFacetsResponse.ExpansionFacet(expansion.getId(), expansion.getName()))

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -61,7 +61,9 @@ public class CardService {
         validateFilterSize(types, "types");
         validateFilterSize(rarities, "rarity");
         validatePriceRange(minPrice, maxPrice);
-        Page<Card> cards = cardRepository.search(types, rarities, expansionId, minPrice, maxPrice, sort, pageable);
+        List<String> expandedTypes = CardTypeEnResolver.resolveOriginalValues(types);
+        List<String> expandedRarities = CardRarityResolver.resolveOriginalValues(rarities);
+        Page<Card> cards = cardRepository.search(expandedTypes, expandedRarities, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
         return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity())));
     }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -14,6 +14,7 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.repository.PokedexKoNameRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.card.support.CardRarityResolver;
 import com.pokade.domain.card.support.CardTypeEnResolver;
 import com.pokade.domain.card.support.KoreanTextUtil;
 import com.pokade.global.exception.BusinessException;
@@ -62,7 +63,7 @@ public class CardService {
         validatePriceRange(minPrice, maxPrice);
         Page<Card> cards = cardRepository.search(types, rarities, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes())));
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity())));
     }
 
     @Transactional
@@ -73,7 +74,7 @@ public class CardService {
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
         Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id, GRADE_WHITELIST_LIST),
                 CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade);
-        return CardDetailResponse.of(card, variants, gradesByVariantId, cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()));
+        return CardDetailResponse.of(card, variants, gradesByVariantId, cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity()));
     }
 
     private <T, K> Map<K, List<String>> groupByKey(List<T> views, Function<T, K> keyFn, Function<T, String> gradeFn) {
@@ -101,7 +102,7 @@ public class CardService {
                 ? searchByPokedexKoName(keyword, pageable)
                 : cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes())));
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity())));
     }
 
     // 한글 검색어를 도감번호 목록으로 변환해 조회한다. 매핑이 없으면 예외 대신 빈 페이지를 반환한다.
@@ -134,7 +135,7 @@ public class CardService {
         }
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(related);
         return related.stream()
-                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c), CardTypeEnResolver.resolve(c.getTypes())))
+                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c), CardTypeEnResolver.resolve(c.getTypes()), CardRarityResolver.resolve(c.getRarityCode(), c.getRarity())))
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -6,12 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
+import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
 import com.pokade.domain.card.entity.PokedexKoName;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.repository.ExpansionRepository;
 import com.pokade.domain.card.repository.PokedexKoNameRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.card.support.CardRarityResolver;
@@ -21,12 +23,14 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.web.PageableValidator;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
@@ -53,6 +57,7 @@ public class CardService {
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final PokedexKoNameRepository pokedexKoNameRepository;
+    private final ExpansionRepository expansionRepository;
     private final CardNameKoResolver cardNameKoResolver;
 
     @Transactional(readOnly = true)
@@ -139,6 +144,26 @@ public class CardService {
         return related.stream()
                 .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c), CardTypeEnResolver.resolve(c.getTypes()), CardRarityResolver.resolve(c.getRarityCode(), c.getRarity())))
                 .toList();
+    }
+
+    /**
+     * 카드 필터 옵션(타입/레어도/세트)을 DB에 실제로 존재하는 값 기준으로 조회한다.
+     * types/rarity_code는 원본이 다국어로 혼재돼 있어 리졸버 적용 후 표준명 기준으로 중복 제거한다
+     * (예: 일본어 "草"와 영문 "Grass"가 함께 있으면 리졸버를 거쳐 "Grass" 하나로 합쳐짐).
+     * 세트명은 아직 언어별 표준화가 없어 원본 그대로 반환한다.
+     */
+    @Transactional(readOnly = true)
+    public CardFacetsResponse getFacets() {
+        Set<String> types = new TreeSet<>(CardTypeEnResolver.resolve(cardRepository.findDistinctTypes()));
+        Set<String> rarities = new TreeSet<>();
+        for (String rarityCode : cardRepository.findDistinctRarityCodes()) {
+            rarities.add(CardRarityResolver.resolve(rarityCode, rarityCode));
+        }
+        List<CardFacetsResponse.ExpansionFacet> expansions = expansionRepository.findAll().stream()
+                .map(expansion -> new CardFacetsResponse.ExpansionFacet(expansion.getId(), expansion.getName()))
+                .sorted(Comparator.comparing(CardFacetsResponse.ExpansionFacet::name))
+                .toList();
+        return CardFacetsResponse.of(List.copyOf(types), List.copyOf(rarities), expansions);
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -14,6 +14,7 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.repository.PokedexKoNameRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.card.support.CardTypeEnResolver;
 import com.pokade.domain.card.support.KoreanTextUtil;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -61,7 +62,7 @@ public class CardService {
         validatePriceRange(minPrice, maxPrice);
         Page<Card> cards = cardRepository.search(types, rarities, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card)));
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes())));
     }
 
     @Transactional
@@ -72,7 +73,7 @@ public class CardService {
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
         Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id, GRADE_WHITELIST_LIST),
                 CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade);
-        return CardDetailResponse.of(card, variants, gradesByVariantId, cardNameKoResolver.resolve(card));
+        return CardDetailResponse.of(card, variants, gradesByVariantId, cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()));
     }
 
     private <T, K> Map<K, List<String>> groupByKey(List<T> views, Function<T, K> keyFn, Function<T, String> gradeFn) {
@@ -100,7 +101,7 @@ public class CardService {
                 ? searchByPokedexKoName(keyword, pageable)
                 : cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card)));
+        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes())));
     }
 
     // 한글 검색어를 도감번호 목록으로 변환해 조회한다. 매핑이 없으면 예외 대신 빈 페이지를 반환한다.
@@ -133,7 +134,7 @@ public class CardService {
         }
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(related);
         return related.stream()
-                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c)))
+                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c), CardTypeEnResolver.resolve(c.getTypes())))
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
@@ -1,6 +1,8 @@
 package com.pokade.domain.card.support;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public final class CardRarityResolver {
 
@@ -11,6 +13,16 @@ public final class CardRarityResolver {
             Map.entry("☆1", "Illustration Rare"),
             Map.entry("EX", "Rare Holo EX"),
             Map.entry("GX", "Rare Holo GX")
+    );
+
+    // rarity_code는 원본 rarity 텍스트가 아니라 언어와 무관한 심볼이라 RARITY_CODE_TO_LABEL을
+    // 그대로 뒤집을 수 없다(뒤집으면 코드가 나오는데, 필터가 비교하는 컬럼은 코드가 아니라
+    // 원본 텍스트인 c.rarity이기 때문). 그래서 표준 라벨 -> 원본 텍스트 목록은 로컬 DB에서
+    // 실제로 확인된 교차언어 사례만 별도로 채운다(2026-08-12 기준: "●" 코드가 EN "Common"/
+    // JA "通常" 두 텍스트를 가짐을 실측 확인). 나머지 코드는 JA 대응 텍스트가 아직 확인되지 않아
+    // 표준명 자기 자신만 후보가 된다(resolveOriginalValues에서 기본 포함).
+    private static final Map<String, List<String>> LABEL_TO_KNOWN_ORIGINAL_TEXTS = Map.of(
+            "Common", List.of("通常")
     );
 
     private CardRarityResolver() {
@@ -25,5 +37,21 @@ public final class CardRarityResolver {
             return rarity;
         }
         return RARITY_CODE_TO_LABEL.getOrDefault(rarityCode, rarity);
+    }
+
+    /**
+     * 표준(영문) 레어도 명칭을 검색 필터로 받았을 때, DB의 원본 rarity 텍스트 컬럼과 비교할 수 있도록
+     * 그 표준명에 대응하는 원본 텍스트 후보로 확장한다. 표준명 자체(영문 카드의 raw 값)는 항상 포함하고,
+     * 알려진 다국어 원본 텍스트가 있으면 추가한다 - 알려지지 않은 값은 표준명 그대로만 포함되므로
+     * 필터가 빈 결과로 좁아지지 않는다.
+     */
+    public static List<String> resolveOriginalValues(List<String> standardRarities) {
+        if (standardRarities == null) {
+            return null;
+        }
+        return standardRarities.stream()
+                .flatMap(label -> Stream.concat(Stream.of(label), LABEL_TO_KNOWN_ORIGINAL_TEXTS.getOrDefault(label, List.of()).stream()))
+                .distinct()
+                .toList();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
@@ -1,0 +1,29 @@
+package com.pokade.domain.card.support;
+
+import java.util.Map;
+
+public final class CardRarityResolver {
+
+    private static final Map<String, String> RARITY_CODE_TO_LABEL = Map.ofEntries(
+            Map.entry("●", "Common"),
+            Map.entry("★H", "Rare Holo"),
+            Map.entry("◇◇", "Double Rare"),
+            Map.entry("☆1", "Illustration Rare"),
+            Map.entry("EX", "Rare Holo EX"),
+            Map.entry("GX", "Rare Holo GX")
+    );
+
+    private CardRarityResolver() {
+    }
+
+    /**
+     * rarity_code를 표준(영문) 레어도 명칭으로 치환한다. 매핑에 없는 코드(신규 코드거나 code가 null)는
+     * 원본 rarity 값 그대로 반환한다 - 신규 코드가 추가돼도 서비스가 죽지 않아야 하기 때문.
+     */
+    public static String resolve(String rarityCode, String rarity) {
+        if (rarityCode == null) {
+            return rarity;
+        }
+        return RARITY_CODE_TO_LABEL.getOrDefault(rarityCode, rarity);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
@@ -15,6 +15,9 @@ public final class CardRarityResolver {
             Map.entry("GX", "Rare Holo GX")
     );
 
+    // 새 rarity_code를 위 맵에 추가할 때는 아래 LABEL_TO_KNOWN_ORIGINAL_TEXTS에도
+    // 대응하는 원본(다국어) 텍스트가 필요한지 함께 확인할 것 - 두 맵은 키가 달라(코드 vs 라벨)
+    // 자동으로 연동되지 않는다.
     // rarity_code는 원본 rarity 텍스트가 아니라 언어와 무관한 심볼이라 RARITY_CODE_TO_LABEL을
     // 그대로 뒤집을 수 없다(뒤집으면 코드가 나오는데, 필터가 비교하는 컬럼은 코드가 아니라
     // 원본 텍스트인 c.rarity이기 때문). 그래서 표준 라벨 -> 원본 텍스트 목록은 로컬 DB에서

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
@@ -1,7 +1,10 @@
 package com.pokade.domain.card.support;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 public final class CardTypeEnResolver {
 
@@ -19,7 +22,16 @@ public final class CardTypeEnResolver {
             Map.entry("無色", "Colorless")
     );
 
+    // JAPANESE_TO_ENGLISH를 그대로 뒤집은 표준명 -> 원본(일본어) 텍스트 목록.
+    private static final Map<String, List<String>> ENGLISH_TO_ORIGINALS = buildReverseMap(JAPANESE_TO_ENGLISH);
+
     private CardTypeEnResolver() {
+    }
+
+    private static Map<String, List<String>> buildReverseMap(Map<String, String> forward) {
+        Map<String, List<String>> reverse = new HashMap<>();
+        forward.forEach((original, standard) -> reverse.computeIfAbsent(standard, k -> new ArrayList<>()).add(original));
+        return reverse;
     }
 
     /**
@@ -32,6 +44,22 @@ public final class CardTypeEnResolver {
         }
         return types.stream()
                 .map(type -> JAPANESE_TO_ENGLISH.getOrDefault(type, type))
+                .toList();
+    }
+
+    /**
+     * 표준(영문) 타입명을 검색 필터로 받았을 때, DB의 원본 컬럼(다국어 텍스트)과 비교할 수 있도록
+     * 그 표준명에 대응하는 모든 원본 텍스트 후보로 확장한다. 표준명 자체(영문 카드의 raw 값)도 항상
+     * 포함하고, 매핑에 없는 값(신규/알 수 없는 값)은 원본 값 그대로 포함한다 - 필터가 빈 결과로
+     * 좁아지지 않도록 방어.
+     */
+    public static List<String> resolveOriginalValues(List<String> standardTypes) {
+        if (standardTypes == null) {
+            return null;
+        }
+        return standardTypes.stream()
+                .flatMap(type -> Stream.concat(Stream.of(type), ENGLISH_TO_ORIGINALS.getOrDefault(type, List.of()).stream()))
+                .distinct()
                 .toList();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
@@ -1,0 +1,37 @@
+package com.pokade.domain.card.support;
+
+import java.util.List;
+import java.util.Map;
+
+public final class CardTypeEnResolver {
+
+    private static final Map<String, String> JAPANESE_TO_ENGLISH = Map.ofEntries(
+            Map.entry("草", "Grass"),
+            Map.entry("炎", "Fire"),
+            Map.entry("水", "Water"),
+            Map.entry("雷", "Lightning"),
+            Map.entry("超", "Psychic"),
+            Map.entry("闘", "Fighting"),
+            Map.entry("悪", "Darkness"),
+            Map.entry("鋼", "Metal"),
+            Map.entry("フェアリー", "Fairy"),
+            Map.entry("ドラゴン", "Dragon"),
+            Map.entry("無色", "Colorless")
+    );
+
+    private CardTypeEnResolver() {
+    }
+
+    /**
+     * 일본어 타입명을 영문 타입명으로 치환한다. 매핑에 없는 값(이미 영문이거나 알 수 없는 값)은
+     * 원본 그대로 유지한다 - 신규 타입이 추가돼도 서비스가 죽지 않아야 하기 때문.
+     */
+    public static List<String> resolve(List<String> types) {
+        if (types == null) {
+            return null;
+        }
+        return types.stream()
+                .map(type -> JAPANESE_TO_ENGLISH.getOrDefault(type, type))
+                .toList();
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
@@ -81,6 +81,7 @@ public class CardUpsertService {
 
     private Expansion syncExpansion(ExpansionDto dto, LocalDateTime now) {
         return expansionRepository.findById(dto.id())
+                .map(existing -> backfillTranslation(existing, dto))
                 .orElseGet(() -> expansionRepository.save(Expansion.builder()
                         .id(dto.id())
                         .name(dto.name())
@@ -96,11 +97,27 @@ public class CardUpsertService {
                         .build()));
     }
 
+    /**
+     * translation 없이 먼저 동기화됐던 기존 세트를 위한 백필 - 이미 값이 있으면 덮어쓰지 않고,
+     * dto에도 새 값이 없으면 그대로 둔다. 세트명 외 다른 필드(name/series 등)는 이 메서드에서 건드리지 않는다.
+     */
+    private Expansion backfillTranslation(Expansion existing, ExpansionDto dto) {
+        if (existing.getTranslation() != null) {
+            return existing;
+        }
+        String translation = toJsonString(extractTranslationName(dto.translation()));
+        if (translation == null) {
+            return existing;
+        }
+        existing.applyTranslationBackfill(translation);
+        return existing;
+    }
+
     private Card syncCard(CardDto dto, Expansion expansion, LocalDateTime now) {
         ImageDto image = firstImage(dto.images());
         CardSyncFields fields = new CardSyncFields(
                 dto.name(),
-                expansion != null ? expansion.getName() : null,
+                resolveExpansionName(expansion),
                 dto.rarity(),
                 dto.supertype(),
                 dto.subtypes(),
@@ -217,6 +234,27 @@ public class CardUpsertService {
             return null;
         }
         return LocalDate.parse(raw, RELEASE_DATE_FORMAT);
+    }
+
+    /**
+     * 세트명은 translation(en.name) 영문 표기가 있으면 그것을 우선 사용하고,
+     * 없거나 파싱에 실패하면 기존처럼 expansion.getName()(원본 언어 표기)으로 폴백한다.
+     */
+    private String resolveExpansionName(Expansion expansion) {
+        if (expansion == null) {
+            return null;
+        }
+        String translation = expansion.getTranslation();
+        if (translation == null) {
+            return expansion.getName();
+        }
+        try {
+            return objectMapper.readValue(translation, String.class);
+        } catch (JsonProcessingException e) {
+            log.warn("expansion.translation 파싱 실패 - name으로 폴백. expansionId={}, translation={}",
+                    expansion.getId(), translation, e);
+            return expansion.getName();
+        }
     }
 
     private String extractTranslationName(TranslationDto translation) {

--- a/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
@@ -261,7 +261,11 @@ public class CardUpsertService {
         if (translation == null || translation.en() == null) {
             return null;
         }
-        return translation.en().name();
+        String name = translation.en().name();
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return name;
     }
 
     /** translation JSONB 컬럼에는 en.name 문자열 하나만 JSON 문자열 값으로 저장한다({"en":{"name":...}} 구조 그대로 넣지 않음). */

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -25,6 +25,8 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.Expansion;
+import com.pokade.domain.card.support.CardRarityResolver;
+import com.pokade.domain.card.support.CardTypeEnResolver;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
@@ -236,6 +238,66 @@ class CardRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("t53 표준 타입명으로 필터링해도 리졸버가 확장한 원본 언어 후보값 덕분에 JA 카드까지 조회된다")
+    void t53() {
+        Expansion sv10ja = persistExpansion("sv10_ja", "サンダー");
+        persistCard("クヌギダマ", "通常", sv10ja, "草", List.of(204), LocalDateTime.now());
+
+        List<String> expandedTypes = CardTypeEnResolver.resolveOriginalValues(List.of("Grass"));
+        Page<Card> result = cardRepository.search(expandedTypes, null, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("クヌギダマ");
+    }
+
+    @Test
+    @DisplayName("t54 표준 레어도명으로 필터링하면 원본이 다른 언어인 카드와 EN 카드가 함께 조회되고 count도 일치한다")
+    void t54() {
+        Expansion sv10ja = persistExpansion("sv10_ja", "サンダー");
+        persistCard("クヌギダマ", "通常", sv10ja, "草", List.of(204), LocalDateTime.now());
+
+        List<String> expandedRarities = CardRarityResolver.resolveOriginalValues(List.of("Common"));
+        Page<Card> result = cardRepository.search(null, expandedRarities, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactlyInAnyOrder("Pikachu", "クヌギダマ");
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("t55 리졸버 매핑에 없는 임의 값으로 필터링하면 확장 전과 동일하게 빈 페이지를 반환한다(회귀)")
+    void t55() {
+        List<String> expandedTypes = CardTypeEnResolver.resolveOriginalValues(List.of("Rock"));
+        List<String> expandedRarities = CardRarityResolver.resolveOriginalValues(List.of("Secret Rare"));
+
+        Page<Card> typeResult = cardRepository.search(expandedTypes, null, null, null, null, null, PageRequest.of(0, 10));
+        Page<Card> rarityResult = cardRepository.search(null, expandedRarities, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(typeResult.getContent()).isEmpty();
+        assertThat(rarityResult.getContent()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t56 타입·레어도 확장값과 가격 필터를 함께 적용해도 AND 결합이 회귀 없이 동작한다")
+    void t56() {
+        Expansion sv10ja = persistExpansion("sv10_ja", "サンダー");
+        Card jaCard = persistCard("クヌギダマ", "通常", sv10ja, "草", List.of(204), LocalDateTime.now());
+        Long seller = persistSeller("multi-filter-seller@test.com");
+        persistListing(jaCard.getId(), seller, 5000, null, ListingStatus.ACTIVE);
+        entityManager.flush();
+
+        List<String> expandedTypes = CardTypeEnResolver.resolveOriginalValues(List.of("Grass"));
+        List<String> expandedRarities = CardRarityResolver.resolveOriginalValues(List.of("Common"));
+        Page<Card> result = cardRepository.search(expandedTypes, expandedRarities, null, 1000, 10000, null, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("クヌギダマ");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -207,6 +207,45 @@ class CardServiceTest {
     }
 
     @Test
+    @DisplayName("t46 레어도 코드가 매핑되어 있으면 표준 명칭으로 변환되고, 타입 매핑도 함께 정상 동작한다")
+    void t46() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("クヌギダマ")
+                .rarity("通常")
+                .rarityCode("●")
+                .types(List.of("草"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.search(null, null, null, null, null, null, pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, pageable);
+
+        assertThat(result.getContent().get(0).rarity()).isEqualTo("Common");
+        assertThat(result.getContent().get(0).types()).containsExactly("Grass");
+    }
+
+    @Test
+    @DisplayName("t47 매핑에 없는 레어도 코드는 원본 rarity 값을 그대로 유지한다")
+    void t47() {
+        Card card = Card.builder()
+                .id(1L)
+                .name("Charizard")
+                .rarity("Hyper Rare")
+                .rarityCode("★★★")
+                .types(List.of("Fire"))
+                .build();
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
+        given(cardRepository.search(null, null, null, null, null, null, pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardService.search(null, null, null, null, null, null, pageable);
+
+        assertThat(result.getContent().get(0).rarity()).isEqualTo("Hyper Rare");
+    }
+
+    @Test
     @DisplayName("t35 검색 결과 카드들의 id를 모아 등급을 배치 조회하고 카드별 등급 배열로 매핑한다")
     void t35() {
         Card charizard = Card.builder().id(1L).name("Charizard").types(List.of("Fire")).build();

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.pokade.domain.card.dto.CardDetailResponse;
+import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
@@ -32,6 +33,7 @@ import com.pokade.domain.card.entity.Expansion;
 import com.pokade.domain.card.entity.PokedexKoName;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.repository.ExpansionRepository;
 import com.pokade.domain.card.repository.PokedexKoNameRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.global.exception.BusinessException;
@@ -48,6 +50,9 @@ class CardServiceTest {
 
     @Mock
     private PokedexKoNameRepository pokedexKoNameRepository;
+
+    @Mock
+    private ExpansionRepository expansionRepository;
 
     @Mock
     private CardNameKoResolver cardNameKoResolver;
@@ -664,5 +669,43 @@ class CardServiceTest {
         Optional<Card> result = cardService.findByExternalId("does-not-exist");
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t48 매핑에 없는 rarity_code는 원본 rarity 텍스트로 폴백해서 노출된다")
+    void t48() {
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of(rarityView("ZZ", "Special Art Rare")));
+        given(expansionRepository.findAll()).willReturn(List.of());
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.rarities()).containsExactly("Special Art Rare");
+    }
+
+    @Test
+    @DisplayName("t49 rarity_code가 null인 카드도 원본 rarity 텍스트로 Facet에 노출된다")
+    void t49() {
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of(rarityView(null, "プロモ")));
+        given(expansionRepository.findAll()).willReturn(List.of());
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.rarities()).containsExactly("プロモ");
+    }
+
+    private CardRepository.CardRarityView rarityView(String rarityCode, String rarity) {
+        return new CardRepository.CardRarityView() {
+            @Override
+            public String getRarityCode() {
+                return rarityCode;
+            }
+
+            @Override
+            public String getRarity() {
+                return rarity;
+            }
+        };
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -65,7 +65,7 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire"), List.of("Rare Holo"), "base1", null, null, "name", pageable)).willReturn(page);
+        given(cardRepository.search(List.of("Fire", "炎"), List.of("Rare Holo"), "base1", null, null, "name", pageable)).willReturn(page);
 
         Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), "base1", null, null, "name", pageable);
 
@@ -83,7 +83,7 @@ class CardServiceTest {
                 .build();
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(card), pageable, 1);
-        given(cardRepository.search(List.of("Fire", "Water"), List.of("Common", "Rare Holo"), null, null, null, null, pageable))
+        given(cardRepository.search(List.of("Fire", "炎", "Water", "水"), List.of("Common", "通常", "Rare Holo"), null, null, null, null, pageable))
                 .willReturn(page);
 
         Page<CardResponse> result = cardService.search(

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
@@ -1,0 +1,43 @@
+package com.pokade.domain.card.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CardRarityResolverTest {
+
+    @ParameterizedTest(name = "{0} → {1}")
+    @DisplayName("t1 매핑된 rarity_code는 표준 명칭으로 치환된다")
+    @CsvSource({
+            "●, Common",
+            "★H, Rare Holo",
+            "◇◇, Double Rare",
+            "☆1, Illustration Rare",
+            "EX, Rare Holo EX",
+            "GX, Rare Holo GX"
+    })
+    void t1(String rarityCode, String expected) {
+        assertThat(CardRarityResolver.resolve(rarityCode, "원본값")).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("t2 매핑에 없는 rarity_code는 원본 rarity 값을 그대로 반환한다")
+    void t2() {
+        assertThat(CardRarityResolver.resolve("★★★", "Hyper Rare")).isEqualTo("Hyper Rare");
+    }
+
+    @Test
+    @DisplayName("t3 rarity_code가 null이면 원본 rarity 값을 그대로 반환한다")
+    void t3() {
+        assertThat(CardRarityResolver.resolve(null, "Rare Holo")).isEqualTo("Rare Holo");
+    }
+
+    @Test
+    @DisplayName("t4 rarity_code와 rarity가 모두 null이어도 예외 없이 null을 반환한다")
+    void t4() {
+        assertThat(CardRarityResolver.resolve(null, null)).isNull();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
@@ -2,6 +2,8 @@ package com.pokade.domain.card.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,5 +41,29 @@ class CardRarityResolverTest {
     @DisplayName("t4 rarity_code와 rarity가 모두 null이어도 예외 없이 null을 반환한다")
     void t4() {
         assertThat(CardRarityResolver.resolve(null, null)).isNull();
+    }
+
+    @Test
+    @DisplayName("t5 표준 레어도명을 역매핑하면 알려진 원본(다국어) 텍스트와 표준명 자신을 함께 반환한다")
+    void t5() {
+        assertThat(CardRarityResolver.resolveOriginalValues(List.of("Common"))).containsExactlyInAnyOrder("Common", "通常");
+    }
+
+    @Test
+    @DisplayName("t6 원본 텍스트가 알려지지 않은 표준 레어도명은 표준명 자신만 포함된다")
+    void t6() {
+        assertThat(CardRarityResolver.resolveOriginalValues(List.of("Rare Holo"))).containsExactly("Rare Holo");
+    }
+
+    @Test
+    @DisplayName("t7 매핑에 없는 임의 값은 원본 값 그대로만 포함된다")
+    void t7() {
+        assertThat(CardRarityResolver.resolveOriginalValues(List.of("Secret Rare"))).containsExactly("Secret Rare");
+    }
+
+    @Test
+    @DisplayName("t8 역매핑 대상이 null이면 null을 반환한다")
+    void t8() {
+        assertThat(CardRarityResolver.resolveOriginalValues(null)).isNull();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardTypeEnResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardTypeEnResolverTest.java
@@ -1,0 +1,69 @@
+package com.pokade.domain.card.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CardTypeEnResolverTest {
+
+    @ParameterizedTest(name = "{0} → {1}")
+    @DisplayName("t1 매핑된 일본어 타입명은 영문 타입명으로 치환된다")
+    @CsvSource({
+            "草, Grass",
+            "炎, Fire",
+            "水, Water",
+            "雷, Lightning",
+            "超, Psychic",
+            "闘, Fighting",
+            "悪, Darkness",
+            "鋼, Metal",
+            "フェアリー, Fairy",
+            "ドラゴン, Dragon",
+            "無色, Colorless"
+    })
+    void t1(String japanese, String expected) {
+        assertThat(CardTypeEnResolver.resolve(List.of(japanese))).containsExactly(expected);
+    }
+
+    @Test
+    @DisplayName("t2 매핑에 없는 값(이미 영문 등)은 원본 그대로 유지한다")
+    void t2() {
+        assertThat(CardTypeEnResolver.resolve(List.of("Fire", "UnknownType"))).containsExactly("Fire", "UnknownType");
+    }
+
+    @Test
+    @DisplayName("t3 types가 null이면 null을 반환한다")
+    void t3() {
+        assertThat(CardTypeEnResolver.resolve(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("t4 표준 영문 타입명을 역매핑하면 원본(일본어) 텍스트와 표준명 자신을 함께 반환한다")
+    void t4() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(List.of("Fire"))).containsExactlyInAnyOrder("Fire", "炎");
+    }
+
+    @Test
+    @DisplayName("t5 여러 표준 타입명을 역매핑하면 각각의 원본 텍스트가 모두 포함된다")
+    void t5() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(List.of("Fire", "Water")))
+                .containsExactlyInAnyOrder("Fire", "炎", "Water", "水");
+    }
+
+    @Test
+    @DisplayName("t6 역매핑에 없는 값(신규/알 수 없는 타입)은 원본 값 그대로만 포함된다")
+    void t6() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(List.of("Rock"))).containsExactly("Rock");
+    }
+
+    @Test
+    @DisplayName("t7 역매핑 대상이 null이면 null을 반환한다")
+    void t7() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(null)).isNull();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
@@ -1,0 +1,132 @@
+package com.pokade.domain.sync.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.Expansion;
+import com.pokade.domain.card.repository.CardPriceRepository;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.repository.ExpansionRepository;
+import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.ExpansionDto;
+import com.pokade.domain.sync.client.dto.TranslationDto;
+
+/**
+ * sv10_ja처럼 translation 없이 먼저 동기화됐던 기존 세트를 재동기화할 때,
+ * CardUpsertService.syncCard()가 세트명(Card.setName)을 translation(영문) 우선으로 채우는지,
+ * 그리고 translation이 없거나 깨져 있어도 예외 없이 원본 이름으로 폴백하는지 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class CardUpsertServiceTest {
+
+    @Mock
+    private ExpansionRepository expansionRepository;
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private CardVariantRepository cardVariantRepository;
+
+    @Mock
+    private CardPriceRepository cardPriceRepository;
+
+    @InjectMocks
+    private CardUpsertService cardUpsertService;
+
+    private static final String EXPANSION_ID = "sv10_ja";
+    private static final String ORIGINAL_EXPANSION_NAME = "サンダー";
+
+    private Expansion existingExpansion(String translation) {
+        return Expansion.builder()
+                .id(EXPANSION_ID)
+                .name(ORIGINAL_EXPANSION_NAME)
+                .translation(translation)
+                .syncedAt(LocalDateTime.now().minusDays(13))
+                .build();
+    }
+
+    private CardDto cardDto(TranslationDto translation) {
+        ExpansionDto expansionDto = new ExpansionDto(
+                EXPANSION_ID, ORIGINAL_EXPANSION_NAME, "Scarlet & Violet", null, 98, null,
+                "JA", "2024/11/01", null, null, null, translation
+        );
+        return new CardDto(
+                "sv10_ja-1", "クヌギダマ", "ポケモン", List.of("草"), List.of("たね"),
+                "通常", "●", null, "YASHIRO Nanaco", List.of(204),
+                "001/098", null, null, expansionDto, 1, "JA", null
+        );
+    }
+
+    private Card capturedSavedCard() {
+        ArgumentCaptor<Card> captor = ArgumentCaptor.forClass(Card.class);
+        org.mockito.Mockito.verify(cardRepository).save(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("t1 translation이 비어있던 기존 세트도, 응답에 translation이 있으면 영문 세트명으로 백필/반영된다")
+    void t1() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-1")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardDto dto = cardDto(new TranslationDto(new TranslationDto.TranslationNameDto("Thunder")));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        assertThat(capturedSavedCard().getSetName()).isEqualTo("Thunder");
+        assertThat(expansion.getTranslation()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("t2 응답에 translation이 없으면 기존처럼 원본 세트명 그대로 저장된다(회귀)")
+    void t2() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-1")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardDto dto = cardDto(null);
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
+        assertThat(expansion.getTranslation()).isNull();
+    }
+
+    @Test
+    @DisplayName("t3 translation JSON이 깨진 형식이면 파싱 예외 없이 원본 세트명으로 폴백한다")
+    void t3() {
+        Expansion expansion = existingExpansion("Thunder");
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-1")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardDto dto = cardDto(new TranslationDto(new TranslationDto.TranslationNameDto("Ignored")));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
+        assertThat(expansion.getTranslation()).isEqualTo("Thunder");
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
@@ -129,4 +129,38 @@ class CardUpsertServiceTest {
         assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
         assertThat(expansion.getTranslation()).isEqualTo("Thunder");
     }
+
+    @Test
+    @DisplayName("t4 translation.en.name이 빈 문자열이면 null로 취급되어 원본 세트명으로 폴백하고, 백필도 스킵되어 다음 기회에 백필 가능한 상태로 남는다")
+    void t4() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-1")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardDto dto = cardDto(new TranslationDto(new TranslationDto.TranslationNameDto("")));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
+        assertThat(expansion.getTranslation()).isNull();
+    }
+
+    @Test
+    @DisplayName("t5 translation.en.name이 공백뿐이면 null로 취급되어 원본 세트명으로 폴백하고, 백필도 스킵되어 다음 기회에 백필 가능한 상태로 남는다")
+    void t5() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-1")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardDto dto = cardDto(new TranslationDto(new TranslationDto.TranslationNameDto("   ")));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
+        assertThat(expansion.getTranslation()).isNull();
+    }
 }


### PR DESCRIPTION
develop에 push된 변경사항을 main으로 자동 승격합니다. 빌드가 통과했으므로 자동 병합됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카드 타입, 레어도, 확장판별 필터 옵션을 제공하는 Facets API가 추가되었습니다.
  * 다국어 카드 타입과 레어도 검색을 지원하며, 표준 영문 명칭으로 결과가 표시됩니다.
  * 카드 목록, 상세 정보, 키워드 및 연관 카드 응답에 타입과 레어도 정보가 포함됩니다.

* **개선 사항**
  * 확장판의 영문명이 누락된 경우 동기화 과정에서 자동으로 보완됩니다.
  * 영문명이 없거나 잘못된 경우 기존 확장판명이 안전하게 사용됩니다.
  * 필터 검색과 데이터 보완 동작에 대한 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->