### PR TITLE
[Feature] #208 워치리스트 목표가 도달 시 알림 자동 생성

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,9 @@ package com.pokade.domain.notification.repository;
 
 import com.pokade.domain.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +14,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     Optional<Notification> findByIdAndUserId(Long id, Long userId);
+
+    // 읽음 처리를 조회-후-갱신이 아니라 조건부 원자적 UPDATE로 수행한다. 동시에 두 요청이 들어와도
+    // is_read=false 조건 자체가 DB 행 잠금과 함께 평가되므로 정확히 하나만 1을 반환한다(TOCTOU 방지).
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true WHERE n.id = :id AND n.userId = :userId AND n.isRead = false")
+    int markAsReadIfUnread(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -41,13 +41,14 @@ public class NotificationService {
         Notification notification = Notification.builder()
                 .userId(watchlist.getUserId())
                 .type(NotificationType.PRICE_TARGET)
-                .message(buildPriceTargetMessage(cardName, reachedTargetPrice))
+                .message(buildPriceTargetMessage(watchlist, cardName, reachedTargetPrice))
                 .build();
 
         notificationRepository.save(notification);
     }
 
-    private String buildPriceTargetMessage(String cardName, Integer reachedTargetPrice) {
-        return String.format("%s 카드가 목표가 %,d원에 도달했습니다.", cardName, reachedTargetPrice);
+    private String buildPriceTargetMessage(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {
+        String targetLabel = reachedTargetPrice.equals(watchlist.getTargetBuyPrice()) ? "구매" : "판매";
+        return String.format("%s 카드가 %s 목표가 %,d원에 도달했습니다.", cardName, targetLabel, reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -29,10 +29,16 @@ public class NotificationService {
 
     @Transactional
     public void markAsRead(Long userId, Long notificationId) {
-        Notification notification = notificationRepository.findByIdAndUserId(notificationId, userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        int updated = notificationRepository.markAsReadIfUnread(notificationId, userId);
+        if (updated == 1) {
+            return;
+        }
 
-        notification.markAsRead();
+        boolean exists = notificationRepository.findByIdAndUserId(notificationId, userId).isPresent();
+        if (!exists) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        throw new BusinessException(ErrorCode.NOTIFICATION_ALREADY_READ);
     }
 
     // 워치리스트 목표가 도달 알림 생성 (reachedTargetPrice: 도달한 것으로 판정된 목표가 - 구매/판매 목표가 중 실제로 도달한 쪽)

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -2,7 +2,9 @@ package com.pokade.domain.notification.service;
 
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
 import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -31,5 +33,21 @@ public class NotificationService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
 
         notification.markAsRead();
+    }
+
+    // 워치리스트 목표가 도달 알림 생성 (reachedTargetPrice: 도달한 것으로 판정된 목표가 - 구매/판매 목표가 중 실제로 도달한 쪽)
+    @Transactional
+    public void createPriceTargetNotification(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {
+        Notification notification = Notification.builder()
+                .userId(watchlist.getUserId())
+                .type(NotificationType.PRICE_TARGET)
+                .message(buildPriceTargetMessage(cardName, reachedTargetPrice))
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    private String buildPriceTargetMessage(String cardName, Integer reachedTargetPrice) {
+        return String.format("%s 카드가 목표가 %,d원에 도달했습니다.", cardName, reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -41,7 +41,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
 
     // 카드별 가장 최근 체결가 1건(grade 지정 시 해당 등급만)
     @Query("SELECT l.cardId AS cardId, t.price AS price FROM Trade t JOIN t.listing l "
-            + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
+            + "WHERE l.cardId IN (:cardIds) AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
             + "AND t.confirmedAt = ("
             + "    SELECT MAX(t2.confirmedAt) FROM Trade t2 JOIN t2.listing l2 "
             + "    WHERE l2.cardId = l.cardId AND (:grade IS NULL OR l2.grade = :grade) AND t2.status = :status"
@@ -79,7 +79,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
 
     // 워치리스트 "목표가 도달" 판정용: 카드별 체결가 전체 기간 최저/최고가를 한 번에 조회
     @Query("SELECT l.cardId AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice FROM Trade t JOIN t.listing l "
-            + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
+            + "WHERE l.cardId IN (:cardIds) AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
             + "GROUP BY l.cardId")
     List<CardPriceRangeView> findPriceRangesByCardIds(@Param("cardIds") List<Long> cardIds,
                                                        @Param("grade") ListingGrade grade,
@@ -93,7 +93,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
 
     // 워치리스트 "목표가 도달" 판정용: 워치리스트 등록(createdAt) 이후 체결된 것만 카드별 최저/최고가 조회
     @Query("SELECT l.cardId AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice FROM Trade t JOIN t.listing l "
-            + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
+            + "WHERE l.cardId IN (:cardIds) AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
             + "AND t.confirmedAt >= :from "
             + "GROUP BY l.cardId")
     List<CardPriceRangeView> findPriceRangesByCardIdsSince(@Param("cardIds") List<Long> cardIds,

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -90,4 +90,14 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
         Integer getMinPrice();
         Integer getMaxPrice();
     }
+
+    // 워치리스트 "목표가 도달" 판정용: 워치리스트 등록(createdAt) 이후 체결된 것만 카드별 최저/최고가 조회
+    @Query("SELECT l.cardId AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice FROM Trade t JOIN t.listing l "
+            + "WHERE l.cardId IN :cardIds AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
+            + "AND t.confirmedAt >= :from "
+            + "GROUP BY l.cardId")
+    List<CardPriceRangeView> findPriceRangesByCardIdsSince(@Param("cardIds") List<Long> cardIds,
+                                                            @Param("grade") ListingGrade grade,
+                                                            @Param("status") TradeStatus status,
+                                                            @Param("from") LocalDateTime from);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -2,6 +2,8 @@ package com.pokade.domain.watchlist.repository;
 
 import com.pokade.domain.watchlist.entity.Watchlist;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +19,9 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     Optional<Watchlist> findByIdAndUserId(Long id, Long userId);
 
     List<Watchlist> findByIsNotifiedFalse();
+
+    // 유저 단위 등록 직렬화용 트랜잭션 스코프 잠금(커밋/롤백 시 자동 해제). 동일 유저의 동시 addWatchlist() 요청을
+    // 직렬화해 "중복 체크 + 20개 제한 체크 + 저장" 구간을 원자적으로 만든다. 다른 유저의 요청과는 경합하지 않는다.
+    @Query(value = "SELECT pg_advisory_xact_lock(:userId)", nativeQuery = true)
+    void acquireUserLock(@Param("userId") Long userId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.repository;
 
 import com.pokade.domain.watchlist.entity.Watchlist;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -24,4 +25,10 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     // 직렬화해 "중복 체크 + 20개 제한 체크 + 저장" 구간을 원자적으로 만든다. 다른 유저의 요청과는 경합하지 않는다.
     @Query(value = "SELECT pg_advisory_xact_lock(:userId)", nativeQuery = true)
     void acquireUserLock(@Param("userId") Long userId);
+
+    // 알림 생성 "권한"을 조건부 원자적 UPDATE로 선점한다. is_notified=false인 행만 갱신되므로,
+    // 삭제됐거나 다른 트랜잭션/인스턴스가 이미 선점한 경우 0을 반환해 중복/유령 알림 생성을 막는다.
+    @Modifying
+    @Query("UPDATE Watchlist w SET w.isNotified = true WHERE w.id = :id AND w.isNotified = false")
+    int markAsNotifiedIfNotYet(@Param("id") Long id);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -15,4 +15,6 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     long countByUserId(Long userId);
 
     Optional<Watchlist> findByIdAndUserId(Long id, Long userId);
+
+    List<Watchlist> findByIsNotifiedFalse();
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -92,16 +92,24 @@ public class WatchlistService {
     }
 
     private boolean isTargetReached(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
+        return resolveReachedTargetPrice(watchlist, range) != null;
+    }
+
+    // 목표가(구매/판매) 도달 판정 - 도달한 목표가 값을 반환(없으면 null).
+    // isTargetReached()와 동일한 판정 로직을 재사용 가능한 형태로 추출한 것 (WatchlistTargetPriceNoticeService에서 재사용).
+    Integer resolveReachedTargetPrice(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
         if (range == null || range.getMinPrice() == null || range.getMaxPrice() == null) {
-            return false;
+            return null;
         }
         Integer targetBuyPrice = watchlist.getTargetBuyPrice();
         if (targetBuyPrice != null && range.getMinPrice() <= targetBuyPrice && targetBuyPrice <= range.getMaxPrice()) {
-            return true;
+            return targetBuyPrice;
         }
         Integer targetSellPrice = watchlist.getTargetSellPrice();
-        return targetSellPrice != null
-                && range.getMinPrice() <= targetSellPrice && targetSellPrice <= range.getMaxPrice();
+        if (targetSellPrice != null && range.getMinPrice() <= targetSellPrice && targetSellPrice <= range.getMaxPrice()) {
+            return targetSellPrice;
+        }
+        return null;
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -13,6 +13,7 @@ import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,10 @@ public class WatchlistService {
             throw new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED);
         }
 
+        // 동시 등록 요청에서 "중복 체크 + 20개 제한 체크 + 저장" 구간이 원자적이도록, 같은 유저의 요청만
+        // 트랜잭션 종료까지 직렬화한다(다른 유저는 영향 없음).
+        watchlistRepository.acquireUserLock(userId);
+
         if (watchlistRepository.existsByUserIdAndCardId(userId, request.cardId())) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
@@ -56,8 +61,13 @@ public class WatchlistService {
                 .targetSellPrice(request.targetSellPrice())
                 .build();
 
-        Watchlist saved = watchlistRepository.save(watchlist);
-        return WatchlistResponse.of(saved);
+        // 위 잠금으로 정상 경로에서는 걸릴 일이 없지만, 방어적으로 DB UNIQUE 제약 위반도 안전하게 변환한다.
+        try {
+            Watchlist saved = watchlistRepository.save(watchlist);
+            return WatchlistResponse.of(saved);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
+        }
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
@@ -1,0 +1,65 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+// 워치리스트 1건 처리를 별도 빈으로 분리한 이유: WatchlistTargetPriceNoticeService의 스케줄러 메서드
+// 안에서 this.process(...)로 self-invocation하면 @Transactional이 AOP 프록시를 안 거쳐 전혀 적용되지
+// 않는다. 여기서 REQUIRES_NEW로 워치리스트 1건마다 독립된 새 트랜잭션을 열어, 한 건 처리 중 예외가 나도
+// "그 건만" 롤백되고 이전에 이미 커밋된 다른 건들은 영향받지 않도록 한다(같은 트랜잭션을 공유했다면, 참여
+// 트랜잭션에서 던진 예외가 물리 트랜잭션을 rollback-only로 표시해 바깥 try/catch로 잡아도 커밋 시점에
+// UnexpectedRollbackException으로 전체가 롤백되는 문제가 있었음).
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WatchlistTargetPriceNoticeProcessor {
+
+    private final WatchlistRepository watchlistRepository;
+    private final PriceTradeStatsRepository priceTradeStatsRepository;
+    private final NotificationService notificationService;
+    private final WatchlistService watchlistService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(Long watchlistId, Card card, PriceTradeStatsRepository.CardPriceRangeView allTimeRange) {
+        // 새 트랜잭션에서 워치리스트를 재조회한다 - 스케줄러가 후보를 읽은 시점과 이 트랜잭션이 실제로
+        // 열리는 시점 사이에 삭제/변경됐을 수 있어, 이전 트랜잭션에서 로드된 인스턴스를 그대로 쓰지 않는다.
+        Watchlist watchlist = watchlistRepository.findById(watchlistId).orElse(null);
+        if (watchlist == null || card == null || watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange) == null) {
+            return;
+        }
+
+        // 2차 확인: 워치리스트 등록(createdAt) 이후 체결분만으로 실제 도달 여부를 재판정
+        // (같은 카드를 여러 워치리스트가 서로 다른 시점에 등록했을 수 있어, 카드 단위 1차 결과만으로는 확정할 수 없음).
+        List<PriceTradeStatsRepository.CardPriceRangeView> sinceRegistration = priceTradeStatsRepository
+                .findPriceRangesByCardIdsSince(List.of(watchlist.getCardId()), null, TradeStatus.COMPLETED, watchlist.getCreatedAt());
+        PriceTradeStatsRepository.CardPriceRangeView rangeSinceRegistration =
+                sinceRegistration.isEmpty() ? null : sinceRegistration.get(0);
+
+        Integer reachedTargetPrice = watchlistService.resolveReachedTargetPrice(watchlist, rangeSinceRegistration);
+        if (reachedTargetPrice == null) {
+            return;
+        }
+
+        // 알림 생성 전, 조건부 원자적 UPDATE(WHERE id=:id AND is_notified=false)로 "알림 생성 권한"을 먼저
+        // 선점한다. 갱신 행 수가 0이면(그 사이 삭제됐거나 다른 트랜잭션/인스턴스가 이미 선점한 경우) 안전하게
+        // 스킵한다 - existsById() 단순 존재 확인보다 더 넓은 레이스(다중 인스턴스 중복 실행 포함)를 막는다.
+        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
+        if (claimed == 0) {
+            log.info("워치리스트 알림 생성 권한을 확보하지 못해 스킵합니다(이미 처리됨 또는 삭제됨): watchlistId={}", watchlist.getId());
+            return;
+        }
+
+        notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
@@ -74,6 +74,14 @@ public class WatchlistTargetPriceNoticeService {
             return;
         }
 
+        // 배치가 후보를 읽은 뒤 알림을 생성하기까지 사이에 사용자가 해당 워치리스트를 삭제했을 수 있어(레이스),
+        // 알림 생성 직전 재확인한다. existsById()는 이 트랜잭션 안에 이미 로드된 엔티티가 있어도
+        // DB에 COUNT 쿼리를 직접 던지므로, 다른 트랜잭션에서 커밋된 삭제를 즉시 반영해 감지할 수 있다.
+        if (!watchlistRepository.existsById(watchlist.getId())) {
+            log.info("워치리스트가 이미 삭제되어 알림 생성을 스킵합니다: watchlistId={}", watchlist.getId());
+            return;
+        }
+
         notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
         watchlist.markAsNotified();
     }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
@@ -74,15 +74,15 @@ public class WatchlistTargetPriceNoticeService {
             return;
         }
 
-        // 배치가 후보를 읽은 뒤 알림을 생성하기까지 사이에 사용자가 해당 워치리스트를 삭제했을 수 있어(레이스),
-        // 알림 생성 직전 재확인한다. existsById()는 이 트랜잭션 안에 이미 로드된 엔티티가 있어도
-        // DB에 COUNT 쿼리를 직접 던지므로, 다른 트랜잭션에서 커밋된 삭제를 즉시 반영해 감지할 수 있다.
-        if (!watchlistRepository.existsById(watchlist.getId())) {
-            log.info("워치리스트가 이미 삭제되어 알림 생성을 스킵합니다: watchlistId={}", watchlist.getId());
+        // 알림 생성 전, 조건부 원자적 UPDATE(WHERE id=:id AND is_notified=false)로 "알림 생성 권한"을 먼저
+        // 선점한다. 갱신 행 수가 0이면(그 사이 삭제됐거나 다른 트랜잭션/인스턴스가 이미 선점한 경우) 안전하게
+        // 스킵한다 - existsById() 단순 존재 확인보다 더 넓은 레이스(다중 인스턴스 중복 실행 포함)를 막는다.
+        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
+        if (claimed == 0) {
+            log.info("워치리스트 알림 생성 권한을 확보하지 못해 스킵합니다(이미 처리됨 또는 삭제됨): watchlistId={}", watchlist.getId());
             return;
         }
 
         notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
-        watchlist.markAsNotified();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
@@ -2,7 +2,6 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
-import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -11,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -20,6 +18,9 @@ import java.util.stream.Collectors;
 
 // 워치리스트 목표가(구매/판매) 도달 감지 배치. 1시간마다 미알림 워치리스트를 훑어
 // 등록(createdAt) 이후 체결분만으로 목표가 도달 여부를 재확인하고, 도달 시 알림을 남긴다.
+// 스케줄러 메서드 자체에는 @Transactional을 걸지 않는다 - 워치리스트 1건마다 독립된 트랜잭션으로 처리해야
+// 하나의 실패가 이전에 커밋된 다른 건들까지 롤백시키지 않으므로, 실제 처리는 별도 빈(WatchlistTargetPriceNoticeProcessor)의
+// REQUIRES_NEW 메서드에 위임한다.
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -28,11 +29,9 @@ public class WatchlistTargetPriceNoticeService {
     private final WatchlistRepository watchlistRepository;
     private final CardRepository cardRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
-    private final NotificationService notificationService;
-    private final WatchlistService watchlistService;
+    private final WatchlistTargetPriceNoticeProcessor processor;
 
     @Scheduled(cron = "0 15 * * * *")
-    @Transactional
     public void detectTargetPriceReached() {
         List<Watchlist> watchlists = watchlistRepository.findByIsNotifiedFalse();
         if (watchlists.isEmpty()) {
@@ -50,39 +49,10 @@ public class WatchlistTargetPriceNoticeService {
 
         for (Watchlist watchlist : watchlists) {
             try {
-                process(watchlist, cardById.get(watchlist.getCardId()), allTimeRangeByCardId.get(watchlist.getCardId()));
+                processor.process(watchlist.getId(), cardById.get(watchlist.getCardId()), allTimeRangeByCardId.get(watchlist.getCardId()));
             } catch (Exception e) {
                 log.warn("워치리스트 목표가 도달 감지 실패: watchlistId={}", watchlist.getId(), e);
             }
         }
-    }
-
-    private void process(Watchlist watchlist, Card card, PriceTradeStatsRepository.CardPriceRangeView allTimeRange) {
-        if (card == null || watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange) == null) {
-            return;
-        }
-
-        // 2차 확인: 워치리스트 등록(createdAt) 이후 체결분만으로 실제 도달 여부를 재판정
-        // (같은 카드를 여러 워치리스트가 서로 다른 시점에 등록했을 수 있어, 카드 단위 1차 결과만으로는 확정할 수 없음).
-        List<PriceTradeStatsRepository.CardPriceRangeView> sinceRegistration = priceTradeStatsRepository
-                .findPriceRangesByCardIdsSince(List.of(watchlist.getCardId()), null, TradeStatus.COMPLETED, watchlist.getCreatedAt());
-        PriceTradeStatsRepository.CardPriceRangeView rangeSinceRegistration =
-                sinceRegistration.isEmpty() ? null : sinceRegistration.get(0);
-
-        Integer reachedTargetPrice = watchlistService.resolveReachedTargetPrice(watchlist, rangeSinceRegistration);
-        if (reachedTargetPrice == null) {
-            return;
-        }
-
-        // 알림 생성 전, 조건부 원자적 UPDATE(WHERE id=:id AND is_notified=false)로 "알림 생성 권한"을 먼저
-        // 선점한다. 갱신 행 수가 0이면(그 사이 삭제됐거나 다른 트랜잭션/인스턴스가 이미 선점한 경우) 안전하게
-        // 스킵한다 - existsById() 단순 존재 확인보다 더 넓은 레이스(다중 인스턴스 중복 실행 포함)를 막는다.
-        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
-        if (claimed == 0) {
-            log.info("워치리스트 알림 생성 권한을 확보하지 못해 스킵합니다(이미 처리됨 또는 삭제됨): watchlistId={}", watchlist.getId());
-            return;
-        }
-
-        notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeService.java
@@ -1,0 +1,80 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+// 워치리스트 목표가(구매/판매) 도달 감지 배치. 1시간마다 미알림 워치리스트를 훑어
+// 등록(createdAt) 이후 체결분만으로 목표가 도달 여부를 재확인하고, 도달 시 알림을 남긴다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WatchlistTargetPriceNoticeService {
+
+    private final WatchlistRepository watchlistRepository;
+    private final CardRepository cardRepository;
+    private final PriceTradeStatsRepository priceTradeStatsRepository;
+    private final NotificationService notificationService;
+    private final WatchlistService watchlistService;
+
+    @Scheduled(cron = "0 15 * * * *")
+    @Transactional
+    public void detectTargetPriceReached() {
+        List<Watchlist> watchlists = watchlistRepository.findByIsNotifiedFalse();
+        if (watchlists.isEmpty()) {
+            return;
+        }
+
+        List<Long> cardIds = watchlists.stream().map(Watchlist::getCardId).distinct().toList();
+        Map<Long, Card> cardById = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, Function.identity()));
+        // 1차 필터: 전체 기간 최저~최고가로 "애초에 목표가 근처도 못 간" 워치리스트를 걸러내
+        // 워치리스트별 개별 조회(2차)를 후보로만 좁힌다 (N+1 최소화).
+        Map<Long, PriceTradeStatsRepository.CardPriceRangeView> allTimeRangeByCardId =
+                priceTradeStatsRepository.findPriceRangesByCardIds(cardIds, null, TradeStatus.COMPLETED).stream()
+                        .collect(Collectors.toMap(PriceTradeStatsRepository.CardPriceRangeView::getCardId, Function.identity()));
+
+        for (Watchlist watchlist : watchlists) {
+            try {
+                process(watchlist, cardById.get(watchlist.getCardId()), allTimeRangeByCardId.get(watchlist.getCardId()));
+            } catch (Exception e) {
+                log.warn("워치리스트 목표가 도달 감지 실패: watchlistId={}", watchlist.getId(), e);
+            }
+        }
+    }
+
+    private void process(Watchlist watchlist, Card card, PriceTradeStatsRepository.CardPriceRangeView allTimeRange) {
+        if (card == null || watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange) == null) {
+            return;
+        }
+
+        // 2차 확인: 워치리스트 등록(createdAt) 이후 체결분만으로 실제 도달 여부를 재판정
+        // (같은 카드를 여러 워치리스트가 서로 다른 시점에 등록했을 수 있어, 카드 단위 1차 결과만으로는 확정할 수 없음).
+        List<PriceTradeStatsRepository.CardPriceRangeView> sinceRegistration = priceTradeStatsRepository
+                .findPriceRangesByCardIdsSince(List.of(watchlist.getCardId()), null, TradeStatus.COMPLETED, watchlist.getCreatedAt());
+        PriceTradeStatsRepository.CardPriceRangeView rangeSinceRegistration =
+                sinceRegistration.isEmpty() ? null : sinceRegistration.get(0);
+
+        Integer reachedTargetPrice = watchlistService.resolveReachedTargetPrice(watchlist, rangeSinceRegistration);
+        if (reachedTargetPrice == null) {
+            return;
+        }
+
+        notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
+        watchlist.markAsNotified();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -63,6 +63,35 @@ class NotificationRepositoryTest {
         assertThat(otherResult).isEmpty();
     }
 
+    @Test
+    void markAsReadIfUnread는_읽지_않은_알림을_1건_갱신하고_이후_재호출은_0건이다() {
+        Long userId = insertUser("mark-unread@test.com");
+        Notification saved = saveNotification(userId, NotificationType.PRICE_TARGET, "unread");
+
+        int firstResult = notificationRepository.markAsReadIfUnread(saved.getId(), userId);
+        entityManager.flush();
+        entityManager.clear();
+        // 두 번째 호출이 "동시에 들어온 다른 요청"을 대신한다 - is_read=false 조건이 이미 거짓이라 0건이어야 한다.
+        int secondResult = notificationRepository.markAsReadIfUnread(saved.getId(), userId);
+
+        assertThat(firstResult).isEqualTo(1);
+        assertThat(secondResult).isEqualTo(0);
+        Notification reloaded = notificationRepository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.isRead()).isTrue();
+    }
+
+    @Test
+    void markAsReadIfUnread는_본인_소유가_아니면_갱신하지_않는다() {
+        Long ownerId = insertUser("mark-owner@test.com");
+        Long otherUserId = insertUser("mark-other@test.com");
+        Notification saved = saveNotification(ownerId, NotificationType.PRICE_TARGET, "owned");
+
+        int result = notificationRepository.markAsReadIfUnread(saved.getId(), otherUserId);
+
+        assertThat(result).isEqualTo(0);
+        assertThat(notificationRepository.findById(saved.getId()).orElseThrow().isRead()).isFalse();
+    }
+
     private Notification saveNotification(Long userId, NotificationType type, String message) {
         Notification saved = notificationRepository.save(
                 Notification.builder()

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -107,8 +107,8 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("목표가 도달 알림 생성: 메시지에 카드명과 목표가가 포함된다")
-    void createPriceTargetNotification_message() {
+    @DisplayName("목표가 도달 알림 생성: 메시지에 카드명, 목표가, '판매' 라벨이 포함된다")
+    void createPriceTargetNotification_message_sell() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetSellPrice(150000).build();
 
         notificationService.createPriceTargetNotification(watchlist, "리자몽", 150000);
@@ -117,6 +117,22 @@ class NotificationServiceTest {
         then(notificationRepository).should().save(captor.capture());
         assertThat(captor.getValue().getMessage())
                 .contains("리자몽")
-                .contains("150,000");
+                .contains("150,000")
+                .contains("판매");
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: 도달한 쪽이 구매 목표가면 메시지에 '구매' 라벨이 포함된다")
+    void createPriceTargetNotification_message_buy() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L)
+                .targetBuyPrice(100000).targetSellPrice(150000).build();
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        then(notificationRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getMessage())
+                .contains("100,000")
+                .contains("구매");
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -59,9 +59,22 @@ class NotificationServiceTest {
     }
 
     // ===== 읽음 처리 =====
+    // markAsReadIfUnread()는 "조회 후 갱신"이 아니라 조건부 원자적 UPDATE라, 존재하지 않는 알림과
+    // 이미 읽은 알림을 구분하려면 0건 갱신 시에만 findByIdAndUserId로 원인을 판별한다.
     @Test
-    @DisplayName("읽음 처리: 존재하지 않으면 NOTIFICATION_NOT_FOUND")
+    @DisplayName("읽음 처리: 원자적 갱신이 1건이면 정상 처리되고 존재 여부를 다시 조회하지 않는다")
+    void markAsRead_success() {
+        given(notificationRepository.markAsReadIfUnread(1L, 1L)).willReturn(1);
+
+        notificationService.markAsRead(1L, 1L);
+
+        then(notificationRepository).should(Mockito.never()).findByIdAndUserId(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    @DisplayName("읽음 처리: 갱신 0건이고 존재하지도 않으면 NOTIFICATION_NOT_FOUND")
     void markAsRead_notFound() {
+        given(notificationRepository.markAsReadIfUnread(1L, 1L)).willReturn(0);
         given(notificationRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
@@ -70,15 +83,14 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("읽음 처리: 정상 케이스면 notification.markAsRead()가 호출된다")
-    void markAsRead_success() {
-        Notification target = Mockito.spy(notification(1L));
-        given(notificationRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+    @DisplayName("읽음 처리: 갱신 0건인데 존재는 하면(이미 읽음, 동시 요청 경합 포함) NOTIFICATION_ALREADY_READ")
+    void markAsRead_alreadyRead() {
+        given(notificationRepository.markAsReadIfUnread(1L, 1L)).willReturn(0);
+        given(notificationRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(notification(1L)));
 
-        notificationService.markAsRead(1L, 1L);
-
-        then(target).should().markAsRead();
-        assertThat(target.isRead()).isTrue();
+        assertThatThrownBy(() -> notificationService.markAsRead(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTIFICATION_ALREADY_READ);
     }
 
     // ===== 목표가 도달 알림 생성 =====

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -68,6 +68,7 @@ class NotificationServiceTest {
 
         notificationService.markAsRead(1L, 1L);
 
+        then(notificationRepository).should(Mockito.times(1)).markAsReadIfUnread(1L, 1L);
         then(notificationRepository).should(Mockito.never()).findByIdAndUserId(Mockito.any(), Mockito.any());
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -4,11 +4,13 @@ import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
 import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -77,5 +79,44 @@ class NotificationServiceTest {
 
         then(target).should().markAsRead();
         assertThat(target.isRead()).isTrue();
+    }
+
+    // ===== 목표가 도달 알림 생성 =====
+    @Test
+    @DisplayName("목표가 도달 알림 생성: notificationRepository.save가 호출된다")
+    void createPriceTargetNotification_saves() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        then(notificationRepository).should().save(Mockito.any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: PRICE_TARGET 타입과 워치리스트의 userId로 저장된다")
+    void createPriceTargetNotification_type() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        then(notificationRepository).should().save(captor.capture());
+        Notification saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(1L);
+        assertThat(saved.getType()).isEqualTo(NotificationType.PRICE_TARGET);
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: 메시지에 카드명과 목표가가 포함된다")
+    void createPriceTargetNotification_message() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetSellPrice(150000).build();
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 150000);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        then(notificationRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getMessage())
+                .contains("리자몽")
+                .contains("150,000");
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.price.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,6 +64,9 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
     private Trade persistCompletedTrade(Listing listing, LocalDateTime confirmedAt) {
         Trade trade = tradeRepository.save(
                 Trade.builder().listing(listing).buyerId(buyerId).price(listing.getPrice()).build());
+        trade.shipToPlatform();
+        trade.markInspected();
+        trade.markDelivered();
         trade.complete();
         entityManager.flush();
         entityManager.createNativeQuery("UPDATE trades SET confirmed_at = :confirmedAt WHERE id = :id")
@@ -138,5 +142,41 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
                 cardId, ListingGrade.S, TradeStatus.COMPLETED, LocalDateTime.now().minusDays(7));
 
         assertThat(count).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("t5 워치리스트 등록(createdAt) 이후 체결분만 반영해 카드별 최저/최고가를 계산한다")
+    void t5() {
+        Listing beforeRegistration = persistListing(2000000, ListingGrade.S);
+        Listing afterRegistrationLow = persistListing(3000000, ListingGrade.S);
+        Listing afterRegistrationHigh = persistListing(3500000, ListingGrade.S);
+
+        LocalDateTime registeredAt = LocalDateTime.now().minusDays(5);
+
+        persistCompletedTrade(beforeRegistration, registeredAt.minusDays(1));
+        persistCompletedTrade(afterRegistrationLow, registeredAt.plusDays(1));
+        persistCompletedTrade(afterRegistrationHigh, registeredAt.plusDays(2));
+
+        var ranges = priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                List.of(cardId), null, TradeStatus.COMPLETED, registeredAt);
+
+        assertThat(ranges).hasSize(1);
+        assertThat(ranges.get(0).getCardId()).isEqualTo(cardId);
+        assertThat(ranges.get(0).getMinPrice()).isEqualTo(3000000);
+        assertThat(ranges.get(0).getMaxPrice()).isEqualTo(3500000);
+    }
+
+    @Test
+    @DisplayName("t6 등록 이후 체결 이력이 없으면 결과에서 제외된다")
+    void t6() {
+        Listing beforeRegistration = persistListing(2000000, ListingGrade.S);
+
+        LocalDateTime registeredAt = LocalDateTime.now().minusDays(5);
+        persistCompletedTrade(beforeRegistration, registeredAt.minusDays(1));
+
+        var ranges = priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                List.of(cardId), null, TradeStatus.COMPLETED, registeredAt);
+
+        assertThat(ranges).isEmpty();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
@@ -179,4 +179,32 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
 
         assertThat(ranges).isEmpty();
     }
+
+    @Test
+    @DisplayName("t7 IN (:cardIds)절에 카드 여러 개를 넘겨도 각 카드별로 정확히 매칭돼 확장된다")
+    void t7() {
+        Card secondCard = Card.builder().name("Blastoise").build();
+        entityManager.persist(secondCard);
+        Long secondCardId = secondCard.getId();
+
+        Listing firstCardListing = persistListing(3000000, ListingGrade.S);
+        Listing secondCardListing = listingRepository.save(
+                Listing.builder().cardId(secondCardId).sellerId(sellerId).price(5000000).grade(ListingGrade.S).build());
+
+        persistCompletedTrade(firstCardListing, LocalDateTime.now().minusDays(1));
+        persistCompletedTrade(secondCardListing, LocalDateTime.now().minusDays(1));
+
+        var ranges = priceTradeStatsRepository.findPriceRangesByCardIds(
+                List.of(cardId, secondCardId), null, TradeStatus.COMPLETED);
+
+        assertThat(ranges).hasSize(2);
+        assertThat(ranges).extracting(PriceTradeStatsRepository.CardPriceRangeView::getCardId)
+                .containsExactlyInAnyOrder(cardId, secondCardId);
+        assertThat(ranges).filteredOn(r -> r.getCardId().equals(cardId))
+                .extracting(PriceTradeStatsRepository.CardPriceRangeView::getMinPrice)
+                .containsExactly(3000000);
+        assertThat(ranges).filteredOn(r -> r.getCardId().equals(secondCardId))
+                .extracting(PriceTradeStatsRepository.CardPriceRangeView::getMinPrice)
+                .containsExactly(5000000);
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
@@ -88,7 +88,11 @@ class WatchlistRepositoryTest {
 
         List<Watchlist> found = watchlistRepository.findByIsNotifiedFalse();
 
-        assertThat(found).extracting(Watchlist::getId).containsExactly(unnotified.getId());
+        // 전역 조회라 다른 테스트/기존 데이터의 미알림 워치리스트가 섞여 있을 수 있어, "정확히 이 목록만"이
+        // 아니라 "이 테스트가 만든 미알림 항목은 포함되고, 알림 완료 항목은 제외되는지"만 검증한다.
+        assertThat(found).extracting(Watchlist::getId)
+                .contains(unnotified.getId())
+                .doesNotContain(notified.getId());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
@@ -75,6 +75,23 @@ class WatchlistRepositoryTest {
     }
 
     @Test
+    void findByIsNotifiedFalse는_알림_미발송_항목만_조회한다() {
+        Long userId = insertUser("notified@test.com");
+        Long notifiedCardId = insertCard("watch-notified-a");
+        Long unnotifiedCardId = insertCard("watch-notified-b");
+        Watchlist notified = saveWatchlist(userId, notifiedCardId, 1000, null);
+        Watchlist unnotified = saveWatchlist(userId, unnotifiedCardId, 2000, null);
+        notified.markAsNotified();
+        watchlistRepository.save(notified);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Watchlist> found = watchlistRepository.findByIsNotifiedFalse();
+
+        assertThat(found).extracting(Watchlist::getId).containsExactly(unnotified.getId());
+    }
+
+    @Test
     void 같은_유저가_같은_카드로_두번_저장하면_UNIQUE_제약으로_예외가_발생한다() {
         Long userId = insertUser("dup@test.com");
         Long cardId = insertCard("watch-dup");

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -1,0 +1,205 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+// WatchlistService.addWatchlist()의 동시 등록 방어(유저 단위 잠금 + UNIQUE 위반 변환)를 실제 DB로 검증한다.
+// addWatchlist()가 PriceService/CardRepository/PriceTradeStatsRepository를 쓰지 않으므로, 실제 빈이 아니라
+// WatchlistRepository만 진짜로 연결하고 나머지는 mock으로 채운 WatchlistService를 직접 생성해 사용한다.
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WatchlistConcurrencyTest {
+
+    @Autowired
+    private WatchlistRepository watchlistRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private WatchlistService newWatchlistService() {
+        return new WatchlistService(watchlistRepository, mock(PriceService.class),
+                mock(CardRepository.class), mock(PriceTradeStatsRepository.class));
+    }
+
+    @Test
+    @DisplayName("같은 카드에 동시 등록을 시도하면 하나만 성공하고 나머지는 DUPLICATE_WATCHLIST로 처리된다")
+    void addWatchlist_concurrentSameCard_onlyOneSucceeds() throws InterruptedException {
+        String runId = UUID.randomUUID().toString().substring(0, 8);
+        TransactionTemplate requiresNew = newRequiresNewTemplate();
+        Long userId = requiresNew.execute(status -> insertUser("concurrent-dup-" + runId + "@test.com"));
+        Long cardId = requiresNew.execute(status -> insertCard("watch-concurrent-dup-" + runId));
+        WatchlistService watchlistService = newWatchlistService();
+
+        try {
+            int threadCount = 5;
+            List<Callable<Boolean>> tasks = new ArrayList<>();
+            for (int i = 0; i < threadCount; i++) {
+                tasks.add(() -> requiresNew.execute(status -> {
+                    try {
+                        watchlistService.addWatchlist(userId, new WatchlistCreateRequest(cardId, null, 1000, null));
+                        return true;
+                    } catch (BusinessException e) {
+                        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_WATCHLIST);
+                        return false;
+                    }
+                }));
+            }
+
+            List<Boolean> results = runConcurrently(tasks);
+
+            assertThat(results).filteredOn(Boolean::booleanValue).hasSize(1);
+            Long finalCount = requiresNew.execute(status -> watchlistRepository.countByUserId(userId));
+            assertThat(finalCount).isEqualTo(1L);
+        } finally {
+            requiresNew.executeWithoutResult(status -> cleanup(userId, List.of(cardId)));
+        }
+    }
+
+    @Test
+    @DisplayName("19개 보유 상태에서 동시에 2건을 등록해도 20개를 넘지 않는다")
+    void addWatchlist_concurrentNearLimit_neverExceedsLimit() throws InterruptedException {
+        String runId = UUID.randomUUID().toString().substring(0, 8);
+        TransactionTemplate requiresNew = newRequiresNewTemplate();
+        Long userId = requiresNew.execute(status -> insertUser("concurrent-limit-" + runId + "@test.com"));
+        WatchlistService watchlistService = newWatchlistService();
+        List<Long> cardIds = new ArrayList<>();
+
+        try {
+            requiresNew.executeWithoutResult(status -> {
+                for (int i = 0; i < 19; i++) {
+                    Long existingCardId = insertCard("watch-limit-existing-" + runId + "-" + i);
+                    cardIds.add(existingCardId);
+                    watchlistRepository.save(Watchlist.builder()
+                            .userId(userId).cardId(existingCardId).targetBuyPrice(1000).build());
+                }
+            });
+
+            Long newCardA = requiresNew.execute(status -> insertCard("watch-limit-new-a-" + runId));
+            Long newCardB = requiresNew.execute(status -> insertCard("watch-limit-new-b-" + runId));
+            cardIds.add(newCardA);
+            cardIds.add(newCardB);
+
+            List<Callable<Boolean>> tasks = List.of(
+                    () -> requiresNew.execute(status -> {
+                        try {
+                            watchlistService.addWatchlist(userId, new WatchlistCreateRequest(newCardA, null, 1000, null));
+                            return true;
+                        } catch (BusinessException e) {
+                            assertThat(e.getErrorCode()).isEqualTo(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
+                            return false;
+                        }
+                    }),
+                    () -> requiresNew.execute(status -> {
+                        try {
+                            watchlistService.addWatchlist(userId, new WatchlistCreateRequest(newCardB, null, 1000, null));
+                            return true;
+                        } catch (BusinessException e) {
+                            assertThat(e.getErrorCode()).isEqualTo(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
+                            return false;
+                        }
+                    })
+            );
+
+            List<Boolean> results = runConcurrently(tasks);
+
+            assertThat(results).filteredOn(Boolean::booleanValue).hasSize(1);
+            Long finalCount = requiresNew.execute(status -> watchlistRepository.countByUserId(userId));
+            assertThat(finalCount).isEqualTo(20L);
+        } finally {
+            requiresNew.executeWithoutResult(status -> cleanup(userId, cardIds));
+        }
+    }
+
+    private TransactionTemplate newRequiresNewTemplate() {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template;
+    }
+
+    private List<Boolean> runConcurrently(List<Callable<Boolean>> tasks) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        try {
+            List<Future<Boolean>> futures = new ArrayList<>();
+            for (Callable<Boolean> task : tasks) {
+                futures.add(executor.submit(task));
+            }
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
+                    .as("모든 스레드가 타임아웃 전에 종료되어야 한다").isTrue();
+
+            List<Boolean> results = new ArrayList<>();
+            for (Future<Boolean> future : futures) {
+                results.add(getUnchecked(future));
+            }
+            return results;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Boolean getUnchecked(Future<Boolean> future) {
+        try {
+            return future.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void cleanup(Long userId, List<Long> cardIds) {
+        watchlistRepository.deleteAll(watchlistRepository.findByUserId(userId));
+        entityManager.flush();
+        entityManager.createNativeQuery("DELETE FROM users WHERE id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM cards WHERE id IN :cardIds")
+                .setParameter("cardIds", cardIds)
+                .executeUpdate();
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Concurrency Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -12,6 +12,7 @@ import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -102,10 +103,25 @@ class WatchlistServiceTest {
 
         WatchlistResponse response = watchlistService.addWatchlist(1L, request);
 
+        then(watchlistRepository).should().acquireUserLock(1L);
         then(watchlistRepository).should().save(any(Watchlist.class));
         assertThat(response.cardId()).isEqualTo(1L);
         assertThat(response.variantId()).isEqualTo(2L);
         assertThat(response.targetBuyPrice()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("등록: 사전 체크를 통과했지만 저장 시점에 DB UNIQUE 제약을 위반하면(동시 등록 경합) DUPLICATE_WATCHLIST로 변환된다")
+    void addWatchlist_saveThrowsDataIntegrityViolation_convertsToDuplicateWatchlist() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class)))
+                .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_WATCHLIST);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -105,9 +105,11 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
         NotificationService notificationService = new NotificationService(notificationRepository);
         WatchlistService watchlistService = new WatchlistService(watchlistRepository,
                 mock(PriceService.class), cardRepository, priceTradeStatsRepository);
+        WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(
+                watchlistRepository, priceTradeStatsRepository, notificationService, watchlistService);
 
         return new WatchlistTargetPriceNoticeService(watchlistRepository, cardRepository,
-                priceTradeStatsRepository, notificationService, watchlistService);
+                priceTradeStatsRepository, processor);
     }
 
     private TransactionTemplate newRequiresNewTemplate() {

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -1,0 +1,168 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+// 여러 배치 인스턴스가 동시에 같은 워치리스트를 후보로 읽어 알림을 생성하려는 상황(다중 인스턴스 배포,
+// 스케줄러 실행 중첩 등)을 실제 스레드로 재현해, markAsNotifiedIfNotYet()의 조건부 원자적 UPDATE가
+// 중복 알림 생성을 막는지 검증한다.
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WatchlistTargetPriceNoticeConcurrencyTest {
+
+    @Autowired
+    private WatchlistRepository watchlistRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
+            implements PriceTradeStatsRepository.CardPriceRangeView {
+        public Long getCardId() { return cardId; }
+        public Integer getMinPrice() { return minPrice; }
+        public Integer getMaxPrice() { return maxPrice; }
+    }
+
+    @Test
+    @DisplayName("여러 인스턴스가 동시에 같은 워치리스트를 감지해도 알림은 정확히 1건만 생성된다")
+    void detectTargetPriceReached_concurrentInstances_onlyOneNotificationCreated() throws InterruptedException {
+        String runId = UUID.randomUUID().toString().substring(0, 8);
+        TransactionTemplate requiresNew = newRequiresNewTemplate();
+        Long userId = requiresNew.execute(status -> insertUser("notice-race-" + runId + "@test.com"));
+        Long cardId = requiresNew.execute(status -> insertCard("watch-notice-race-" + runId));
+        Long watchlistId = requiresNew.execute(status -> watchlistRepository.save(
+                Watchlist.builder().userId(userId).cardId(cardId).targetBuyPrice(1000).build()).getId());
+
+        try {
+            int instanceCount = 5;
+            List<Callable<Void>> tasks = new ArrayList<>();
+            for (int i = 0; i < instanceCount; i++) {
+                tasks.add(() -> requiresNew.execute(status -> {
+                    newNoticeService(cardId).detectTargetPriceReached();
+                    return null;
+                }));
+            }
+
+            runConcurrently(tasks);
+
+            List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+            assertThat(notifications).hasSize(1);
+            Watchlist reloaded = requiresNew.execute(status -> watchlistRepository.findById(watchlistId).orElseThrow());
+            assertThat(reloaded.isNotified()).isTrue();
+        } finally {
+            requiresNew.executeWithoutResult(status -> cleanup(userId, watchlistId, cardId));
+        }
+    }
+
+    // card/price 조회는 항상 "목표가 도달"로 고정 응답하는 mock으로 대체해, 오직 markAsNotifiedIfNotYet()의
+    // 원자성만으로 중복 알림 방지가 되는지를 순수하게 검증한다.
+    private WatchlistTargetPriceNoticeService newNoticeService(Long cardId) {
+        CardRepository cardRepository = mock(CardRepository.class);
+        given(cardRepository.findAllById(any())).willReturn(List.of(Card.builder().id(cardId).name("리자몽").build()));
+
+        PriceTradeStatsRepository priceTradeStatsRepository = mock(PriceTradeStatsRepository.class);
+        PriceRange range = new PriceRange(cardId, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(any(), any(), any())).willReturn(List.of(range));
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any())).willReturn(List.of(range));
+
+        NotificationService notificationService = new NotificationService(notificationRepository);
+        WatchlistService watchlistService = new WatchlistService(watchlistRepository,
+                mock(PriceService.class), cardRepository, priceTradeStatsRepository);
+
+        return new WatchlistTargetPriceNoticeService(watchlistRepository, cardRepository,
+                priceTradeStatsRepository, notificationService, watchlistService);
+    }
+
+    private TransactionTemplate newRequiresNewTemplate() {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template;
+    }
+
+    private void runConcurrently(List<Callable<Void>> tasks) throws InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        try {
+            List<Future<Void>> futures = new ArrayList<>();
+            for (Callable<Void> task : tasks) {
+                futures.add(executor.submit(task));
+            }
+            executor.shutdown();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
+                    .as("모든 스레드가 타임아웃 전에 종료되어야 한다").isTrue();
+            for (Future<Void> future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private void cleanup(Long userId, Long watchlistId, Long cardId) {
+        notificationRepository.deleteAll(notificationRepository.findByUserIdOrderByCreatedAtDesc(userId));
+        watchlistRepository.deleteById(watchlistId);
+        entityManager.flush();
+        entityManager.createNativeQuery("DELETE FROM users WHERE id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM cards WHERE id = :cardId")
+                .setParameter("cardId", cardId)
+                .executeUpdate();
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Concurrency Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
@@ -1,0 +1,132 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistTargetPriceNoticeProcessorTest {
+
+    @Mock WatchlistRepository watchlistRepository;
+    @Mock PriceTradeStatsRepository priceTradeStatsRepository;
+    @Mock NotificationService notificationService;
+    @Mock WatchlistService watchlistService;
+    @InjectMocks WatchlistTargetPriceNoticeProcessor processor;
+
+    private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
+            implements PriceTradeStatsRepository.CardPriceRangeView {
+        public Long getCardId() { return cardId; }
+        public Integer getMinPrice() { return minPrice; }
+        public Integer getMaxPrice() { return maxPrice; }
+    }
+
+    @Test
+    @DisplayName("워치리스트가 그 사이 삭제되어 재조회에 실패하면(0건) 아무 것도 하지 않고 스킵한다")
+    void process_watchlistNotFoundOnRefetch_skipsSafely() {
+        given(watchlistRepository.findById(1L)).willReturn(Optional.empty());
+
+        processor.process(1L, Card.builder().id(10L).name("리자몽").build(), new PriceRange(10L, 800, 1200));
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
+    }
+
+    @Test
+    @DisplayName("목표가 도달: 재조회 후 알림 생성 권한(원자적 UPDATE)을 확보한 뒤 알림을 생성한다")
+    void process_targetReached_claimsAndCreatesNotification() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findById(1L)).willReturn(Optional.of(watchlist));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of(sinceRegistration));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(1);
+
+        processor.process(1L, card, allTimeRange);
+
+        then(watchlistRepository).should().markAsNotifiedIfNotYet(watchlist.getId());
+        then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
+    }
+
+    @Test
+    @DisplayName("알림 생성 권한 확보(원자적 UPDATE)가 0건이면(이미 처리됨 또는 삭제됨) 알림을 생성하지 않고 안전하게 스킵한다")
+    void process_claimFails_skipsSafely() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findById(1L)).willReturn(Optional.of(watchlist));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of(sinceRegistration));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(0);
+
+        processor.process(1L, card, allTimeRange);
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("등록 이전 체결로만 목표가 근처였던 경우, 등록 이후 기준 재확인에서 걸러져 알림이 가지 않는다")
+    void process_reachedOnlyBeforeRegistration_noNotification() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findById(1L)).willReturn(Optional.of(watchlist));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+
+        // 전체 기간 기준으로는 후보로 걸러짐(1차 통과)
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        // 등록 이후로 좁히면 체결 이력 없음 -> 2차 확인에서 탈락
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of());
+        given(watchlistService.resolveReachedTargetPrice(watchlist, null)).willReturn(null);
+
+        processor.process(1L, card, allTimeRange);
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
+    }
+
+    @Test
+    @DisplayName("카드 정보가 없으면(배치 조회에서 못 찾은 경우) 알림을 생성하지 않는다")
+    void process_cardNull_noNotification() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findById(1L)).willReturn(Optional.of(watchlist));
+
+        processor.process(1L, null, new PriceRange(10L, 800, 1200));
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
@@ -1,0 +1,142 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistTargetPriceNoticeServiceTest {
+
+    @Mock WatchlistRepository watchlistRepository;
+    @Mock CardRepository cardRepository;
+    @Mock PriceTradeStatsRepository priceTradeStatsRepository;
+    @Mock NotificationService notificationService;
+    @Mock WatchlistService watchlistService;
+    @InjectMocks WatchlistTargetPriceNoticeService noticeService;
+
+    private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
+            implements PriceTradeStatsRepository.CardPriceRangeView {
+        public Long getCardId() { return cardId; }
+        public Integer getMinPrice() { return minPrice; }
+        public Integer getMaxPrice() { return maxPrice; }
+    }
+
+    @Test
+    @DisplayName("워치리스트가 0건이면 추가 조회 없이 정상 종료된다")
+    void detect_noWatchlists_doesNothing() {
+        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of());
+
+        noticeService.detectTargetPriceReached();
+
+        then(cardRepository).should(never()).findAllById(any());
+        then(priceTradeStatsRepository).should(never())
+                .findPriceRangesByCardIds(any(), any(), any());
+        then(notificationService).should(never())
+                .createPriceTargetNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("목표가 도달: 알림 생성 후 isNotified가 true로 갱신된다")
+    void detect_targetReached_createsNotificationAndMarksNotified() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
+        given(cardRepository.findAllById(List.of(10L)))
+                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
+
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(allTimeRange));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of(sinceRegistration));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+
+        noticeService.detectTargetPriceReached();
+
+        then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
+        assertThat(watchlist.isNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("등록 이전 체결로만 목표가 근처였던 경우, 등록 이후 기준 재확인에서 걸러져 알림이 가지 않는다")
+    void detect_reachedOnlyBeforeRegistration_noNotification() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000)
+                .build();
+        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
+        given(cardRepository.findAllById(List.of(10L)))
+                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
+
+        // 전체 기간 기준으로는 후보로 걸러짐(1차 통과)
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(allTimeRange));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        // 등록 이후로 좁히면 체결 이력 없음 -> 2차 확인에서 탈락
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of());
+        given(watchlistService.resolveReachedTargetPrice(watchlist, null)).willReturn(null);
+
+        noticeService.detectTargetPriceReached();
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        assertThat(watchlist.isNotified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("배치 중 한 항목이 예외를 던져도 나머지 항목은 정상 처리된다")
+    void detect_oneItemFails_othersStillProcessed() {
+        Watchlist failing = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        Watchlist succeeding = Watchlist.builder().userId(2L).cardId(20L).targetBuyPrice(2000).build();
+        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(failing, succeeding));
+        given(cardRepository.findAllById(List.of(10L, 20L))).willReturn(List.of(
+                Card.builder().id(10L).name("리자몽").build(),
+                Card.builder().id(20L).name("이브이").build()));
+
+        PriceRange failingRange = new PriceRange(10L, 800, 1200);
+        PriceRange succeedingRange = new PriceRange(20L, 1800, 2200);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L, 20L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(failingRange, succeedingRange));
+        given(watchlistService.resolveReachedTargetPrice(failing, failingRange))
+                .willThrow(new RuntimeException("판정 중 오류"));
+        given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingRange)).willReturn(2000);
+
+        PriceRange succeedingSince = new PriceRange(20L, 1900, 2100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(20L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of(succeedingSince));
+        given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingSince)).willReturn(2000);
+
+        noticeService.detectTargetPriceReached();
+
+        then(notificationService).should().createPriceTargetNotification(succeeding, "이브이", 2000);
+        then(notificationService).should(never()).createPriceTargetNotification(eq(failing), any(), any());
+        assertThat(succeeding.isNotified()).isTrue();
+        assertThat(failing.isNotified()).isFalse();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
@@ -74,11 +74,39 @@ class WatchlistTargetPriceNoticeServiceTest {
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(sinceRegistration));
         given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        given(watchlistRepository.existsById(watchlist.getId())).willReturn(true);
 
         noticeService.detectTargetPriceReached();
 
         then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
         assertThat(watchlist.isNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("알림 생성 직전 워치리스트가 이미 삭제된 경우(레이스), 알림을 생성하지 않고 안전하게 스킵한다")
+    void detect_watchlistDeletedJustBeforeNotification_skipsSafely() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
+        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
+        given(cardRepository.findAllById(List.of(10L)))
+                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
+
+        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(allTimeRange));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+
+        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
+                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
+                .willReturn(List.of(sinceRegistration));
+        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        // 목표가는 도달했지만, 알림 생성 직전 재확인 시점엔 이미 삭제되어 없는 상태를 시뮬레이션
+        given(watchlistRepository.existsById(watchlist.getId())).willReturn(false);
+
+        noticeService.detectTargetPriceReached();
+
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        assertThat(watchlist.isNotified()).isFalse();
     }
 
     @Test
@@ -131,6 +159,7 @@ class WatchlistTargetPriceNoticeServiceTest {
                 eq(List.of(20L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(succeedingSince));
         given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingSince)).willReturn(2000);
+        given(watchlistRepository.existsById(succeeding.getId())).willReturn(true);
 
         noticeService.detectTargetPriceReached();
 

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class WatchlistTargetPriceNoticeServiceTest {
@@ -57,8 +58,8 @@ class WatchlistTargetPriceNoticeServiceTest {
     }
 
     @Test
-    @DisplayName("목표가 도달: 알림 생성 후 isNotified가 true로 갱신된다")
-    void detect_targetReached_createsNotificationAndMarksNotified() {
+    @DisplayName("목표가 도달: 알림 생성 권한(원자적 UPDATE)을 확보한 뒤 알림을 생성한다")
+    void detect_targetReached_claimsAndCreatesNotification() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
         given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
         given(cardRepository.findAllById(List.of(10L)))
@@ -74,17 +75,17 @@ class WatchlistTargetPriceNoticeServiceTest {
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(sinceRegistration));
         given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
-        given(watchlistRepository.existsById(watchlist.getId())).willReturn(true);
+        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(1);
 
         noticeService.detectTargetPriceReached();
 
+        then(watchlistRepository).should().markAsNotifiedIfNotYet(watchlist.getId());
         then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
-        assertThat(watchlist.isNotified()).isTrue();
     }
 
     @Test
-    @DisplayName("알림 생성 직전 워치리스트가 이미 삭제된 경우(레이스), 알림을 생성하지 않고 안전하게 스킵한다")
-    void detect_watchlistDeletedJustBeforeNotification_skipsSafely() {
+    @DisplayName("알림 생성 권한 확보(원자적 UPDATE)가 0건이면(이미 처리됨 또는 삭제됨) 알림을 생성하지 않고 안전하게 스킵한다")
+    void detect_claimFails_skipsSafely() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
         given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
         given(cardRepository.findAllById(List.of(10L)))
@@ -100,13 +101,12 @@ class WatchlistTargetPriceNoticeServiceTest {
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(sinceRegistration));
         given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
-        // 목표가는 도달했지만, 알림 생성 직전 재확인 시점엔 이미 삭제되어 없는 상태를 시뮬레이션
-        given(watchlistRepository.existsById(watchlist.getId())).willReturn(false);
+        // 목표가는 도달했지만, 알림 생성 직전 원자적 권한 확보에 실패한 상태(삭제됐거나 다른 인스턴스가 선점)를 시뮬레이션
+        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(0);
 
         noticeService.detectTargetPriceReached();
 
         then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
-        assertThat(watchlist.isNotified()).isFalse();
     }
 
     @Test
@@ -159,13 +159,14 @@ class WatchlistTargetPriceNoticeServiceTest {
                 eq(List.of(20L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(succeedingSince));
         given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingSince)).willReturn(2000);
-        given(watchlistRepository.existsById(succeeding.getId())).willReturn(true);
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
 
         noticeService.detectTargetPriceReached();
 
+        // failing/succeeding 둘 다 빌더로 만들어 getId()가 null이라 인자로는 구분할 수 없으므로,
+        // "권한 확보 시도가 정확히 1번만"(= 예외를 던진 failing은 그 앞 단계에서 걸러졌다는 뜻) 호출 횟수로 검증한다.
+        then(watchlistRepository).should(times(1)).markAsNotifiedIfNotYet(any());
         then(notificationService).should().createPriceTargetNotification(succeeding, "이브이", 2000);
         then(notificationService).should(never()).createPriceTargetNotification(eq(failing), any(), any());
-        assertThat(succeeding.isNotified()).isTrue();
-        assertThat(failing.isNotified()).isFalse();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeServiceTest.java
@@ -2,7 +2,6 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
-import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -14,26 +13,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
+// 이 클래스는 이제 후보를 모아 WatchlistTargetPriceNoticeProcessor(별도 빈, REQUIRES_NEW)에 위임하는
+// 역할만 한다 - 실제 목표가 판정/알림 생성/권한 선점 로직은 WatchlistTargetPriceNoticeProcessorTest에서 검증한다.
 @ExtendWith(MockitoExtension.class)
 class WatchlistTargetPriceNoticeServiceTest {
 
     @Mock WatchlistRepository watchlistRepository;
     @Mock CardRepository cardRepository;
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
-    @Mock NotificationService notificationService;
-    @Mock WatchlistService watchlistService;
+    @Mock WatchlistTargetPriceNoticeProcessor processor;
     @InjectMocks WatchlistTargetPriceNoticeService noticeService;
 
     private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
@@ -51,122 +49,47 @@ class WatchlistTargetPriceNoticeServiceTest {
         noticeService.detectTargetPriceReached();
 
         then(cardRepository).should(never()).findAllById(any());
-        then(priceTradeStatsRepository).should(never())
-                .findPriceRangesByCardIds(any(), any(), any());
-        then(notificationService).should(never())
-                .createPriceTargetNotification(any(), any(), any());
+        then(priceTradeStatsRepository).should(never()).findPriceRangesByCardIds(any(), any(), any());
+        then(processor).should(never()).process(any(), any(), any());
     }
 
     @Test
-    @DisplayName("목표가 도달: 알림 생성 권한(원자적 UPDATE)을 확보한 뒤 알림을 생성한다")
-    void detect_targetReached_claimsAndCreatesNotification() {
+    @DisplayName("후보 각각에 대해 카드/전체기간 범위와 함께 processor.process()를 위임 호출한다")
+    void detect_delegatesEachCandidateToProcessor() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
         given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
-        given(cardRepository.findAllById(List.of(10L)))
-                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+        given(cardRepository.findAllById(List.of(10L))).willReturn(List.of(card));
 
         PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of(allTimeRange));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
-
-        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
-        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
-                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
-                .willReturn(List.of(sinceRegistration));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
-        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(1);
 
         noticeService.detectTargetPriceReached();
 
-        then(watchlistRepository).should().markAsNotifiedIfNotYet(watchlist.getId());
-        then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
+        then(processor).should().process(watchlist.getId(), card, allTimeRange);
     }
 
     @Test
-    @DisplayName("알림 생성 권한 확보(원자적 UPDATE)가 0건이면(이미 처리됨 또는 삭제됨) 알림을 생성하지 않고 안전하게 스킵한다")
-    void detect_claimFails_skipsSafely() {
-        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
-        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
-        given(cardRepository.findAllById(List.of(10L)))
-                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
-
-        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
-                .willReturn(List.of(allTimeRange));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
-
-        PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
-        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
-                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
-                .willReturn(List.of(sinceRegistration));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
-        // 목표가는 도달했지만, 알림 생성 직전 원자적 권한 확보에 실패한 상태(삭제됐거나 다른 인스턴스가 선점)를 시뮬레이션
-        given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(0);
-
-        noticeService.detectTargetPriceReached();
-
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("등록 이전 체결로만 목표가 근처였던 경우, 등록 이후 기준 재확인에서 걸러져 알림이 가지 않는다")
-    void detect_reachedOnlyBeforeRegistration_noNotification() {
-        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000)
-                .build();
-        given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(watchlist));
-        given(cardRepository.findAllById(List.of(10L)))
-                .willReturn(List.of(Card.builder().id(10L).name("리자몽").build()));
-
-        // 전체 기간 기준으로는 후보로 걸러짐(1차 통과)
-        PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
-                .willReturn(List.of(allTimeRange));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
-
-        // 등록 이후로 좁히면 체결 이력 없음 -> 2차 확인에서 탈락
-        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
-                eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
-                .willReturn(List.of());
-        given(watchlistService.resolveReachedTargetPrice(watchlist, null)).willReturn(null);
-
-        noticeService.detectTargetPriceReached();
-
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
-        assertThat(watchlist.isNotified()).isFalse();
-    }
-
-    @Test
-    @DisplayName("배치 중 한 항목이 예외를 던져도 나머지 항목은 정상 처리된다")
-    void detect_oneItemFails_othersStillProcessed() {
+    @DisplayName("배치 중 한 항목의 processor.process()가 예외를 던져도 나머지 항목은 정상 위임된다")
+    void detect_oneItemFails_othersStillDelegated() {
         Watchlist failing = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(1000).build();
         Watchlist succeeding = Watchlist.builder().userId(2L).cardId(20L).targetBuyPrice(2000).build();
         given(watchlistRepository.findByIsNotifiedFalse()).willReturn(List.of(failing, succeeding));
-        given(cardRepository.findAllById(List.of(10L, 20L))).willReturn(List.of(
-                Card.builder().id(10L).name("리자몽").build(),
-                Card.builder().id(20L).name("이브이").build()));
+        Card failingCard = Card.builder().id(10L).name("리자몽").build();
+        Card succeedingCard = Card.builder().id(20L).name("이브이").build();
+        given(cardRepository.findAllById(List.of(10L, 20L))).willReturn(List.of(failingCard, succeedingCard));
 
         PriceRange failingRange = new PriceRange(10L, 800, 1200);
         PriceRange succeedingRange = new PriceRange(20L, 1800, 2200);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L, 20L)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of(failingRange, succeedingRange));
-        given(watchlistService.resolveReachedTargetPrice(failing, failingRange))
-                .willThrow(new RuntimeException("판정 중 오류"));
-        given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingRange)).willReturn(2000);
 
-        PriceRange succeedingSince = new PriceRange(20L, 1900, 2100);
-        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
-                eq(List.of(20L)), isNull(), eq(TradeStatus.COMPLETED), any()))
-                .willReturn(List.of(succeedingSince));
-        given(watchlistService.resolveReachedTargetPrice(succeeding, succeedingSince)).willReturn(2000);
-        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
+        doThrow(new RuntimeException("처리 중 오류")).when(processor).process(failing.getId(), failingCard, failingRange);
 
         noticeService.detectTargetPriceReached();
 
-        // failing/succeeding 둘 다 빌더로 만들어 getId()가 null이라 인자로는 구분할 수 없으므로,
-        // "권한 확보 시도가 정확히 1번만"(= 예외를 던진 failing은 그 앞 단계에서 걸러졌다는 뜻) 호출 횟수로 검증한다.
-        then(watchlistRepository).should(times(1)).markAsNotifiedIfNotYet(any());
-        then(notificationService).should().createPriceTargetNotification(succeeding, "이브이", 2000);
-        then(notificationService).should(never()).createPriceTargetNotification(eq(failing), any(), any());
+        then(processor).should().process(failing.getId(), failingCard, failingRange);
+        then(processor).should().process(succeeding.getId(), succeedingCard, succeedingRange);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
@@ -1,0 +1,158 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+// 스케줄러가 여러 워치리스트를 한 트랜잭션으로 처리하면, 한 건에서 던진 예외가 물리 트랜잭션을 통째로
+// rollback-only로 표시해(참여 트랜잭션의 전형적인 함정) 바깥 try/catch로 잡아도 커밋 시점에
+// UnexpectedRollbackException으로 "이전에 이미 성공 처리된 다른 건들"까지 롤백되는 문제가 있었다.
+// WatchlistTargetPriceNoticeProcessor를 REQUIRES_NEW로 분리한 뒤 이 문제가 실제로 해결됐는지,
+// 실제 Postgres + 실제 Spring 트랜잭션 프록시로 검증한다(mock 기반 단위 테스트로는 AOP가 개입하지 않아
+// 이 버그 자체가 재현되지 않는다).
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({WatchlistTargetPriceNoticeService.class, WatchlistTargetPriceNoticeProcessor.class,
+        WatchlistService.class, com.pokade.domain.notification.service.NotificationService.class})
+class WatchlistTargetPriceNoticeTransactionIsolationTest {
+
+    @Autowired
+    private WatchlistRepository watchlistRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private WatchlistTargetPriceNoticeService noticeService;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @MockitoBean
+    private CardRepository cardRepository;
+
+    @MockitoBean
+    private PriceTradeStatsRepository priceTradeStatsRepository;
+
+    @MockitoBean
+    private PriceService priceService;
+
+    private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
+            implements PriceTradeStatsRepository.CardPriceRangeView {
+        public Long getCardId() { return cardId; }
+        public Integer getMinPrice() { return minPrice; }
+        public Integer getMaxPrice() { return maxPrice; }
+    }
+
+    @Test
+    @DisplayName("한 워치리스트 처리 중 예외가 나도, 이전에 이미 성공 처리된 다른 워치리스트의 알림/isNotified는 롤백되지 않는다")
+    void oneItemFails_previouslyCommittedItemSurvives() {
+        String runId = UUID.randomUUID().toString().substring(0, 8);
+        TransactionTemplate requiresNew = newRequiresNewTemplate();
+
+        Long userId = requiresNew.execute(status -> insertUser("tx-isolation-" + runId + "@test.com"));
+        Long okCardId = requiresNew.execute(status -> insertCard("watch-tx-ok-" + runId));
+        Long failCardId = requiresNew.execute(status -> insertCard("watch-tx-fail-" + runId));
+        // Notification.message는 VARCHAR(255) - 카드명을 300자로 만들면 메시지 조립 시 컬럼 길이를 넘어
+        // notificationRepository.save()에서 실제 DataIntegrityViolationException이 발생한다(원래 버그의
+        // "참여 트랜잭션에서 예외가 던져지는" 조건을 인위적 훅 없이 실제 제약 위반으로 재현).
+        String tooLongCardName = "가".repeat(300);
+
+        Long okWatchlistId = requiresNew.execute(status -> watchlistRepository.save(
+                Watchlist.builder().userId(userId).cardId(okCardId).targetBuyPrice(1000).build()).getId());
+        Long failWatchlistId = requiresNew.execute(status -> watchlistRepository.save(
+                Watchlist.builder().userId(userId).cardId(failCardId).targetBuyPrice(1000).build()).getId());
+
+        given(cardRepository.findAllById(any())).willReturn(List.of(
+                Card.builder().id(okCardId).name("리자몽").build(),
+                Card.builder().id(failCardId).name(tooLongCardName).build()));
+
+        PriceRange okRange = new PriceRange(okCardId, 900, 1100);
+        PriceRange failRange = new PriceRange(failCardId, 900, 1100);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(any(), any(), any()))
+                .willReturn(List.of(okRange, failRange));
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any()))
+                .willAnswer(invocation -> {
+                    List<Long> ids = invocation.getArgument(0);
+                    return ids.get(0).equals(okCardId) ? List.of(okRange) : List.of(failRange);
+                });
+
+        try {
+            requiresNew.executeWithoutResult(status -> noticeService.detectTargetPriceReached());
+
+            Watchlist okReloaded = requiresNew.execute(status -> watchlistRepository.findById(okWatchlistId).orElseThrow());
+            assertThat(okReloaded.isNotified()).isTrue();
+
+            List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
+            assertThat(notifications).hasSize(1);
+            assertThat(notifications.get(0).getMessage()).contains("리자몽");
+
+            Watchlist failReloaded = requiresNew.execute(status -> watchlistRepository.findById(failWatchlistId).orElseThrow());
+            assertThat(failReloaded.isNotified()).isFalse();
+        } finally {
+            requiresNew.executeWithoutResult(status ->
+                    cleanup(userId, List.of(okWatchlistId, failWatchlistId), List.of(okCardId, failCardId)));
+        }
+    }
+
+    private TransactionTemplate newRequiresNewTemplate() {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template;
+    }
+
+    private void cleanup(Long userId, List<Long> watchlistIds, List<Long> cardIds) {
+        notificationRepository.deleteAll(notificationRepository.findByUserIdOrderByCreatedAtDesc(userId));
+        watchlistIds.forEach(watchlistRepository::deleteById);
+        entityManager.flush();
+        entityManager.createNativeQuery("DELETE FROM users WHERE id = :userId")
+                .setParameter("userId", userId)
+                .executeUpdate();
+        entityManager.createNativeQuery("DELETE FROM cards WHERE id IN :cardIds")
+                .setParameter("cardIds", cardIds)
+                .executeUpdate();
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status, terms_agreed_at) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE', now()) RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Tx Isolation Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #208 

## ✨ 작업 내용
- 워치리스트 등록 이후 체결분만 반영하는 시세 조회 쿼리 추가
- 알림 생성 메서드 신규 추가 (NotificationService)
- 1시간마다 실행되는 목표가 도달 감지 배치 신규 작성 (WatchlistTargetPriceNoticeService)
- 배치 처리 중 워치리스트 삭제 레이스 방어
- 동시성 이슈 3건 해결 (이전 PR #153/#158 CodeRabbit 지적 사항):
  - 워치리스트 UNIQUE 제약 위반 시 DUPLICATE_WATCHLIST 변환
  - 20개 제한 원자성 확보 (advisory lock)
  - 알림 읽음처리 TOCTOU 해결 (원자적 UPDATE)

## 📸 스크린샷 / 테스트 결과
- 실제 스레드 기반 동시성 테스트(WatchlistConcurrencyTest) 통과
- watchlist/notification 도메인 전체 테스트 통과

## 🔍 리뷰 포인트
- 배치 주기는 기존 스케줄러 (03:00, 04:00)와 안 겹치게 1시간(매시 15분)으로 잡았습니다
- 목표가 판정은 #213의 로직(전체 등급 기준, 구매/매도 구분 없이 동일 적용)을 그대로 재사용했습니다
- 이번 PR에 동시성 버그 3건도 같이 포함되어 있습니다(워치리스트 UNIQUE 위반, 20개 제한, 알림 읽음처리)
- 이메일 발송은 이번엔 포함 안 했습니다 - DB 알림 목록에만 뜨는 형태입니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 워치리스트의 구매·판매 목표가 도달 여부를 주기적으로 확인하고 알림을 보냅니다.
  - 워치리스트 등록 이후 완료된 거래만 기준으로 목표가 도달 여부를 판단합니다.
  - 목표가 알림이 전송된 워치리스트는 중복 알림이 발생하지 않도록 처리됩니다.

- **버그 수정**
  - 알림 읽음 처리가 본인 소유의 읽지 않은 알림에만 적용됩니다.
  - 이미 읽었거나 존재하지 않는 알림을 구분해 안내합니다.
  - 워치리스트 동시 등록 시 중복 등록과 최대 등록 개수 초과를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->