### PR TITLE
[Chore] #217 카드 도메인 모니터링(Actuator/Prometheus/Grafana) 실험 - 임시

### DIFF
--- a/Pokade/docker-compose.observability.yml
+++ b/Pokade/docker-compose.observability.yml
@@ -1,0 +1,29 @@
+# Actuator/Prometheus/Grafana 로컬 실험용 오버레이 - 커밋 대상 아님.
+# 기존 docker-compose.yml은 그대로 두고, 아래처럼 함께 실행한다:
+#   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+#
+# 앱은 컨테이너가 아니라 호스트에서 ./gradlew.bat bootRun 으로 직접 띄운다는 전제.
+# host.docker.internal 로 호스트의 8080 포트(actuator/prometheus)를 스크랩한다.
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: pokade-prometheus
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: pokade-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus

--- a/Pokade/docker-compose.observability.yml
+++ b/Pokade/docker-compose.observability.yml
@@ -14,16 +14,15 @@ services:
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
 
   grafana:
     image: grafana/grafana:latest
     container_name: pokade-grafana
     restart: unless-stopped
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD}"
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     depends_on:
       - prometheus

--- a/Pokade/observability/prometheus.yml
+++ b/Pokade/observability/prometheus.yml
@@ -1,5 +1,6 @@
 global:
   scrape_interval: 5s
+  scrape_timeout: 4s
 
 scrape_configs:
   - job_name: pokade-backend

--- a/Pokade/observability/prometheus.yml
+++ b/Pokade/observability/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: pokade-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      # host.docker.internal: Docker Desktop(Windows/Mac)에서 컨테이너가 호스트에서 실행 중인
+      # ./gradlew bootRun 앱(기본 포트 8080)에 접근하기 위한 특수 DNS 이름.
+      - targets: ["host.docker.internal:8080"]

--- a/Pokade/src/main/java/com/pokade/domain/card/config/MetricsConfig.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/config/MetricsConfig.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.card.config;
+
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Actuator/Prometheus 로컬 실험용 설정 - 커밋 대상 아님.
+ * TimedAspect Bean이 없으면 CardService의 @Timed 애노테이션이 조용히 무시된다.
+ */
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+        return new TimedAspect(meterRegistry);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -50,12 +50,15 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         thread.setDaemon(true);
         return thread;
     });
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
     private final MeterRegistry meterRegistry;
 
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
     public CardRateLimitFilter() {
         this(new SimpleMeterRegistry());
     }
 
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
     public CardRateLimitFilter(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
         cleanupExecutor.scheduleAtFixedRate(this::evictIdleEntries,
@@ -69,11 +72,13 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         entry.touch();
 
         if (entry.bucket().tryConsume(1)) {
+            // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
             meterRegistry.counter("card.ratelimit.allowed").increment();
             filterChain.doFilter(request, response);
             return;
         }
 
+        // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
         meterRegistry.counter("card.ratelimit.rejected").increment();
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
         response.setContentType(JSON_CONTENT_TYPE);

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -18,6 +18,8 @@ import com.pokade.global.response.ApiResponse;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Refill;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -48,8 +50,14 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         thread.setDaemon(true);
         return thread;
     });
+    private final MeterRegistry meterRegistry;
 
     public CardRateLimitFilter() {
+        this(new SimpleMeterRegistry());
+    }
+
+    public CardRateLimitFilter(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
         cleanupExecutor.scheduleAtFixedRate(this::evictIdleEntries,
                 CLEANUP_INTERVAL.toMillis(), CLEANUP_INTERVAL.toMillis(), TimeUnit.MILLISECONDS);
     }
@@ -61,10 +69,12 @@ public class CardRateLimitFilter extends OncePerRequestFilter {
         entry.touch();
 
         if (entry.bucket().tryConsume(1)) {
+            meterRegistry.counter("card.ratelimit.allowed").increment();
             filterChain.doFilter(request, response);
             return;
         }
 
+        meterRegistry.counter("card.ratelimit.rejected").increment();
         response.setStatus(ErrorCode.CARD_RATE_LIMIT_EXCEEDED.getStatus().value());
         response.setContentType(JSON_CONTENT_TYPE);
         response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.fail(ErrorCode.CARD_RATE_LIMIT_EXCEEDED)));

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilterConfig.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilterConfig.java
@@ -16,6 +16,7 @@ import org.springframework.core.Ordered;
 @Configuration
 public class CardRateLimitFilterConfig {
 
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님 (MeterRegistry 주입)
     @Bean
     public FilterRegistrationBean<CardRateLimitFilter> cardRateLimitFilterRegistration(MeterRegistry meterRegistry) {
         FilterRegistrationBean<CardRateLimitFilter> registration = new FilterRegistrationBean<>();

--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilterConfig.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilterConfig.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.card.filter;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,9 +17,9 @@ import org.springframework.core.Ordered;
 public class CardRateLimitFilterConfig {
 
     @Bean
-    public FilterRegistrationBean<CardRateLimitFilter> cardRateLimitFilterRegistration() {
+    public FilterRegistrationBean<CardRateLimitFilter> cardRateLimitFilterRegistration(MeterRegistry meterRegistry) {
         FilterRegistrationBean<CardRateLimitFilter> registration = new FilterRegistrationBean<>();
-        registration.setFilter(new CardRateLimitFilter());
+        registration.setFilter(new CardRateLimitFilter(meterRegistry));
         registration.addUrlPatterns("/api/cards/*");
         // Spring Security 필터체인보다 먼저 실행되어, 초과 요청은 JWT 인증 이전에 차단된다.
         registration.setOrder(Ordered.HIGHEST_PRECEDENCE);

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -23,6 +23,10 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.web.PageableValidator;
 
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -35,6 +39,7 @@ import java.util.TreeSet;
 import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +66,12 @@ public class CardService {
     private final ExpansionRepository expansionRepository;
     private final CardNameKoResolver cardNameKoResolver;
 
+    // Actuator/Prometheus 로컬 실험용 계측 - 커밋 대상 아님.
+    // final이 아니라 Lombok @RequiredArgsConstructor 생성 대상에서 빠져 기존 테스트(@InjectMocks) 영향 없음.
+    @Autowired
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    @Timed(value = "card.search.duration")
     @Transactional(readOnly = true)
     public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
@@ -79,6 +90,7 @@ public class CardService {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
         cardRepository.incrementViewCount(id);
+        meterRegistry.counter("card.view.increment.calls").increment();
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
         Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id, GRADE_WHITELIST_LIST),
                 CardVariantRepository.VariantGradeView::getVariantId, CardVariantRepository.VariantGradeView::getGrade);
@@ -95,6 +107,7 @@ public class CardService {
         return result;
     }
 
+    @Timed(value = "card.search.keyword.duration")
     @Transactional(readOnly = true)
     public Page<CardResponse> searchByKeyword(String q, Pageable pageable) {
         if (q == null || q.isBlank()) {
@@ -172,6 +185,7 @@ public class CardService {
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {
+        meterRegistry.counter("card.grade.batch.calls").increment();
         if (cards.isEmpty()) {
             return Map.of();
         }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -188,11 +188,11 @@ public class CardService {
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {
-        // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
-        meterRegistry.counter("card.grade.batch.calls").increment();
         if (cards.isEmpty()) {
             return Map.of();
         }
+        // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
+        meterRegistry.counter("card.grade.batch.calls").increment();
         List<Long> cardIds = cards.stream().map(Card::getId).toList();
         return groupByKey(cardRepository.findGradesByCardIds(cardIds, GRADE_WHITELIST_LIST),
                 CardRepository.CardGradeView::getCardId, CardRepository.CardGradeView::getGrade);

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -71,6 +71,7 @@ public class CardService {
     @Autowired
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
     @Timed(value = "card.search.duration")
     @Transactional(readOnly = true)
     public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
@@ -90,6 +91,7 @@ public class CardService {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
         cardRepository.incrementViewCount(id);
+        // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
         meterRegistry.counter("card.view.increment.calls").increment();
         List<CardVariant> variants = cardVariantRepository.findByCardIdOrderByPrimaryDescVariantNameAsc(id);
         Map<Long, List<String>> gradesByVariantId = groupByKey(cardVariantRepository.findGradesByCardId(id, GRADE_WHITELIST_LIST),
@@ -107,6 +109,7 @@ public class CardService {
         return result;
     }
 
+    // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
     @Timed(value = "card.search.keyword.duration")
     @Transactional(readOnly = true)
     public Page<CardResponse> searchByKeyword(String q, Pageable pageable) {
@@ -185,6 +188,7 @@ public class CardService {
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {
+        // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님
         meterRegistry.counter("card.grade.batch.calls").increment();
         if (cards.isEmpty()) {
             return Map.of();

--- a/Pokade/src/main/resources/application-dev.yaml
+++ b/Pokade/src/main/resources/application-dev.yaml
@@ -46,6 +46,13 @@ spring:
 sync:
   enabled: false
 
+# Actuator/Prometheus 로컬 실험용 - 커밋 대상 아님
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,metrics
+
 scrydex:
   api-key: ${SCRYDEX_API_KEY:}
   team-id: ${SCRYDEX_TEAM_ID:}


### PR DESCRIPTION
## 📌 관련 이슈
- #217 

## ✨ 작업 내용
- 카드 도메인에 Actuator/Micrometer 기반 계측(카운터, @Timed)을 추가하고, Prometheus + Grafana로 실제 그래프까지 확인하는 실습
  진행
- 지난번(2026-08-07) 숫자로만 확인했던 것과 비교해, 이번엔 그라파나 대시보드로 시간에 따른 변화를 그래프로 실제로 확인함
  (card_search_duration_seconds_count가 시간순으로 계단식 증가하는 것 확인)
- N+1 없음도 이번에도 재확인 (card_grade_batch_calls_total이 카드 개수와 무관하게 호출 1회로 고정)
- ⚠️ 이 PR은 임시/실험 코드입니다. 코드 내 모든 계측 지점에 `// 임시 계측 - #217, 팀 논의 전 커밋 대상 아님` 주석을 달아뒀습니다.

## 📸 스크린샷 / 테스트 결과
- Prometheus가 /actuator/prometheus를 정상 스크랩 (Targets 정상)
- Grafana 데이터소스 연결 성공 ("Successfully queried the Prometheus API")
- 대시보드 패널에서 card_search_duration_seconds_count 실시간 그래프 확인
- 카드 도메인 테스트(CardServiceTest, CardRateLimitFilterTest) 회귀 없음

## 🔍 리뷰 포인트
- CardRateLimitFilter, CardRateLimitFilterConfig, CardService에 계측 코드 추가됨. 모든 지점에 임시 표시 주석 있음
- MetricsConfig.java(TimedAspect 등록)는 domain/card/config 하위에 둬서 다른 도메인 공유 영역은 안 건드림
- docker-compose.observability.yml(Prometheus+Grafana)은 로컬 실습용, 배포 파이프라인과 무관
- 이 PR은 병합보다는 "팀이 실제로 그래프까지 보고 판단할 수 있게 기록으로 남기는" 목적이 큽니다. 
  병합 여부는 팀 논의 후 결정 부탁드려요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

## 📌 사용 방법

### 1) 로컬에서 켜는 방법
```bash
export GRAFANA_ADMIN_PASSWORD=원하는비밀번호   # 필수! 없으면 기동 거부됨
docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
```

### 2) 확인 방법
- Prometheus: http://localhost:9090 (지표 값 raw로 확인, Targets 메뉴에서 정상 스크랩 되는지 확인)
- Grafana: http://localhost:3001 (admin / 위에서 설정한 비밀번호로 로그인)
  - Connections → Data sources → Add → Prometheus, URL은 `http://prometheus:9090`
  - Dashboards → New → Add visualization 에서 아래 지표 검색해서 그래프로 추가 가능

### 3) 지금 확인 가능한 지표 목록
| 지표명 | 의미 |
|---|---|
| `card_search_duration_seconds_count/sum/max` | 카드 검색 API 호출 횟수/총 응답시간/최대 응답시간 |
| `card_search_keyword_duration_seconds_*` | 키워드 검색 응답시간 |
| `card_grade_batch_calls_total` | 등급 배치 조회 호출 횟수 (N+1 확인용 - 카드 수와 무관하게 1이면 정상) |
| `card_view_increment_calls_total` | 카드 상세 조회수 증가 호출 횟수 |
| `card_ratelimit_allowed_total` / `card_ratelimit_rejected_total` | Rate Limit 허용/차단 횟수 |

### 4) 종료하는 방법
```bash
docker compose -f docker-compose.yml -f docker-compose.observability.yml down
```

### 5) 주의할 점
- 이건 로컬 실습용 임시 코드입니다. 코드 전체에 `// 임시 계측 - #217, 팀 논의 전 커밋 대상 아님` 주석이 달려있습니다
- 팀 전체가 실제로 쓰기로 결정하려면 아래 4가지를 먼저 정해야 합니다:
  1. 지표 이름 규칙(도메인.동작.결과) 통일
  2. `TimedAspect` 등록 위치를 공용 설정 파일 1곳으로 합의
  3. `/actuator/prometheus` 보안(인증 또는 포트 분리) - 이건 실제  배포 서버에 노출하면 위험한 부분
  4. 공통 라벨(서버/환경 구분) 필요 여부
- 각자 로컬에서 켜보면 자기 컴퓨터에서만 그래프가 보입니다 
- 팀 공용 대시보드로 만들려면 별도 인프라(사내 서버 등)가 필요해서 이번 스코프 밖입니다
-  `docker-compose.observability.yml`에 볼륨 설정이 없어서, Grafana 대시보드/데이터소스 설정은 재기동하면 날아갑니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로컬 환경에서 Prometheus와 Grafana를 활용한 관측성 실험 환경을 제공합니다.
  * 애플리케이션의 상태, 메트릭 및 Prometheus 엔드포인트를 확인할 수 있습니다.
  * 카드 조회·검색 성능과 요청 처리량, 레이트 리밋 허용·거부 건수를 모니터링할 수 있습니다.
  * 메트릭을 5초 간격으로 수집하도록 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->