### PR TITLE
[Feature] #213 워치리스트 시세 연동

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -77,9 +77,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
         Double getAvgPrice();
     }
 
-    // 워치리스트 "목표가 도달" 판정용: 카드별 체결가 전체 기간 최저/최고가를 한 번에 조회한다.
-    // 목표가가 이 구간(min~max) 안에 들어오면 시세가 오르내리는 동안 그 가격을 실제로 지나간 적이
-    // 있다고 보고 도달로 판정한다(매수/매도 목표가를 구분하지 않고 동일하게 적용).
+    // 워치리스트 "목표가 도달" 판정용: 카드별 체결가 전체 기간 최저/최고가를 한 번에 조회
     @Query("SELECT l.cardId AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice FROM Trade t JOIN t.listing l "
             + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
             + "GROUP BY l.cardId")

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -76,4 +76,20 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
         Long getCardId();
         Double getAvgPrice();
     }
+
+    // 워치리스트 "목표가 도달" 판정용: 카드별 체결가 전체 기간 최저/최고가를 한 번에 조회한다.
+    // 목표가가 이 구간(min~max) 안에 들어오면 시세가 오르내리는 동안 그 가격을 실제로 지나간 적이
+    // 있다고 보고 도달로 판정한다(매수/매도 목표가를 구분하지 않고 동일하게 적용).
+    @Query("SELECT l.cardId AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice FROM Trade t JOIN t.listing l "
+            + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
+            + "GROUP BY l.cardId")
+    List<CardPriceRangeView> findPriceRangesByCardIds(@Param("cardIds") List<Long> cardIds,
+                                                       @Param("grade") ListingGrade grade,
+                                                       @Param("status") TradeStatus status);
+
+    interface CardPriceRangeView {
+        Long getCardId();
+        Integer getMinPrice();
+        Integer getMaxPrice();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -227,6 +227,41 @@ public class PriceService {
         return new PriceStatsResponse(changeRate, changeAmount, volume);
     }
 
+    // 워치리스트 "등락" 배지용 - getStatsFromTrades()와 동일한 7일 블록 비교를, 여러 카드를 한 번에
+    // 계산한다(getRanking()과 같은 방식으로 배치 조회 후 원하는 cardId만 골라 쓴다). 데이터가 부족하면
+    // getStats()와 동일하게 0으로 채운다(랭킹처럼 후보에서 제외하지 않음 - 워치리스트 항목은 항상 표시돼야 함).
+    public Map<Long, BigDecimal> getChangeRates(List<Long> cardIds) {
+        LocalDateTime recentFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS);
+        LocalDateTime previousFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS * 2L);
+
+        Map<Long, Double> recentAvgByCard = priceTradeStatsRepository
+                .findAveragePricesByGradeSince(STATS_GRADE, TradeStatus.COMPLETED, recentFrom).stream()
+                .collect(Collectors.toMap(
+                        PriceTradeStatsRepository.CardAvgPriceView::getCardId,
+                        PriceTradeStatsRepository.CardAvgPriceView::getAvgPrice));
+        Map<Long, Double> previousAvgByCard = priceTradeStatsRepository
+                .findAveragePricesByGradeBetween(STATS_GRADE, TradeStatus.COMPLETED, previousFrom, recentFrom).stream()
+                .collect(Collectors.toMap(
+                        PriceTradeStatsRepository.CardAvgPriceView::getCardId,
+                        PriceTradeStatsRepository.CardAvgPriceView::getAvgPrice));
+
+        return cardIds.stream().distinct().collect(Collectors.toMap(
+                Function.identity(),
+                cardId -> computeChangeRate(recentAvgByCard.get(cardId), previousAvgByCard.get(cardId))));
+    }
+
+    private BigDecimal computeChangeRate(Double recentAvg, Double previousAvg) {
+        if (recentAvg == null || previousAvg == null) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal recentAvgAmount = BigDecimal.valueOf(recentAvg);
+        BigDecimal previousAvgAmount = BigDecimal.valueOf(previousAvg);
+        return recentAvgAmount.subtract(previousAvgAmount)
+                .divide(previousAvgAmount, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
     // PSA10/PSA9/PSA8은 공인 등급이라 company='PSA', 자체 AI등급(S/A/B)은 company=''.
     private PriceStatsResponse getStatsFromCardPrices(Long variantId, ListingGrade grade, StatsPeriod period) {
         GradeKey gradeKey = toGradeKey(grade);

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -226,10 +226,7 @@ public class PriceService {
 
         return new PriceStatsResponse(changeRate, changeAmount, volume);
     }
-
-    // 워치리스트 "등락" 배지용 - getStatsFromTrades()와 동일한 7일 블록 비교를, 여러 카드를 한 번에
-    // 계산한다(getRanking()과 같은 방식으로 배치 조회 후 원하는 cardId만 골라 쓴다). 데이터가 부족하면
-    // getStats()와 동일하게 0으로 채운다(랭킹처럼 후보에서 제외하지 않음 - 워치리스트 항목은 항상 표시돼야 함).
+    
     public Map<Long, BigDecimal> getChangeRates(List<Long> cardIds) {
         LocalDateTime recentFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS);
         LocalDateTime previousFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS * 2L);

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -42,13 +42,7 @@ public record WatchlistResponse(
         );
     }
 
-    /**
-     * 목록 조회 응답 - 배치로 조회한 카드 정보·현재 시세·등락률을 함께 담는다.
-     * targetReached는 "지금 시세가 목표가 대비 얼마인지"가 아니라 "체결가가 그동안 한 번이라도 그
-     * 목표가를 지나간 적이 있는지"로 판정하므로(WatchlistService 참고), 여기서는 그 결과를 그대로 받는다.
-     * changeRate는 PriceStatsResponse/PriceRankingResponse와 같은 최근 7일 vs 이전 7일 S등급 평균
-     * 체결가 비교(%)이고, 데이터가 부족하면 0으로 채운다(랭킹처럼 항목 자체를 빼지 않음).
-     */
+
     public static WatchlistResponse withPrice(
             Watchlist watchlist, Card card, CardPriceSummaryResponse currentPrice,
             BigDecimal changeRate, boolean targetReached) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -1,67 +1,75 @@
 package com.pokade.domain.watchlist.dto;
 
+import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record WatchlistResponse(
         Long id,
         Long cardId,
         Long variantId,
+        String cardName,
+        String setName,
+        String imageUrl,
         Integer targetBuyPrice,
         Integer targetSellPrice,
         boolean isNotified,
         LocalDateTime createdAt,
         CardPriceSummaryResponse currentPrice,
+        BigDecimal changeRate,
         boolean targetReached
 ) {
 
-    /** 등록 직후 응답 - 아직 현재 시세를 조회하지 않은 상태라 currentPrice는 없다. */
+    /** 등록 직후 응답 - 아직 카드/현재 시세를 조회하지 않은 상태라 카드 정보·currentPrice·등락률은 없다. */
     public static WatchlistResponse of(Watchlist watchlist) {
         return new WatchlistResponse(
                 watchlist.getId(),
                 watchlist.getCardId(),
                 watchlist.getVariantId(),
+                null,
+                null,
+                null,
                 watchlist.getTargetBuyPrice(),
                 watchlist.getTargetSellPrice(),
                 watchlist.isNotified(),
                 watchlist.getCreatedAt(),
                 null,
+                null,
                 false
         );
     }
 
-    /** 목록 조회 응답 - 배치로 조회한 현재 시세를 함께 담아 목표가 도달 여부까지 판단한다. */
-    public static WatchlistResponse withPrice(Watchlist watchlist, CardPriceSummaryResponse currentPrice) {
+    /**
+     * 목록 조회 응답 - 배치로 조회한 카드 정보·현재 시세·등락률을 함께 담는다.
+     * targetReached는 "지금 시세가 목표가 대비 얼마인지"가 아니라 "체결가가 그동안 한 번이라도 그
+     * 목표가를 지나간 적이 있는지"로 판정하므로(WatchlistService 참고), 여기서는 그 결과를 그대로 받는다.
+     * changeRate는 PriceStatsResponse/PriceRankingResponse와 같은 최근 7일 vs 이전 7일 S등급 평균
+     * 체결가 비교(%)이고, 데이터가 부족하면 0으로 채운다(랭킹처럼 항목 자체를 빼지 않음).
+     */
+    public static WatchlistResponse withPrice(
+            Watchlist watchlist, Card card, CardPriceSummaryResponse currentPrice,
+            BigDecimal changeRate, boolean targetReached) {
         return new WatchlistResponse(
                 watchlist.getId(),
                 watchlist.getCardId(),
                 watchlist.getVariantId(),
+                card != null ? card.getName() : null,
+                card != null ? card.getSetName() : null,
+                card != null ? resolveImageUrl(card) : null,
                 watchlist.getTargetBuyPrice(),
                 watchlist.getTargetSellPrice(),
                 watchlist.isNotified(),
                 watchlist.getCreatedAt(),
                 currentPrice,
-                isTargetReached(watchlist, currentPrice)
+                changeRate,
+                targetReached
         );
     }
 
-    /**
-     * 매수 목표가는 현재가(buyPrice)가 목표가 이하로 떨어졌을 때, 매도 목표가는 현재가(sellPrice)가
-     * 목표가 이상으로 올랐을 때 도달로 본다. 둘 다 설정돼 있으면 하나만 도달해도 true.
-     */
-    private static boolean isTargetReached(Watchlist watchlist, CardPriceSummaryResponse currentPrice) {
-        if (currentPrice == null) {
-            return false;
-        }
-        Integer targetBuyPrice = watchlist.getTargetBuyPrice();
-        if (targetBuyPrice != null && currentPrice.buyPrice() != null
-                && currentPrice.buyPrice() <= targetBuyPrice) {
-            return true;
-        }
-        Integer targetSellPrice = watchlist.getTargetSellPrice();
-        return targetSellPrice != null && currentPrice.sellPrice() != null
-                && currentPrice.sellPrice() >= targetSellPrice;
+    private static String resolveImageUrl(Card card) {
+        return card.getImageMedium() != null ? card.getImageMedium() : card.getImageSmall();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.watchlist.dto;
 
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
 
 import java.time.LocalDateTime;
@@ -11,9 +12,12 @@ public record WatchlistResponse(
         Integer targetBuyPrice,
         Integer targetSellPrice,
         boolean isNotified,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        CardPriceSummaryResponse currentPrice,
+        boolean targetReached
 ) {
 
+    /** 등록 직후 응답 - 아직 현재 시세를 조회하지 않은 상태라 currentPrice는 없다. */
     public static WatchlistResponse of(Watchlist watchlist) {
         return new WatchlistResponse(
                 watchlist.getId(),
@@ -22,7 +26,42 @@ public record WatchlistResponse(
                 watchlist.getTargetBuyPrice(),
                 watchlist.getTargetSellPrice(),
                 watchlist.isNotified(),
-                watchlist.getCreatedAt()
+                watchlist.getCreatedAt(),
+                null,
+                false
         );
+    }
+
+    /** 목록 조회 응답 - 배치로 조회한 현재 시세를 함께 담아 목표가 도달 여부까지 판단한다. */
+    public static WatchlistResponse withPrice(Watchlist watchlist, CardPriceSummaryResponse currentPrice) {
+        return new WatchlistResponse(
+                watchlist.getId(),
+                watchlist.getCardId(),
+                watchlist.getVariantId(),
+                watchlist.getTargetBuyPrice(),
+                watchlist.getTargetSellPrice(),
+                watchlist.isNotified(),
+                watchlist.getCreatedAt(),
+                currentPrice,
+                isTargetReached(watchlist, currentPrice)
+        );
+    }
+
+    /**
+     * 매수 목표가는 현재가(buyPrice)가 목표가 이하로 떨어졌을 때, 매도 목표가는 현재가(sellPrice)가
+     * 목표가 이상으로 올랐을 때 도달로 본다. 둘 다 설정돼 있으면 하나만 도달해도 true.
+     */
+    private static boolean isTargetReached(Watchlist watchlist, CardPriceSummaryResponse currentPrice) {
+        if (currentPrice == null) {
+            return false;
+        }
+        Integer targetBuyPrice = watchlist.getTargetBuyPrice();
+        if (targetBuyPrice != null && currentPrice.buyPrice() != null
+                && currentPrice.buyPrice() <= targetBuyPrice) {
+            return true;
+        }
+        Integer targetSellPrice = watchlist.getTargetSellPrice();
+        return targetSellPrice != null && currentPrice.sellPrice() != null
+                && currentPrice.sellPrice() >= targetSellPrice;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -65,9 +65,7 @@ public class WatchlistService {
         if (watchlists.isEmpty()) {
             return List.of();
         }
-
-        // 대표 variant 기준 시세만 배치 조회한다 - watchlist에 variantId가 지정된 항목도 지금은
-        // 대표 variant 시세로 표시된다(개별 variant 시세 반영은 추후 필요해지면 확장).
+        
         List<Long> cardIds = watchlists.stream().map(Watchlist::getCardId).distinct().toList();
         Map<Long, CardPriceSummaryResponse> priceByCardId = priceService.getSummaries(cardIds, null, true)
                 .stream()
@@ -75,9 +73,7 @@ public class WatchlistService {
         Map<Long, Card> cardById = cardRepository.findAllById(cardIds)
                 .stream()
                 .collect(Collectors.toMap(Card::getId, Function.identity()));
-        // "목표가 도달"은 지금 시세가 목표가보다 높은지/낮은지가 아니라, 체결가가 그동안 오르내리며
-        // 그 목표가를 한 번이라도 지나간 적이 있는지로 판정한다 - 그래서 매수/매도 구분 없이 전체 기간
-        // 체결가의 최저~최고 구간에 목표가가 들어오는지만 본다(사용자 요청, 2026-08-13).
+
         Map<Long, PriceTradeStatsRepository.CardPriceRangeView> rangeByCardId =
                 priceTradeStatsRepository.findPriceRangesByCardIds(cardIds, null, TradeStatus.COMPLETED)
                         .stream()

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.watchlist.service;
 
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -11,6 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +25,7 @@ public class WatchlistService {
     private static final long WATCHLIST_LIMIT = 20;
 
     private final WatchlistRepository watchlistRepository;
+    private final PriceService priceService;
 
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
@@ -48,9 +54,20 @@ public class WatchlistService {
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {
-        return watchlistRepository.findByUserId(userId)
+        List<Watchlist> watchlists = watchlistRepository.findByUserId(userId);
+        if (watchlists.isEmpty()) {
+            return List.of();
+        }
+
+        // 대표 variant 기준 시세만 배치 조회한다 - watchlist에 variantId가 지정된 항목도 지금은
+        // 대표 variant 시세로 표시된다(개별 variant 시세 반영은 추후 필요해지면 확장).
+        List<Long> cardIds = watchlists.stream().map(Watchlist::getCardId).distinct().toList();
+        Map<Long, CardPriceSummaryResponse> priceByCardId = priceService.getSummaries(cardIds, null, true)
                 .stream()
-                .map(WatchlistResponse::of)
+                .collect(Collectors.toMap(CardPriceSummaryResponse::cardId, Function.identity()));
+
+        return watchlists.stream()
+                .map(watchlist -> WatchlistResponse.withPrice(watchlist, priceByCardId.get(watchlist.getCardId())))
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -1,7 +1,11 @@
 package com.pokade.domain.watchlist.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -12,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -26,6 +31,8 @@ public class WatchlistService {
 
     private final WatchlistRepository watchlistRepository;
     private final PriceService priceService;
+    private final CardRepository cardRepository;
+    private final PriceTradeStatsRepository priceTradeStatsRepository;
 
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
@@ -65,10 +72,40 @@ public class WatchlistService {
         Map<Long, CardPriceSummaryResponse> priceByCardId = priceService.getSummaries(cardIds, null, true)
                 .stream()
                 .collect(Collectors.toMap(CardPriceSummaryResponse::cardId, Function.identity()));
+        Map<Long, Card> cardById = cardRepository.findAllById(cardIds)
+                .stream()
+                .collect(Collectors.toMap(Card::getId, Function.identity()));
+        // "목표가 도달"은 지금 시세가 목표가보다 높은지/낮은지가 아니라, 체결가가 그동안 오르내리며
+        // 그 목표가를 한 번이라도 지나간 적이 있는지로 판정한다 - 그래서 매수/매도 구분 없이 전체 기간
+        // 체결가의 최저~최고 구간에 목표가가 들어오는지만 본다(사용자 요청, 2026-08-13).
+        Map<Long, PriceTradeStatsRepository.CardPriceRangeView> rangeByCardId =
+                priceTradeStatsRepository.findPriceRangesByCardIds(cardIds, null, TradeStatus.COMPLETED)
+                        .stream()
+                        .collect(Collectors.toMap(PriceTradeStatsRepository.CardPriceRangeView::getCardId, Function.identity()));
+        // "등락" 배지용 - 최근 7일 vs 이전 7일 S등급 평균 체결가 비교(%). getStats()/getRanking()과 같은 기준.
+        Map<Long, BigDecimal> changeRateByCardId = priceService.getChangeRates(cardIds);
 
         return watchlists.stream()
-                .map(watchlist -> WatchlistResponse.withPrice(watchlist, priceByCardId.get(watchlist.getCardId())))
+                .map(watchlist -> WatchlistResponse.withPrice(
+                        watchlist,
+                        cardById.get(watchlist.getCardId()),
+                        priceByCardId.get(watchlist.getCardId()),
+                        changeRateByCardId.get(watchlist.getCardId()),
+                        isTargetReached(watchlist, rangeByCardId.get(watchlist.getCardId()))))
                 .toList();
+    }
+
+    private boolean isTargetReached(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
+        if (range == null || range.getMinPrice() == null || range.getMaxPrice() == null) {
+            return false;
+        }
+        Integer targetBuyPrice = watchlist.getTargetBuyPrice();
+        if (targetBuyPrice != null && range.getMinPrice() <= targetBuyPrice && targetBuyPrice <= range.getMaxPrice()) {
+            return true;
+        }
+        Integer targetSellPrice = watchlist.getTargetSellPrice();
+        return targetSellPrice != null
+                && range.getMinPrice() <= targetSellPrice && targetSellPrice <= range.getMaxPrice();
     }
 
     @Transactional

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -91,7 +91,7 @@ class WatchlistControllerTest {
     void 등록에_성공하면_200과_등록된_항목을_반환한다() throws Exception {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, 10000, null, false, LocalDateTime.now(), null, false);
+                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
 
         given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
                 .willReturn(response);
@@ -139,7 +139,7 @@ class WatchlistControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, 10000, null, false, LocalDateTime.now(), null, false);
+                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
 
         given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
 
@@ -154,14 +154,17 @@ class WatchlistControllerTest {
         CardPriceSummaryResponse currentPrice =
                 new CardPriceSummaryResponse(1L, 9000, 8000, null, "KRW", null, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, 10000, null, false, LocalDateTime.now(), currentPrice, true);
+                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(),
+                currentPrice, new java.math.BigDecimal("3.25"), true);
 
         given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/watchlist").with(userId(100L)))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].cardName").value("피카츄"))
                 .andExpect(jsonPath("$.data[0].currentPrice.buyPrice").value(9000))
                 .andExpect(jsonPath("$.data[0].currentPrice.sellPrice").value(8000))
+                .andExpect(jsonPath("$.data[0].changeRate").value(3.25))
                 .andExpect(jsonPath("$.data[0].targetReached").value(true));
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.auth.service.OAuth2LoginService;
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.service.WatchlistService;
@@ -90,7 +91,7 @@ class WatchlistControllerTest {
     void 등록에_성공하면_200과_등록된_항목을_반환한다() throws Exception {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, 10000, null, false, LocalDateTime.now());
+                1L, 1L, null, 10000, null, false, LocalDateTime.now(), null, false);
 
         given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
                 .willReturn(response);
@@ -138,7 +139,7 @@ class WatchlistControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, 10000, null, false, LocalDateTime.now());
+                1L, 1L, null, 10000, null, false, LocalDateTime.now(), null, false);
 
         given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
 
@@ -146,6 +147,22 @@ class WatchlistControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].id").value(1L));
+    }
+
+    @Test
+    void 목록_조회_응답에_현재_시세와_목표가_도달_여부가_포함된다() throws Exception {
+        CardPriceSummaryResponse currentPrice =
+                new CardPriceSummaryResponse(1L, 9000, 8000, null, "KRW", null, null);
+        WatchlistResponse response = new WatchlistResponse(
+                1L, 1L, null, 10000, null, false, LocalDateTime.now(), currentPrice, true);
+
+        given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/watchlist").with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].currentPrice.buyPrice").value(9000))
+                .andExpect(jsonPath("$.data[0].currentPrice.sellPrice").value(8000))
+                .andExpect(jsonPath("$.data[0].targetReached").value(true));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.watchlist.service;
 
+import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -19,6 +21,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -27,6 +32,7 @@ import static org.mockito.Mockito.never;
 class WatchlistServiceTest {
 
     @Mock WatchlistRepository watchlistRepository;
+    @Mock PriceService priceService;
     @InjectMocks WatchlistService watchlistService;
 
     private Watchlist watchlist(Long userId, Long cardId) {
@@ -126,17 +132,51 @@ class WatchlistServiceTest {
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result).isEmpty();
+        then(priceService).should(never()).getSummaries(any(), any(), anyBoolean());
     }
 
     @Test
-    @DisplayName("목록 조회: 등록된 워치리스트 개수만큼 반환")
+    @DisplayName("목록 조회: 등록된 워치리스트 개수만큼 반환하고, cardId로 시세를 배치 조회해 매핑한다")
     void getWatchlist_success() {
         given(watchlistRepository.findByUserId(1L))
                 .willReturn(List.of(watchlist(1L, 10L), watchlist(1L, 20L)));
+        given(priceService.getSummaries(eq(List.of(10L, 20L)), isNull(), eq(true)))
+                .willReturn(List.of(
+                        new CardPriceSummaryResponse(10L, 900, 800, null, "KRW", null, null),
+                        new CardPriceSummaryResponse(20L, null, null, null, "KRW", null, null)
+                ));
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result).hasSize(2);
+        assertThat(result.get(0).currentPrice().buyPrice()).isEqualTo(900);
+        assertThat(result.get(1).currentPrice().buyPrice()).isNull();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 매수 목표가 이하로 현재가가 내려오면 targetReached=true")
+    void getWatchlist_targetBuyPriceReached() {
+        Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true)))
+                .willReturn(List.of(new CardPriceSummaryResponse(10L, 900, null, null, "KRW", null, null)));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).targetReached()).isTrue();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 현재가가 목표가에 도달하지 않으면 targetReached=false")
+    void getWatchlist_targetNotReached() {
+        Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true)))
+                .willReturn(List.of(new CardPriceSummaryResponse(10L, 1100, null, null, "KRW", null, null)));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).targetReached()).isFalse();
     }
 
     // ===== 삭제 =====

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -1,7 +1,11 @@
 package com.pokade.domain.watchlist.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -33,6 +37,8 @@ class WatchlistServiceTest {
 
     @Mock WatchlistRepository watchlistRepository;
     @Mock PriceService priceService;
+    @Mock CardRepository cardRepository;
+    @Mock PriceTradeStatsRepository priceTradeStatsRepository;
     @InjectMocks WatchlistService watchlistService;
 
     private Watchlist watchlist(Long userId, Long cardId) {
@@ -40,6 +46,13 @@ class WatchlistServiceTest {
                 .userId(userId).cardId(cardId).variantId(null)
                 .targetBuyPrice(1000).targetSellPrice(null)
                 .build();
+    }
+
+    private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
+            implements PriceTradeStatsRepository.CardPriceRangeView {
+        public Long getCardId() { return cardId; }
+        public Integer getMinPrice() { return minPrice; }
+        public Integer getMaxPrice() { return maxPrice; }
     }
 
     // ===== 등록 =====
@@ -133,6 +146,9 @@ class WatchlistServiceTest {
 
         assertThat(result).isEmpty();
         then(priceService).should(never()).getSummaries(any(), any(), anyBoolean());
+        then(cardRepository).should(never()).findAllById(any());
+        then(priceTradeStatsRepository).should(never()).findPriceRangesByCardIds(any(), any(), any());
+        then(priceService).should(never()).getChangeRates(any());
     }
 
     @Test
@@ -154,12 +170,34 @@ class WatchlistServiceTest {
     }
 
     @Test
-    @DisplayName("목록 조회: 매수 목표가 이하로 현재가가 내려오면 targetReached=true")
-    void getWatchlist_targetBuyPriceReached() {
+    @DisplayName("목록 조회: 배치로 조회한 카드 정보(이름·세트명·이미지)가 함께 매핑된다")
+    void getWatchlist_includesCardInfo() {
+        Watchlist watchlist = watchlist(1L, 10L);
+        Card card = Card.builder()
+                .id(10L).name("피카츄").setName("기본팩").imageSmall("small.png").imageMedium("medium.png")
+                .build();
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(cardRepository.findAllById(List.of(10L))).willReturn(List.of(card));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).cardName()).isEqualTo("피카츄");
+        assertThat(result.get(0).setName()).isEqualTo("기본팩");
+        assertThat(result.get(0).imageUrl()).isEqualTo("medium.png");
+    }
+
+    // targetReached는 "지금 시세가 목표가보다 높은지/낮은지"가 아니라 "체결가가 그동안 오르내리며
+    // 목표가를 한 번이라도 지나간 적이 있는지"로 판정한다(사용자 요청, 2026-08-13) - 그래서 아래
+    // 테스트들은 currentPrice가 아니라 findPriceRangesByCardIds가 돌려주는 최저~최고 구간을 기준으로 한다.
+    @Test
+    @DisplayName("목록 조회: 목표가가 체결가 최저~최고 구간 안에 있으면 targetReached=true")
+    void getWatchlist_targetWithinRange() {
         Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
-        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true)))
-                .willReturn(List.of(new CardPriceSummaryResponse(10L, 900, null, null, "KRW", null, null)));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(new PriceRange(10L, 800, 1200)));
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
@@ -167,16 +205,61 @@ class WatchlistServiceTest {
     }
 
     @Test
-    @DisplayName("목록 조회: 현재가가 목표가에 도달하지 않으면 targetReached=false")
-    void getWatchlist_targetNotReached() {
-        Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
+    @DisplayName("목록 조회: 목표가가 현재가보다 훨씬 높아도, 체결가 최고가가 그 목표가에 닿았으면 targetReached=true")
+    void getWatchlist_targetAboveCurrentButWithinHistoricalHigh() {
+        Watchlist watchlist = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(9000).build(); // 현재가(가정 500)보다 훨씬 높은 목표가
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true)))
-                .willReturn(List.of(new CardPriceSummaryResponse(10L, 1100, null, null, "KRW", null, null)));
+                .willReturn(List.of(new CardPriceSummaryResponse(10L, 500, null, null, "KRW", null, null)));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(new PriceRange(10L, 300, 9500))); // 과거 한때 9500까지 거래된 적 있음
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).targetReached()).isTrue();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 목표가가 체결가 최저~최고 구간 밖이면 targetReached=false")
+    void getWatchlist_targetOutsideRange() {
+        Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(new PriceRange(10L, 1500, 2000)));
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result.get(0).targetReached()).isFalse();
+    }
+
+    @Test
+    @DisplayName("목록 조회: 체결 이력이 없는 카드는 targetReached=false")
+    void getWatchlist_noTradeHistory_notReached() {
+        Watchlist watchlist = watchlist(1L, 10L);
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of());
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).targetReached()).isFalse();
+    }
+
+    @Test
+    @DisplayName("목록 조회: PriceService.getChangeRates() 배치 조회 결과가 changeRate로 매핑된다")
+    void getWatchlist_includesChangeRate() {
+        Watchlist watchlist = watchlist(1L, 10L);
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(priceService.getChangeRates(List.of(10L)))
+                .willReturn(java.util.Map.of(10L, new java.math.BigDecimal("3.25")));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).changeRate()).isEqualTo(new java.math.BigDecimal("3.25"));
     }
 
     // ===== 삭제 =====


### PR DESCRIPTION
## 📌 관련 이슈
- #213 

## ✨ 작업 내용
- `GET /api/watchlist` 응답에 카드 정보(cardName/setName/imageUrl), 현재 시세(currentPrice), 등락률(changeRate), 목표가 도달 여부(targetReached) 추가
- `PriceService.getSummaries()`/`getChangeRates()`, `CardRepository.findAllById()`를 배치 조회로 재사용해 N+1 방지
- `targetReached` 판정 기준: "지금 시세가 목표가보다 높은지/낮은지"가 아니라, 체결가 전체 기간 최저~최고 구간에 목표가가 한 번이라도 들어온 적이 있는지로 판정 (매수/매도 방향 무관하게 동일 적용)
- `PriceTradeStatsRepository.findPriceRangesByCardIds()` 신규 추가 — 카드별 체결가 최저~최고 구간 배치 조회
- `PriceService.getChangeRates()` 신규 추가 — 최근 7일 vs 이전 7일 S등급 평균 체결가 등락률(%) 배치 조회 (`getStats()`/`getRanking()`과 동일 공식 재사용)
- `WatchlistServiceTest`/`WatchlistControllerTest`에 시세 연동·목표가 도달·등락률 케이스 보강

## 📸 스크린샷 / 테스트 결과
- 로컬 dev 환경에서 실제 API 호출로 검증:
```json
GET /api/watchlist
{
  "cardName": "Charizard", "setName": "Base",
  "targetBuyPrice": 3000000,
  "currentPrice": { "buyPrice": 2700000, "sellPrice": 2850000, "recentTradePrice": 3100000 },
  "changeRate": 3.73,
  "targetReached": true
}
- WatchlistServiceTest 16/16, WatchlistControllerTest 7/7 통과
````
🔍 리뷰 포인트

- targetReached를 "현재가 vs 목표가 비교"가 아니라 "체결가 이력 구간에 포함되는지"로 판정하도록 바꾼 배경 — 목표가를 현재가와 크게 다르게 잡아도, 실제로 그 가격을 지나간 적이 없으면 미도달로 처리됩니다. 이 기준이 적절한지 봐주세요.
- watchlist.variantId가 지정된 항목도 지금은 대표(primary) variant 시세만 사용
- changeRate/targetReached 계산에 배치 쿼리 2개(가격 구간, 등락률)가 매 요청마다 추가로 실행
- WatchlistService가 PriceService를 서비스 레벨에서 직접 재사용

✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관심목록에서 카드명, 세트명, 이미지와 현재 시세를 함께 확인할 수 있습니다.
  * 최근 가격 변동률이 카드별로 표시됩니다.
  * 과거 체결가 기준으로 매수·매도 목표가 도달 여부를 확인할 수 있습니다.
  * 가격 정보나 거래 이력이 없는 경우에도 안정적으로 목록을 조회할 수 있습니다.

* **개선 사항**
  * 관심목록 조회 시 여러 카드의 가격 정보를 효율적으로 불러오도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->