### PR TITLE
[Feature] #230 알림 SSE 구독 엔드포인트 및 Emitter 관리 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardFacetsResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardFacetsResponse.java
@@ -8,7 +8,7 @@ public record CardFacetsResponse(
         List<ExpansionFacet> expansions
 ) {
 
-    public record ExpansionFacet(String id, String name) {
+    public record ExpansionFacet(String id, String name, String series) {
     }
 
     public static CardFacetsResponse of(List<String> types, List<String> rarities, List<ExpansionFacet> expansions) {

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -10,6 +10,7 @@ import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.entity.Expansion;
 import com.pokade.domain.card.entity.PokedexKoName;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
@@ -27,6 +28,7 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -172,6 +175,9 @@ public class CardService {
                 CardRarityResolver.resolve(card.getRarityCode(), card.getRarity()));
     }
 
+    // series가 없는(null) 세트를 묶는 그룹 라벨 - FE 아코디언에서 "기타" 그룹으로 표시된다.
+    private static final String UNKNOWN_SERIES_LABEL = "기타";
+
     /**
      * 카드 필터 옵션(타입/레어도/세트)을 DB에 실제로 존재하는 값 기준으로 조회한다.
      * types/rarity_code는 원본이 다국어로 혼재돼 있어 리졸버 적용 후 표준명 기준으로 중복 제거한다
@@ -190,15 +196,38 @@ public class CardService {
                 rarities.add(resolvedRarity);
             }
         }
-        // expansions.name이 NULL인 레거시/수동 적재 데이터가 있을 수 있어, FE 응답 스키마(name: string,
-        // non-null)를 깨지 않도록 빈 문자열로 대체하고 정렬도 null-safe하게 처리한다.
-        List<CardFacetsResponse.ExpansionFacet> expansions = expansionRepository.findAll().stream()
-                .map(expansion -> new CardFacetsResponse.ExpansionFacet(
-                        expansion.getId(), Objects.requireNonNullElse(expansion.getName(), "")))
-                .sorted(Comparator.comparing(CardFacetsResponse.ExpansionFacet::name,
-                        Comparator.nullsLast(Comparator.naturalOrder())))
-                .toList();
+        List<CardFacetsResponse.ExpansionFacet> expansions = buildExpansionFacets();
         return CardFacetsResponse.of(List.copyOf(types), List.copyOf(rarities), expansions);
+    }
+
+    // expansions.name/series가 NULL인 레거시/수동 적재 데이터가 있을 수 있어, FE 응답 스키마(non-null)를
+    // 깨지 않도록 각각 빈 문자열/"기타"로 대체한다. FE가 series로 묶어 아코디언 렌더링을 하기 편하도록,
+    // 목록 자체를 "series 그룹의 최신 발매일(release_date) 내림차순 -> 그룹 내 세트명 오름차순"으로 정렬해
+    // 반환한다(같은 series가 여러 해에 걸쳐 발매될 수 있어 그룹의 대표값은 MIN이 아닌 MAX release_date를 쓴다.
+    // release_date가 전부 NULL인 series는 가장 오래된 것으로 취급해 뒤로 보낸다).
+    private List<CardFacetsResponse.ExpansionFacet> buildExpansionFacets() {
+        List<Expansion> allExpansions = expansionRepository.findAll();
+
+        Map<String, LocalDate> latestReleaseBySeries = allExpansions.stream()
+                .collect(Collectors.groupingBy(
+                        expansion -> Objects.requireNonNullElse(expansion.getSeries(), UNKNOWN_SERIES_LABEL),
+                        Collectors.mapping(Expansion::getReleaseDate,
+                                Collectors.collectingAndThen(Collectors.toList(), dates -> dates.stream()
+                                        .filter(Objects::nonNull)
+                                        .max(Comparator.naturalOrder())
+                                        .orElse(LocalDate.MIN)))));
+
+        return allExpansions.stream()
+                .map(expansion -> new CardFacetsResponse.ExpansionFacet(
+                        expansion.getId(),
+                        Objects.requireNonNullElse(expansion.getName(), ""),
+                        Objects.requireNonNullElse(expansion.getSeries(), UNKNOWN_SERIES_LABEL)))
+                .sorted(Comparator
+                        .comparing((CardFacetsResponse.ExpansionFacet facet) -> latestReleaseBySeries.get(facet.series()))
+                        .reversed()
+                        .thenComparing(CardFacetsResponse.ExpansionFacet::name,
+                                Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {

--- a/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
@@ -4,12 +4,14 @@ import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -32,5 +34,10 @@ public class NotificationController {
     ) {
         notificationService.markAsRead(userId, id);
         return ApiResponse.ok("알림을 읽음 처리했습니다.");
+    }
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
+        return notificationService.subscribe(userId);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -4,21 +4,35 @@ import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
 import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
 
+    // FE가 만료 전에 재연결해야 하는 SSE 연결 유지 시간
+    private static final long SSE_TIMEOUT_MILLIS = 30L * 60 * 1000;
+
+    // 리버스 프록시(nginx/ALB 등)의 idle timeout이 보통 60초 안팎이라, 그보다 짧은 주기로 더미 코멘트를
+    // 보내 연결이 유휴 상태로 조기 종료되지 않도록 한다.
+    private static final long HEARTBEAT_INTERVAL_MILLIS = 15_000L;
+
     private final NotificationRepository notificationRepository;
+    private final SseEmitterStore sseEmitterStore;
 
     public List<NotificationResponse> getNotifications(Long userId) {
         return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
@@ -51,10 +65,53 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
+        pushToSubscribers(watchlist.getUserId(), NotificationResponse.of(notification));
     }
 
     private String buildPriceTargetMessage(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {
         String targetLabel = reachedTargetPrice.equals(watchlist.getTargetBuyPrice()) ? "구매" : "판매";
         return String.format("%s 카드가 %s 목표가 %,d원에 도달했습니다.", cardName, targetLabel, reachedTargetPrice);
+    }
+
+    // 로그인 유저의 SSE 구독을 등록한다. 인증은 기존 JwtAuthenticationFilter가 처리하므로
+    // 여기서는 이미 인증된 userId를 받아 Emitter를 저장소에 등록하는 역할만 한다.
+    public SseEmitter subscribe(Long userId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        sseEmitterStore.save(userId, emitter);
+
+        emitter.onCompletion(() -> sseEmitterStore.remove(userId, emitter));
+        emitter.onTimeout(() -> sseEmitterStore.remove(userId, emitter));
+        emitter.onError(e -> sseEmitterStore.remove(userId, emitter));
+
+        // 연결 직후 더미 이벤트를 보내 프록시/브라우저가 연결을 바로 끊지 않도록 한다.
+        sendEvent(emitter, SseEmitter.event().name("connect").data("connected"));
+
+        return emitter;
+    }
+
+    // 구독 중인 Emitter가 없으면(구독 중이 아니면) 조용히 스킵한다.
+    private void pushToSubscribers(Long userId, NotificationResponse response) {
+        for (SseEmitter emitter : sseEmitterStore.findByUserId(userId)) {
+            sendEvent(emitter, SseEmitter.event().name("notification").data(response));
+        }
+    }
+
+    // 유휴 상태로 프록시에 의해 연결이 끊기지 않도록 데이터 없는 코멘트만 주기적으로 보낸다.
+    // 이 이벤트는 FE의 이벤트 리스너(onmessage 등)에 아무런 영향을 주지 않는다.
+    @Scheduled(fixedRate = HEARTBEAT_INTERVAL_MILLIS)
+    public void sendHeartbeat() {
+        for (SseEmitter emitter : sseEmitterStore.findAll()) {
+            sendEvent(emitter, SseEmitter.event().comment("heartbeat"));
+        }
+    }
+
+    // 하나의 Emitter 전송 실패가 나머지 Emitter 처리를 막지 않도록 예외를 여기서 흡수한다.
+    private void sendEvent(SseEmitter emitter, SseEmitter.SseEventBuilder event) {
+        try {
+            emitter.send(event);
+        } catch (IOException e) {
+            log.info("SSE 전송 실패로 연결을 종료합니다.", e);
+            emitter.completeWithError(e);
+        }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.notification.store;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -11,6 +12,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 // 유저별 SSE Emitter를 인메모리로 관리한다. 유저가 여러 탭/기기에서 동시 구독할 수 있어 유저당 리스트로 보관한다.
 // TODO: 서버 인스턴스가 여러 대로 늘어나면 이 저장소는 인스턴스 로컬이라 다른 인스턴스에 연결된 유저에게는
 // push할 수 없다. 인스턴스 간 브로드캐스트가 필요해지면 Redis Pub/Sub 등으로 교체해야 한다.
+@Slf4j
 @Repository
 public class SseEmitterStore {
 
@@ -18,6 +20,7 @@ public class SseEmitterStore {
 
     public void save(Long userId, SseEmitter emitter) {
         emitters.computeIfAbsent(userId, key -> new CopyOnWriteArrayList<>()).add(emitter);
+        log.info("[SSE] Emitter 등록 userId={}, 현재 연결 수={}", userId, emitters.get(userId).size());
     }
 
     public void remove(Long userId, SseEmitter emitter) {
@@ -25,6 +28,7 @@ public class SseEmitterStore {
             list.remove(emitter);
             return list.isEmpty() ? null : list;
         });
+        log.info("[SSE] Emitter 제거 userId={}, 남은 연결 수={}", userId, findByUserId(userId).size());
     }
 
     public List<SseEmitter> findByUserId(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
@@ -1,0 +1,40 @@
+package com.pokade.domain.notification.store;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+// 유저별 SSE Emitter를 인메모리로 관리한다. 유저가 여러 탭/기기에서 동시 구독할 수 있어 유저당 리스트로 보관한다.
+// TODO: 서버 인스턴스가 여러 대로 늘어나면 이 저장소는 인스턴스 로컬이라 다른 인스턴스에 연결된 유저에게는
+// push할 수 없다. 인스턴스 간 브로드캐스트가 필요해지면 Redis Pub/Sub 등으로 교체해야 한다.
+@Repository
+public class SseEmitterStore {
+
+    private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long userId, SseEmitter emitter) {
+        emitters.computeIfAbsent(userId, key -> new CopyOnWriteArrayList<>()).add(emitter);
+    }
+
+    public void remove(Long userId, SseEmitter emitter) {
+        emitters.computeIfPresent(userId, (key, list) -> {
+            list.remove(emitter);
+            return list.isEmpty() ? null : list;
+        });
+    }
+
+    public List<SseEmitter> findByUserId(Long userId) {
+        return emitters.getOrDefault(userId, List.of());
+    }
+
+    // 하트비트 등 전체 구독자에게 보낼 때 사용 - 현재 등록된 Emitter들의 스냅샷을 반환한다.
+    public List<SseEmitter> findAll() {
+        return emitters.values().stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -740,6 +741,74 @@ class CardServiceTest {
         CardFacetsResponse result = cardService.getFacets();
 
         assertThat(result.rarities()).containsExactlyInAnyOrder("Common", "프로모");
+    }
+
+    @Test
+    @DisplayName("t53 series가 있는 expansion은 series 값이 그대로 Facet에 노출된다")
+    void t53() {
+        Expansion expansion = Expansion.builder().id("sv3pt5").name("151")
+                .series("Scarlet & Violet").syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(expansion));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions().get(0).series()).isEqualTo("Scarlet & Violet");
+    }
+
+    @Test
+    @DisplayName("t54 series가 null인 expansion은 \"기타\" 그룹으로 노출된다")
+    void t54() {
+        Expansion expansion = Expansion.builder().id("legacy1").name("Legacy")
+                .series(null).syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(expansion));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions().get(0).series()).isEqualTo("기타");
+    }
+
+    @Test
+    @DisplayName("t55 series 그룹은 그룹 내 최신 release_date 기준 내림차순으로, 그룹 내에서는 이름순으로 정렬된다")
+    void t55() {
+        // Old Series의 최신 release_date(2016)보다 New Series의 release_date(2020)가 더 최신이므로
+        // New Series 그룹 전체가 앞에 와야 한다.
+        Expansion oldSeriesNewer = Expansion.builder().id("old2").name("Old B")
+                .series("Old Series").releaseDate(LocalDate.of(2016, 1, 1)).syncedAt(LocalDateTime.now()).build();
+        Expansion oldSeriesOlder = Expansion.builder().id("old1").name("Old A")
+                .series("Old Series").releaseDate(LocalDate.of(2015, 1, 1)).syncedAt(LocalDateTime.now()).build();
+        Expansion newSeries = Expansion.builder().id("new1").name("New A")
+                .series("New Series").releaseDate(LocalDate.of(2020, 1, 1)).syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(oldSeriesNewer, oldSeriesOlder, newSeries));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions())
+                .extracting(CardFacetsResponse.ExpansionFacet::name)
+                .containsExactly("New A", "Old A", "Old B");
+    }
+
+    @Test
+    @DisplayName("t56 release_date가 전부 null인 series는 가장 오래된 것으로 취급돼 맨 뒤로 정렬된다")
+    void t56() {
+        Expansion noDateSeries = Expansion.builder().id("nodate1").name("No Date")
+                .series("Unknown Timing").syncedAt(LocalDateTime.now()).build();
+        Expansion datedSeries = Expansion.builder().id("dated1").name("Dated")
+                .series("Dated Series").releaseDate(LocalDate.of(1999, 1, 1)).syncedAt(LocalDateTime.now()).build();
+        given(cardRepository.findDistinctTypes()).willReturn(List.of());
+        given(cardRepository.findDistinctRarityCodes()).willReturn(List.of());
+        given(expansionRepository.findAll()).willReturn(List.of(noDateSeries, datedSeries));
+
+        CardFacetsResponse result = cardService.getFacets();
+
+        assertThat(result.expansions())
+                .extracting(CardFacetsResponse.ExpansionFacet::name)
+                .containsExactly("Dated", "No Date");
     }
 
     private CardRepository.CardRarityView rarityView(String rarityCode, String rarity) {

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -14,6 +14,7 @@ import com.pokade.global.security.oauth.CustomOAuth2UserService;
 import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
 import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
@@ -25,19 +26,24 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(NotificationController.class)
@@ -122,5 +128,33 @@ class NotificationControllerTest {
         mockMvc.perform(patch("/api/notifications/1/read").with(userId(100L)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("NOTIFICATION_ALREADY_READ"));
+    }
+
+    @Test
+    void SSE_구독_요청은_비동기로_시작된다() throws Exception {
+        given(notificationService.subscribe(100L)).willReturn(new SseEmitter());
+
+        mockMvc.perform(get("/api/notifications/subscribe").with(userId(100L)))
+                .andExpect(request().asyncStarted())
+                .andExpect(status().isOk());
+
+        then(notificationService).should().subscribe(100L);
+    }
+
+    @Test
+    void 인증되지_않은_SSE_구독_요청은_401을_반환한다() throws Exception {
+        // 이 테스트 슬라이스의 jwtAuthenticationEntryPoint는 별도 스텁이 없으면 응답 상태를 건드리지 않아
+        // 기본값(200)이 나온다. anyRequest().authenticated() 규칙이 실제로 이 경로를 막는지 검증하려면
+        // 진입점이 401을 쓰도록 이 테스트에서만 동작을 지정한다.
+        willAnswer(invocation -> {
+            HttpServletResponse response = invocation.getArgument(1);
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }).given(jwtAuthenticationEntryPoint).commence(any(), any(), any());
+
+        mockMvc.perform(get("/api/notifications/subscribe"))
+                .andExpect(status().isUnauthorized());
+
+        then(notificationService).should(never()).subscribe(any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
 import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -15,19 +16,28 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
 
     @Mock NotificationRepository notificationRepository;
+    @Mock SseEmitterStore sseEmitterStore;
     @InjectMocks NotificationService notificationService;
 
     private Notification notification(Long userId) {
@@ -147,5 +157,87 @@ class NotificationServiceTest {
         assertThat(captor.getValue().getMessage())
                 .contains("100,000")
                 .contains("구매");
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: 구독 중인 Emitter가 있으면 notification 이벤트를 전송한다")
+    void createPriceTargetNotification_pushes_to_subscriber() throws Exception {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
+        SseEmitter emitter = mock(SseEmitter.class);
+        given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        then(emitter).should().send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: 구독 중인 Emitter가 없으면 예외 없이 조용히 스킵된다")
+    void createPriceTargetNotification_no_subscriber_noop() {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
+        given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
+
+        assertThatCode(() -> notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("목표가 도달 알림 생성: 전송 중 IOException이 발생하면 Emitter를 종료 처리한다")
+    void createPriceTargetNotification_send_fails_completesWithError() throws Exception {
+        Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
+        SseEmitter emitter = mock(SseEmitter.class);
+        doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        then(emitter).should().completeWithError(any(IOException.class));
+    }
+
+    // ===== SSE 구독 =====
+    @Test
+    @DisplayName("subscribe: Emitter를 생성해 저장소에 등록하고 반환한다")
+    void subscribe_registers_emitter() {
+        SseEmitter emitter = notificationService.subscribe(1L);
+
+        assertThat(emitter).isNotNull();
+        then(sseEmitterStore).should().save(eq(1L), eq(emitter));
+    }
+
+    // ===== 하트비트 =====
+    @Test
+    @DisplayName("sendHeartbeat: 등록된 모든 Emitter에 comment 이벤트를 보낸다")
+    void sendHeartbeat_sends_to_every_emitter() throws Exception {
+        SseEmitter first = mock(SseEmitter.class);
+        SseEmitter second = mock(SseEmitter.class);
+        given(sseEmitterStore.findAll()).willReturn(List.of(first, second));
+
+        notificationService.sendHeartbeat();
+
+        then(first).should().send(any(SseEmitter.SseEventBuilder.class));
+        then(second).should().send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    @DisplayName("sendHeartbeat: 하나의 Emitter 전송이 실패해도 나머지 Emitter는 정상 전송된다")
+    void sendHeartbeat_one_failure_does_not_block_others() throws Exception {
+        SseEmitter failing = mock(SseEmitter.class);
+        SseEmitter healthy = mock(SseEmitter.class);
+        doThrow(new IOException("broken pipe")).when(failing).send(any(SseEmitter.SseEventBuilder.class));
+        given(sseEmitterStore.findAll()).willReturn(List.of(failing, healthy));
+
+        assertThatCode(() -> notificationService.sendHeartbeat()).doesNotThrowAnyException();
+
+        then(failing).should().completeWithError(any(IOException.class));
+        then(healthy).should().send(any(SseEmitter.SseEventBuilder.class));
+        then(healthy).should(never()).completeWithError(any());
+    }
+
+    @Test
+    @DisplayName("sendHeartbeat: 등록된 Emitter가 없으면 예외 없이 조용히 끝난다")
+    void sendHeartbeat_no_subscribers_noop() {
+        given(sseEmitterStore.findAll()).willReturn(List.of());
+
+        assertThatCode(() -> notificationService.sendHeartbeat()).doesNotThrowAnyException();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
@@ -1,0 +1,66 @@
+package com.pokade.domain.notification.service;
+
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.store.SseEmitterStore;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+
+// NotificationServiceTest는 SseEmitterStore를 mock으로 대체해 sendEvent() 호출 여부만 검증한다.
+// 이 클래스는 실제 서버(로컬 curl 검증, #230 PR 리뷰 대응)에서 일어나는 순서 그대로 -
+// subscribe()로 등록한 실제 Emitter가 실제 SseEmitterStore에 저장된 뒤, createPriceTargetNotification()이
+// "같은 userId 키"로 그 Emitter를 정확히 찾아 예외 없이 전송하는지를 mock 없이(NotificationRepository만 제외)
+// 확인한다. 실제 TCP 소켓이 없어 전송된 바이트 자체는 검증할 수 없지만, subscribe→push 사이의 실제 객체
+// 배선(같은 store, 같은 userId 키)이 올바른지는 이 테스트가 유닛 테스트보다 더 신뢰성 있게 보여준다.
+@ExtendWith(MockitoExtension.class)
+class NotificationSseFlowTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private final SseEmitterStore sseEmitterStore = new SseEmitterStore();
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("subscribe 후 같은 유저에게 createPriceTargetNotification이 발생하면 연결이 끊기지 않고 유지된다")
+    void subscribe_then_notify_keeps_connection_alive() {
+        notificationService = new NotificationService(notificationRepository, sseEmitterStore);
+        Long userId = 1L;
+        Watchlist watchlist = Watchlist.builder().userId(userId).cardId(10L).targetBuyPrice(100000).build();
+
+        SseEmitter emitter = notificationService.subscribe(userId);
+        assertThat(sseEmitterStore.findByUserId(userId)).containsExactly(emitter);
+
+        assertThatCode(() ->
+                notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000))
+                .doesNotThrowAnyException();
+
+        // 전송이 실패했다면 sendEvent()의 completeWithError -> onError 콜백으로 store에서 제거됐을 것이다.
+        // 여전히 남아있다는 것은 실제 Emitter 객체에 대한 send()가 예외 없이 끝났다는 뜻이다.
+        assertThat(sseEmitterStore.findByUserId(userId)).containsExactly(emitter);
+    }
+
+    @Test
+    @DisplayName("다른 유저를 구독 중인 Emitter는 대상 유저에게 온 알림의 영향을 받지 않는다")
+    void notification_for_one_user_does_not_touch_another_subscriber() {
+        notificationService = new NotificationService(notificationRepository, sseEmitterStore);
+        Long targetUserId = 1L;
+        Long otherUserId = 2L;
+        Watchlist watchlist = Watchlist.builder().userId(targetUserId).cardId(10L).targetBuyPrice(100000).build();
+
+        SseEmitter otherEmitter = notificationService.subscribe(otherUserId);
+        notificationService.subscribe(targetUserId);
+
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+
+        assertThat(sseEmitterStore.findByUserId(otherUserId)).containsExactly(otherEmitter);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/store/SseEmitterStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/store/SseEmitterStoreTest.java
@@ -1,0 +1,91 @@
+package com.pokade.domain.notification.store;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SseEmitterStoreTest {
+
+    private final SseEmitterStore store = new SseEmitterStore();
+
+    @Test
+    @DisplayName("save: 등록한 Emitter를 findByUserId로 조회할 수 있다")
+    void save_and_find() {
+        SseEmitter emitter = new SseEmitter();
+
+        store.save(1L, emitter);
+
+        assertThat(store.findByUserId(1L)).containsExactly(emitter);
+    }
+
+    @Test
+    @DisplayName("findByUserId: 등록된 Emitter가 없으면 빈 리스트를 반환한다")
+    void find_empty() {
+        assertThat(store.findByUserId(999L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("save: 같은 유저가 여러 번(다른 탭/기기) 구독하면 모두 유지된다")
+    void save_multiple_for_same_user() {
+        SseEmitter first = new SseEmitter();
+        SseEmitter second = new SseEmitter();
+
+        store.save(1L, first);
+        store.save(1L, second);
+
+        assertThat(store.findByUserId(1L)).containsExactlyInAnyOrder(first, second);
+    }
+
+    @Test
+    @DisplayName("remove: 여러 Emitter 중 하나만 제거해도 나머지는 유지된다")
+    void remove_one_keeps_others() {
+        SseEmitter first = new SseEmitter();
+        SseEmitter second = new SseEmitter();
+        store.save(1L, first);
+        store.save(1L, second);
+
+        store.remove(1L, first);
+
+        assertThat(store.findByUserId(1L)).containsExactly(second);
+    }
+
+    @Test
+    @DisplayName("remove: 마지막 Emitter까지 제거하면 findByUserId는 빈 리스트를 반환한다")
+    void remove_last_leaves_empty() {
+        SseEmitter emitter = new SseEmitter();
+        store.save(1L, emitter);
+
+        store.remove(1L, emitter);
+
+        assertThat(store.findByUserId(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("remove: 등록되지 않은 Emitter를 제거해도 예외 없이 무시된다")
+    void remove_unknown_is_noop() {
+        store.remove(1L, new SseEmitter());
+
+        assertThat(store.findByUserId(1L)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAll: 등록된 유저가 없으면 빈 리스트를 반환한다")
+    void findAll_empty() {
+        assertThat(store.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findAll: 여러 유저에 등록된 Emitter를 모두 반환한다")
+    void findAll_returns_every_user_emitter() {
+        SseEmitter userOneFirst = new SseEmitter();
+        SseEmitter userOneSecond = new SseEmitter();
+        SseEmitter userTwo = new SseEmitter();
+        store.save(1L, userOneFirst);
+        store.save(1L, userOneSecond);
+        store.save(2L, userTwo);
+
+        assertThat(store.findAll()).containsExactlyInAnyOrder(userOneFirst, userOneSecond, userTwo);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -102,7 +103,7 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
         given(priceTradeStatsRepository.findPriceRangesByCardIds(any(), any(), any())).willReturn(List.of(range));
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any())).willReturn(List.of(range));
 
-        NotificationService notificationService = new NotificationService(notificationRepository);
+        NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore());
         WatchlistService watchlistService = new WatchlistService(watchlistRepository,
                 mock(PriceService.class), cardRepository, priceTradeStatsRepository);
         WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
@@ -37,7 +37,8 @@ import static org.mockito.BDDMockito.given;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({WatchlistTargetPriceNoticeService.class, WatchlistTargetPriceNoticeProcessor.class,
-        WatchlistService.class, com.pokade.domain.notification.service.NotificationService.class})
+        WatchlistService.class, com.pokade.domain.notification.service.NotificationService.class,
+        com.pokade.domain.notification.store.SseEmitterStore.class})
 class WatchlistTargetPriceNoticeTransactionIsolationTest {
 
     @Autowired


### PR DESCRIPTION
## 📌 관련 이슈
- #230 

## ✨ 작업 내용
- 알림 실시간 푸시를 위한 SSE 구독 엔드포인트 신규 구현 (GET /api/notifications/subscribe)
- 유저별 Emitter를 관리하는 인메모리 저장소(SseEmitterStore) 구현, 연결 종료 시 자동 정리
- 알림 생성 시 구독 중인 클라이언트에 즉시 이벤트 푸시 (구독자 없으면 조용히 스킵)
- 리버스 프록시 idle timeout으로 인한 연결 조기 종료를 막기 위해 15초 주기 하트비트 추가
- 인증: 브라우저 EventSource가 커스텀 헤더를 지원하지 않는 제약으로, 
   BE는 기존 Bearer 토큰 인증을 그대로 유지하고 FE에서 fetch 기반 라이브러리로 헤더 인증 처리하는 방향으로 역할 분리
- 다중 서버 인스턴스 간 브로드캐스트는 이번 범위 밖으로 TODO 명시

- `CardFacetsResponse.ExpansionFacet`에 `series` 필드 추가
- null series는 "기타"로 고정 라벨 처리 (아코디언 그룹 헤더 용도라 빈 문자열 대신 사람이 읽을 수 있는 값 사용)
- 시리즈 그룹은 그룹 내 최신 `release_date` 기준 내림차순 정렬, 그룹 내부는 기존처럼 이름순
- FE(#110)에서 이 응답으로 시리즈별 아코디언 필터 UI 구현 예정

## 📸 스크린샷 / 테스트 결과
- notification.*, watchlist.* 도메인 테스트 전체 통과
- 하트비트 추가 전/후 전체 스위트 비교: 테스트 수 643→648(신규 5건)
- 하트비트 부분 실패 격리 테스트로 검증(정상 Emitter가 실패한 Emitter에 영향받지 않음)

## 🔍 리뷰 포인트
- 인메모리 저장소라 다중 서버 환경에선 브로드캐스트가 안 되지만, 현재 단일 EC2 구조라 문제없음 
  (스케일아웃 시 Redis Pub/Sub 등 필요, TODO 명시)
- 연결 끊김/실시간 알림 배선은 curl 및 통합 테스트로 실제 검증 완료
- 카드 필터 변경분(`CardFacetsResponse`, `CardService.buildExpansionFacets()`)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?