### PR TITLE
[Chore] #224 카드 도메인 정리 - facets 500 에러 수정, 슬라이스 테스트 방지

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -177,7 +177,12 @@ public class CardService {
         Set<String> types = new TreeSet<>(CardTypeEnResolver.resolve(cardRepository.findDistinctTypes()));
         Set<String> rarities = new TreeSet<>();
         for (CardRepository.CardRarityView view : cardRepository.findDistinctRarityCodes()) {
-            rarities.add(CardRarityResolver.resolve(view.getRarityCode(), view.getRarity()));
+            // rarity_code와 rarity가 둘 다 null인 카드가 있으면 resolve()가 null을 반환하는데,
+            // TreeSet.add(null)은 자연순서 비교 시 NullPointerException을 던지므로 여기서 걸러낸다.
+            String resolvedRarity = CardRarityResolver.resolve(view.getRarityCode(), view.getRarity());
+            if (resolvedRarity != null) {
+                rarities.add(resolvedRarity);
+            }
         }
         // expansions.name이 NULL인 레거시/수동 적재 데이터가 있을 수 있어, FE 응답 스키마(name: string,
         // non-null)를 깨지 않도록 빈 문자열로 대체하고 정렬도 null-safe하게 처리한다.

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -86,7 +86,7 @@ public class CardService {
         List<String> expandedRarities = CardRarityResolver.resolveOriginalValues(rarities);
         Page<Card> cards = cardRepository.search(expandedTypes, expandedRarities, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity())));
+        return cards.map(card -> toCardResponse(card, gradesByCardId));
     }
 
     @Transactional
@@ -129,7 +129,7 @@ public class CardService {
                 ? searchByPokedexKoName(keyword, pageable)
                 : cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()), cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()), CardRarityResolver.resolve(card.getRarityCode(), card.getRarity())));
+        return cards.map(card -> toCardResponse(card, gradesByCardId));
     }
 
     // 한글 검색어를 도감번호 목록으로 변환해 조회한다. 매핑이 없으면 예외 대신 빈 페이지를 반환한다.
@@ -162,8 +162,14 @@ public class CardService {
         }
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(related);
         return related.stream()
-                .map(c -> CardResponse.from(c, gradesByCardId.getOrDefault(c.getId(), List.of()), cardNameKoResolver.resolve(c), CardTypeEnResolver.resolve(c.getTypes()), CardRarityResolver.resolve(c.getRarityCode(), c.getRarity())))
+                .map(relatedCard -> toCardResponse(relatedCard, gradesByCardId))
                 .toList();
+    }
+
+    private CardResponse toCardResponse(Card card, Map<Long, List<String>> gradesByCardId) {
+        return CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()),
+                cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()),
+                CardRarityResolver.resolve(card.getRarityCode(), card.getRarity()));
     }
 
     /**

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -68,7 +68,10 @@ public class CardService {
 
     // Actuator/Prometheus 로컬 실험용 계측 - 커밋 대상 아님.
     // final이 아니라 Lombok @RequiredArgsConstructor 생성 대상에서 빠져 기존 테스트(@InjectMocks) 영향 없음.
-    @Autowired
+    // required = false: @DataJpaTest 등 슬라이스 테스트엔 MeterRegistry 빈이 없어 NoSuchBeanDefinitionException으로
+    // 컨텍스트 로딩 자체가 깨졌다(#224). 매칭되는 빈이 없으면 Spring이 필드를 건드리지 않고 그대로 두므로
+    // (value == null이면 field.set() 자체를 안 함), 아래 기본값(SimpleMeterRegistry)이 계속 살아남아 null이 되지 않는다.
+    @Autowired(required = false)
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     // 임시 계측 - #217, 팀 논의 전 커밋 대상 아님

--- a/Pokade/src/main/java/com/pokade/domain/card/support/CardNameKoResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/support/CardNameKoResolver.java
@@ -40,6 +40,11 @@ public class CardNameKoResolver {
             return null;
         }
         Integer pokedexNumber = pokedexNumbers.get(0);
+        if (pokedexNumber == null) {
+            // pokedexKoNameCache는 내부적으로 Map.of()/ConcurrentHashMap을 쓰는데 둘 다 null 키를
+            // 허용하지 않아 get(null)이 NPE를 던진다 - 원본 이름 폴백으로 안전하게 빠진다.
+            return null;
+        }
         String nameEn = pokedexKoNameCache.getNameEn(pokedexNumber);
         String nameKo = pokedexKoNameCache.getNameKo(pokedexNumber);
         if (nameEn == null || nameKo == null) {

--- a/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
+++ b/Pokade/src/main/java/com/pokade/domain/sync/service/CardUpsertService.java
@@ -64,6 +64,13 @@ public class CardUpsertService {
             log.warn("is_online_only=true 카드가 필터를 통과해 응답에 포함됨 - skip. externalId={}", dto.id());
             return false;
         }
+        // 카드 이름은 카드의 정체성 자체라 blank/null이면 세트/판본/가격까지 갈 필요 없이 여기서 건너뛴다.
+        // Card.name은 nullable=false라 그대로 저장을 시도하면 DataIntegrityViolationException으로
+        // (CardSyncService의 카드별 try/catch에 잡히긴 하지만) 불필요하게 실패 처리되므로 미리 막는다.
+        if (dto.name() == null || dto.name().isBlank()) {
+            log.warn("카드 이름이 없어(blank/null) 동기화를 건너뜁니다. externalId={}", dto.id());
+            return false;
+        }
 
         LocalDateTime now = LocalDateTime.now();
         Expansion expansion = expansionDto == null ? null : syncExpansion(expansionDto, now);
@@ -71,6 +78,12 @@ public class CardUpsertService {
 
         CardVariantDto primaryVariant = selectPrimaryVariant(dto.variants());
         if (primaryVariant == null) {
+            return true;
+        }
+        // 판본 이름도 blank/null이면(대표 판본 선정 자체는 가능했더라도) 판본/가격 동기화만 건너뛴다 -
+        // 카드 자체는 이미 정상 저장됐으므로 그 값은 유지한다.
+        if (primaryVariant.name() == null || primaryVariant.name().isBlank()) {
+            log.warn("대표 판본 이름이 없어(blank/null) 판본/가격 동기화를 건너뜁니다. externalId={}", dto.id());
             return true;
         }
 
@@ -82,19 +95,32 @@ public class CardUpsertService {
     private Expansion syncExpansion(ExpansionDto dto, LocalDateTime now) {
         return expansionRepository.findById(dto.id())
                 .map(existing -> backfillTranslation(existing, dto))
-                .orElseGet(() -> expansionRepository.save(Expansion.builder()
-                        .id(dto.id())
-                        .name(dto.name())
-                        .series(dto.series())
-                        .code(dto.code())
-                        .total(dto.total())
-                        .languageCode(dto.languageCode())
-                        .releaseDate(parseReleaseDate(dto.releaseDate()))
-                        .logo(dto.logo())
-                        .symbol(dto.symbol())
-                        .translation(toJsonString(extractTranslationName(dto.translation())))
-                        .syncedAt(now)
-                        .build()));
+                .orElseGet(() -> createExpansion(dto, now));
+    }
+
+    /**
+     * 세트 이름이 없으면(blank/null) 세트 생성을 건너뛰고 null을 반환한다 - 호출부(upsertCard)가
+     * expansionDto == null일 때와 동일하게 처리하므로(Card.expansion은 nullable), 카드 자체 저장에는
+     * 영향이 없다.
+     */
+    private Expansion createExpansion(ExpansionDto dto, LocalDateTime now) {
+        if (dto.name() == null || dto.name().isBlank()) {
+            log.warn("세트 이름이 없어(blank/null) 세트 동기화를 건너뜁니다. expansionId={}", dto.id());
+            return null;
+        }
+        return expansionRepository.save(Expansion.builder()
+                .id(dto.id())
+                .name(dto.name())
+                .series(dto.series())
+                .code(dto.code())
+                .total(dto.total())
+                .languageCode(dto.languageCode())
+                .releaseDate(parseReleaseDate(dto.releaseDate()))
+                .logo(dto.logo())
+                .symbol(dto.symbol())
+                .translation(toJsonString(extractTranslationName(dto.translation())))
+                .syncedAt(now)
+                .build());
     }
 
     /**

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -694,4 +694,39 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         Page<Card> page0Retry = cardRepository.findByNationalPokedexNumbersIn(List.of(132), PageRequest.of(0, 1));
         assertThat(page0Retry.getContent()).extracting(Card::getId).containsExactly(dittoFirst.getId());
     }
+
+    @Test
+    @DisplayName("t57 rarity_code와 rarity가 둘 다 null인 카드도 findDistinctRarityCodes() 결과에 (null, null) 조합으로 포함된다")
+    void t57() {
+        Expansion expansion = persistExpansion("null-rarity-set", "Null Rarity Set");
+        Card mysteryCard = Card.builder()
+                .name("Mystery Card")
+                .supertype("Pokémon")
+                .expansion(expansion)
+                .rarity(null)
+                .rarityCode(null)
+                .syncedAt(LocalDateTime.now())
+                .build();
+        entityManager.persist(mysteryCard);
+        entityManager.flush();
+
+        List<CardRepository.CardRarityView> result = cardRepository.findDistinctRarityCodes();
+
+        // CardService.getFacets()에서 이 (null, null) 조합이 실제로 NPE 없이 걸러지는지는
+        // CardServiceTest(t52)가 서비스 레벨에서 검증하고, 여기서는 리포지토리 쿼리 자체가
+        // 실제 Postgres에서 이 조합을 WHERE로 걸러내지 않고 그대로 돌려주는지만 확인한다.
+        assertThat(result).anyMatch(v -> v.getRarityCode() == null && v.getRarity() == null);
+        // setUp()의 기존 카드들(rarity_code는 항상 null, rarity는 값이 있음)도 여전히 섞여 나온다.
+        assertThat(result).anyMatch(v -> v.getRarityCode() == null && "Rare Holo".equals(v.getRarity()));
+    }
+
+    @Test
+    @DisplayName("t58 findDistinctTypes()는 실제 저장된 카드들의 type을 중복 없이 전부 반환한다")
+    void t58() {
+        List<String> result = cardRepository.findDistinctTypes();
+
+        // setUp()에서 Fire(Charizard/Charizard ex 중복)/Water/Lightning을 심어뒀다 - 중복 제거되고
+        // 트레이너 카드(types 없음)는 섞이지 않는지 함께 확인한다.
+        assertThat(result).containsExactlyInAnyOrder("Fire", "Water", "Lightning");
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -727,6 +727,21 @@ class CardServiceTest {
                 .containsExactly("", "Base", "Sword & Shield");
     }
 
+    @Test
+    @DisplayName("t52 rarity_code와 rarity가 둘 다 null인 카드가 섞여 있어도 NPE 없이 나머지 rarity는 정상 노출된다")
+    void t52() {
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of(
+                rarityView(null, null),
+                rarityView("C", "Common"),
+                rarityView(null, "프로모")));
+        given(expansionRepository.findAll()).willReturn(List.of());
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.rarities()).containsExactlyInAnyOrder("Common", "프로모");
+    }
+
     private CardRepository.CardRarityView rarityView(String rarityCode, String rarity) {
         return new CardRepository.CardRarityView() {
             @Override

--- a/Pokade/src/test/java/com/pokade/domain/card/support/CardNameKoResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/support/CardNameKoResolverTest.java
@@ -2,7 +2,10 @@ package com.pokade.domain.card.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -93,5 +96,14 @@ class CardNameKoResolverTest {
         given(pokedexKoNameCache.getNameKo(940)).willReturn("파이코");
 
         assertThat(cardNameKoResolver.resolve("クヌギダマ", List.of(940))).isEqualTo("파이코");
+    }
+
+    @Test
+    @DisplayName("t10 pokedexNumbers의 첫 번째 원소가 null이면 NPE 없이 null을 반환한다(원본 이름 폴백)")
+    void t10() {
+        assertThat(cardNameKoResolver.resolve("Charizard", Arrays.asList(null, 6))).isNull();
+
+        then(pokedexKoNameCache).should(never()).getNameEn(org.mockito.ArgumentMatchers.any());
+        then(pokedexKoNameCache).should(never()).getNameKo(org.mockito.ArgumentMatchers.any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/sync/service/CardUpsertServiceTest.java
@@ -3,6 +3,8 @@ package com.pokade.domain.sync.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +25,7 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.repository.ExpansionRepository;
 import com.pokade.domain.sync.client.dto.CardDto;
+import com.pokade.domain.sync.client.dto.CardVariantDto;
 import com.pokade.domain.sync.client.dto.ExpansionDto;
 import com.pokade.domain.sync.client.dto.TranslationDto;
 
@@ -162,5 +165,109 @@ class CardUpsertServiceTest {
         assertThat(saved).isTrue();
         assertThat(capturedSavedCard().getSetName()).isEqualTo(ORIGINAL_EXPANSION_NAME);
         assertThat(expansion.getTranslation()).isNull();
+    }
+
+    @Test
+    @DisplayName("t6 카드 이름이 blank면 세트/카드 동기화를 전부 건너뛰고 false를 반환한다")
+    void t6() {
+        CardDto dto = cardDtoWithName("   ", "sv10_ja-6");
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isFalse();
+        then(expansionRepository).should(never()).findById(any());
+        then(cardRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("t7 카드 이름이 null이면 세트/카드 동기화를 전부 건너뛰고 false를 반환한다")
+    void t7() {
+        CardDto dto = cardDtoWithName(null, "sv10_ja-7");
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isFalse();
+        then(expansionRepository).should(never()).findById(any());
+        then(cardRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("t8 신규 세트인데 세트 이름이 blank면 세트 생성은 건너뛰고, 카드는 expansion 없이 정상 저장된다")
+    void t8() {
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.empty());
+        given(cardRepository.findByExternalId("sv10_ja-8")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        ExpansionDto blankNameExpansion = new ExpansionDto(
+                EXPANSION_ID, "  ", "Scarlet & Violet", null, 98, null,
+                "JA", "2024/11/01", null, null, null, null);
+        CardDto dto = cardDtoWithExpansionAndVariants("sv10_ja-8", blankNameExpansion, null);
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        then(expansionRepository).should(never()).save(any());
+        assertThat(capturedSavedCard().getExpansion()).isNull();
+    }
+
+    @Test
+    @DisplayName("t9 대표 판본 이름이 blank면 카드는 저장되지만 판본/가격 동기화는 건너뛴다")
+    void t9() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-9")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        CardVariantDto blankNameVariant = new CardVariantDto("   ", null, null);
+        CardDto dto = cardDtoWithExpansionAndVariants("sv10_ja-9", null, List.of(blankNameVariant));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        then(cardVariantRepository).should(never()).findByCardId(any());
+        then(cardVariantRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("t10 정상적인 이름을 가진 대표 판본은 예전처럼 정상적으로 동기화된다(회귀)")
+    void t10() {
+        Expansion expansion = existingExpansion(null);
+        given(expansionRepository.findById(EXPANSION_ID)).willReturn(Optional.of(expansion));
+        given(cardRepository.findByExternalId("sv10_ja-10")).willReturn(Optional.empty());
+        given(cardRepository.save(any(Card.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(cardVariantRepository.findByCardId(any())).willReturn(Optional.empty());
+        given(cardVariantRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+        // prices가 없어(null) findNmPrice()가 즉시 null을 반환하므로 syncPrice()는 cardPriceRepository까지
+        // 가지 않고 조용히 리턴한다 - 이 테스트의 관심사(판본 동기화)와 무관해 가격 관련 스텁은 넣지 않는다.
+        CardVariantDto normalVariant = new CardVariantDto("Normal", null, null);
+        CardDto dto = cardDtoWithExpansionAndVariants("sv10_ja-10", null, List.of(normalVariant));
+
+        boolean saved = cardUpsertService.upsertCard(dto);
+
+        assertThat(saved).isTrue();
+        then(cardVariantRepository).should().save(any());
+    }
+
+    private CardDto cardDtoWithName(String name, String externalId) {
+        ExpansionDto expansionDto = new ExpansionDto(
+                EXPANSION_ID, ORIGINAL_EXPANSION_NAME, "Scarlet & Violet", null, 98, null,
+                "JA", "2024/11/01", null, null, null, null);
+        return new CardDto(
+                externalId, name, "ポケモン", List.of("草"), List.of("たね"),
+                "通常", "●", null, "YASHIRO Nanaco", List.of(204),
+                "001/098", null, null, expansionDto, 1, "JA", null
+        );
+    }
+
+    private CardDto cardDtoWithExpansionAndVariants(String externalId, ExpansionDto expansionDto,
+                                                      List<CardVariantDto> variants) {
+        ExpansionDto resolvedExpansionDto = expansionDto != null ? expansionDto : new ExpansionDto(
+                EXPANSION_ID, ORIGINAL_EXPANSION_NAME, "Scarlet & Violet", null, 98, null,
+                "JA", "2024/11/01", null, null, null, null);
+        return new CardDto(
+                externalId, "クヌギダマ", "ポケモン", List.of("草"), List.of("たね"),
+                "通常", "●", null, "YASHIRO Nanaco", List.of(204),
+                "001/098", null, null, resolvedExpansionDto, 1, "JA", variants
+        );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #224 

## ✨ 작업 내용
- CardService MeterRegistry 주입을 required=false로 변경 (슬라이스 테스트 깨짐 방지)
- 배포 서버 /api/cards/facets 500 에러 수정 (레어도 정보 완전 누락 카드로 인한 NPE)
- CardNameKoResolver pokedexNumbers null 원소 방어
- CardUpsertService name류(세트/카드/판본) blank/null 방어 추가
- CardResponse 매핑 반복 로직을 공용 헬퍼로 추출
- facets 쿼리 실제 DB 통합 테스트 추가

## 📸 스크린샷 / 테스트 결과
- 신규 테스트 다수 추가, 전부 통과

## 🔍 리뷰 포인트
- 이 PR은 배포에서 실제 발생한 500 에러 수정을 포함합니다 (facets NPE) - 우선 확인 부탁드려요
- CardUpsertService(sync 도메인) 파일 수정 -  순수 방어 코드 추가라 다른 로직 영향 없음을 테스트로 확인

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카드 검색 및 관련 카드 조회 결과가 일관되게 표시됩니다.
  * 등급 정보가 없는 카드로 인한 오류를 방지했습니다.
  * 일부 카드 이름·세트·판본 정보가 누락된 경우 동기화가 안정적으로 처리됩니다.
  * 특정 카드명 조회 시 잘못된 데이터로 인한 오류를 방지했습니다.

* **테스트**
  * 등급·유형 필터와 카드 동기화의 예외 상황에 대한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->