### PR TITLE
[Fix] #193 후속 - Facet API NPE 및 리스트 null 방어 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -159,9 +160,13 @@ public class CardService {
         for (CardRepository.CardRarityView view : cardRepository.findDistinctRarityCodes()) {
             rarities.add(CardRarityResolver.resolve(view.getRarityCode(), view.getRarity()));
         }
+        // expansions.name이 NULL인 레거시/수동 적재 데이터가 있을 수 있어, FE 응답 스키마(name: string,
+        // non-null)를 깨지 않도록 빈 문자열로 대체하고 정렬도 null-safe하게 처리한다.
         List<CardFacetsResponse.ExpansionFacet> expansions = expansionRepository.findAll().stream()
-                .map(expansion -> new CardFacetsResponse.ExpansionFacet(expansion.getId(), expansion.getName()))
-                .sorted(Comparator.comparing(CardFacetsResponse.ExpansionFacet::name))
+                .map(expansion -> new CardFacetsResponse.ExpansionFacet(
+                        expansion.getId(), Objects.requireNonNullElse(expansion.getName(), "")))
+                .sorted(Comparator.comparing(CardFacetsResponse.ExpansionFacet::name,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
         return CardFacetsResponse.of(List.copyOf(types), List.copyOf(rarities), expansions);
     }

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
@@ -13,7 +13,10 @@ public final class CardRarityResolver {
             Map.entry("◇◇", "Double Rare"),
             Map.entry("☆1", "Illustration Rare"),
             Map.entry("EX", "Rare Holo EX"),
-            Map.entry("GX", "Rare Holo GX")
+            Map.entry("GX", "Rare Holo GX"),
+            Map.entry("C", "Common"),
+            Map.entry("R", "Rare"),
+            Map.entry("U", "Uncommon")
     );
 
     // 새 rarity_code를 위 맵에 추가할 때는 아래 LABEL_TO_KNOWN_ORIGINAL_TEXTS에도
@@ -26,7 +29,9 @@ public final class CardRarityResolver {
     // JA "通常" 두 텍스트를 가짐을 실측 확인). 나머지 코드는 JA 대응 텍스트가 아직 확인되지 않아
     // 표준명 자기 자신만 후보가 된다(resolveOriginalValues에서 기본 포함).
     private static final Map<String, List<String>> LABEL_TO_KNOWN_ORIGINAL_TEXTS = Map.of(
-            "Common", List.of("通常")
+            "Common", List.of("通常"),
+            "Rare", List.of("希少"),
+            "Uncommon", List.of("非")
     );
 
     private CardRarityResolver() {

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardRarityResolver.java
@@ -2,6 +2,7 @@ package com.pokade.domain.card.support;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public final class CardRarityResolver {
@@ -53,6 +54,7 @@ public final class CardRarityResolver {
             return null;
         }
         return standardRarities.stream()
+                .filter(Objects::nonNull)
                 .flatMap(label -> Stream.concat(Stream.of(label), LABEL_TO_KNOWN_ORIGINAL_TEXTS.getOrDefault(label, List.of()).stream()))
                 .distinct()
                 .toList();

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardTypeEnResolver.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public final class CardTypeEnResolver {
@@ -43,6 +44,7 @@ public final class CardTypeEnResolver {
             return null;
         }
         return types.stream()
+                .filter(Objects::nonNull)
                 .map(type -> JAPANESE_TO_ENGLISH.getOrDefault(type, type))
                 .toList();
     }
@@ -58,6 +60,7 @@ public final class CardTypeEnResolver {
             return null;
         }
         return standardTypes.stream()
+                .filter(Objects::nonNull)
                 .flatMap(type -> Stream.concat(Stream.of(type), ENGLISH_TO_ORIGINALS.getOrDefault(type, List.of()).stream()))
                 .distinct()
                 .toList();

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -695,6 +695,38 @@ class CardServiceTest {
         assertThat(result.rarities()).containsExactly("プロモ");
     }
 
+    @Test
+    @DisplayName("t50 name이 null인 expansion이 있어도 NPE 없이 빈 문자열로 노출된다")
+    void t50() {
+        Expansion expansion = Expansion.builder().id("legacy1").name(null).syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(expansion));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions()).hasSize(1);
+        assertThat(result.expansions().get(0).id()).isEqualTo("legacy1");
+        assertThat(result.expansions().get(0).name()).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("t51 name이 null인 expansion과 정상 expansion이 섞여 있어도 나머지는 이름순 정렬이 유지된다")
+    void t51() {
+        Expansion legacy = Expansion.builder().id("legacy1").name(null).syncedAt(LocalDateTime.now()).build();
+        Expansion base = Expansion.builder().id("base1").name("Base").syncedAt(LocalDateTime.now()).build();
+        Expansion swsh = Expansion.builder().id("swsh1").name("Sword & Shield").syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(swsh, legacy, base));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions())
+                .extracting(CardFacetsResponse.ExpansionFacet::name)
+                .containsExactly("", "Base", "Sword & Shield");
+    }
+
     private CardRepository.CardRarityView rarityView(String rarityCode, String rarity) {
         return new CardRepository.CardRarityView() {
             @Override

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
@@ -20,7 +20,10 @@ class CardRarityResolverTest {
             "◇◇, Double Rare",
             "☆1, Illustration Rare",
             "EX, Rare Holo EX",
-            "GX, Rare Holo GX"
+            "GX, Rare Holo GX",
+            "C, Common",
+            "R, Rare",
+            "U, Uncommon"
     })
     void t1(String rarityCode, String expected) {
         assertThat(CardRarityResolver.resolve(rarityCode, "원본값")).isEqualTo(expected);
@@ -48,6 +51,18 @@ class CardRarityResolverTest {
     @DisplayName("t5 표준 레어도명을 역매핑하면 알려진 원본(다국어) 텍스트와 표준명 자신을 함께 반환한다")
     void t5() {
         assertThat(CardRarityResolver.resolveOriginalValues(List.of("Common"))).containsExactlyInAnyOrder("Common", "通常");
+    }
+
+    @Test
+    @DisplayName("t5-1 표준 레어도명 Rare를 역매핑하면 알려진 원본(다국어) 텍스트와 표준명 자신을 함께 반환한다")
+    void t5_1() {
+        assertThat(CardRarityResolver.resolveOriginalValues(List.of("Rare"))).containsExactlyInAnyOrder("Rare", "希少");
+    }
+
+    @Test
+    @DisplayName("t5-2 표준 레어도명 Uncommon을 역매핑하면 알려진 원본(다국어) 텍스트와 표준명 자신을 함께 반환한다")
+    void t5_2() {
+        assertThat(CardRarityResolver.resolveOriginalValues(List.of("Uncommon"))).containsExactlyInAnyOrder("Uncommon", "非");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardRarityResolverTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.card.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -65,5 +66,18 @@ class CardRarityResolverTest {
     @DisplayName("t8 역매핑 대상이 null이면 null을 반환한다")
     void t8() {
         assertThat(CardRarityResolver.resolveOriginalValues(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("t9 리스트에 null 원소가 섞여 있어도 NPE 없이 나머지 원소만 정상 처리된다")
+    void t9() {
+        assertThat(CardRarityResolver.resolveOriginalValues(Arrays.asList("Common", null)))
+                .containsExactlyInAnyOrder("Common", "通常");
+    }
+
+    @Test
+    @DisplayName("t10 리스트가 전부 null이면 빈 리스트를 반환한다")
+    void t10() {
+        assertThat(CardRarityResolver.resolveOriginalValues(Arrays.asList(null, null))).isEmpty();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardTypeEnResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardTypeEnResolverTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.card.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -65,5 +66,31 @@ class CardTypeEnResolverTest {
     @DisplayName("t7 역매핑 대상이 null이면 null을 반환한다")
     void t7() {
         assertThat(CardTypeEnResolver.resolveOriginalValues(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("t8 리스트에 null 원소가 섞여 있어도 NPE 없이 나머지 원소만 정상 처리된다")
+    void t8() {
+        assertThat(CardTypeEnResolver.resolve(Arrays.asList("炎", null, "UnknownType")))
+                .containsExactly("Fire", "UnknownType");
+    }
+
+    @Test
+    @DisplayName("t9 리스트가 전부 null이면 빈 리스트를 반환한다")
+    void t9() {
+        assertThat(CardTypeEnResolver.resolve(Arrays.asList(null, null))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t10 역매핑 대상 리스트에 null 원소가 섞여 있어도 NPE 없이 나머지 원소만 정상 처리된다")
+    void t10() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(Arrays.asList("Fire", null)))
+                .containsExactlyInAnyOrder("Fire", "炎");
+    }
+
+    @Test
+    @DisplayName("t11 역매핑 대상 리스트가 전부 null이면 빈 리스트를 반환한다")
+    void t11() {
+        assertThat(CardTypeEnResolver.resolveOriginalValues(Arrays.asList(null, null))).isEmpty();
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #193 

## ✨ 작업 내용
- GET /api/cards/facets에서 expansions.name이 null인 경우 NPE 발생하던 버그 수정 (null-safe 정렬)
- CardTypeEnResolver, CardRarityResolver의 리스트 원소 null 방어 추가 (코드 점검 중 발견, 같은 유형의 재발 방지)

## 📸 스크린샷 / 테스트 결과
- 카드 도메인 전체 테스트 통과 (신규 케이스 포함)
- 배포 서버(api.pokade.store)에서 500 에러 확인 후 수정

## 🔍 리뷰 포인트
- 배포에서 필터 옵션이 전혀 안 뜨던 원인으로 추정되는 버그입니다
- resolver null 방어는 오늘 코드 점검 과정에서 미리 발견한 잠재 버그로, 현재 데이터로는 재현 안 되지만 외부 데이터 유입 시 위험

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카드 필터에서 확장판 이름이 없을 때 빈 문자열로 표시되도록 개선했습니다.
  * 확장판 이름에 값이 없는 카드와 일반 카드가 함께 있어도 필터 목록이 안정적으로 정렬됩니다.

* **테스트**
  * 확장판 이름이 없는 경우와 혼합된 정렬 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->