### PR TITLE
[Feature] #233 프로필 조회 API - 공개 프로필 / 내 프로필 상세

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -37,6 +37,8 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
 
     List<Listing> findBySellerIdAndStatus(Long sellerId, ListingStatus status);
 
+    long countBySellerIdAndStatus(Long sellerId, ListingStatus status);
+
     boolean existsBySellerIdAndCardIdAndVariantIdAndStatus(
             Long sellerId, Long cardId, Long variantId, ListingStatus status);
 

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingCounter.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingCounter.java
@@ -1,0 +1,19 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.global.port.ListingCountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ListingCounter implements ListingCountPort {
+
+    private final ListingRepository listingRepository;
+
+    @Override
+    public long countActiveListings(Long sellerId) {
+        return listingRepository.countBySellerIdAndStatus(sellerId, ListingStatus.ACTIVE);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
@@ -2,14 +2,13 @@ package com.pokade.domain.trade.repository;
 
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface TradeRepository extends JpaRepository<Trade, Long> {
 
@@ -32,4 +31,10 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status IN :statuses")
     List<Trade> findByParticipantIdAndStatusIn(@Param("userId") Long userId,
                                                 @Param("statuses") List<TradeStatus> statuses);
+
+    // 공개 프로필용: 확정된 거래 수 ( 구매자, 판매자 양쪽 합산)
+    @Query("SELECT COUNT(t) FROM Trade t JOIN t.listing l "
+            + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status = :status")
+    long countByParticipantIdAndStatus(@Param("userId") Long userId,
+                                       @Param("status") TradeStatus status);
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeCounter.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeCounter.java
@@ -1,0 +1,20 @@
+package com.pokade.domain.trade.service;
+
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.repository.TradeRepository;
+import com.pokade.global.port.TradeCountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TradeCounter implements TradeCountPort {
+
+    private final TradeRepository tradeRepository;
+
+    // 확정된 거래 수를 센다
+    @Override
+    public long countCompletedTrades(Long userId) {
+        return tradeRepository.countByParticipantIdAndStatus(userId, TradeStatus.COMPLETED);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -3,7 +3,10 @@ package com.pokade.domain.user.controller;
 import com.pokade.domain.user.dto.request.NicknameUpdateRequest;
 import com.pokade.domain.user.dto.request.PasswordUpdateRequest;
 import com.pokade.domain.user.dto.request.WithdrawalRequest;
+import com.pokade.domain.user.dto.response.MyProfileResponse;
+import com.pokade.domain.user.dto.response.PublicProfileResponse;
 import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.service.ProfileService;
 import com.pokade.domain.user.service.UserService;
 import com.pokade.domain.user.service.WithdrawalService;
 import com.pokade.global.response.ApiResponse;
@@ -19,10 +22,21 @@ public class UserController {
 
     private final UserService userService;
     private final WithdrawalService withdrawalService;
+    private final ProfileService profileService;
 
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
         return ApiResponse.ok("내 정보 조회 성공", userService.getMyInfo(userId));
+    }
+
+    @GetMapping("/me/profile")
+    public ApiResponse<MyProfileResponse> getMyProfile(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok("내 프로필 조회 성공", profileService.getMyProfile(userId));
+    }
+
+    @GetMapping("/{userId}")
+    public ApiResponse<PublicProfileResponse> getPublicProfile(@PathVariable Long userId) {
+        return ApiResponse.ok("공개 프로필 조회 성공", profileService.getPublicProfile(userId));
     }
 
     @PatchMapping("/me")

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/MyProfileResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/MyProfileResponse.java
@@ -1,0 +1,27 @@
+package com.pokade.domain.user.dto.response;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record MyProfileResponse(
+        String email,
+        String phoneNumber,
+        Provider provider,
+        boolean socialLinked,
+        LocalDateTime joinedAt,
+        LocalDate birthDate
+) {
+    public static MyProfileResponse from(User user) {
+        return new MyProfileResponse(
+                user.getEmail(),
+                user.getPhoneNumber(),
+                user.getProvider(),
+                !user.isLocalUser(),
+                user.getCreated_At(),
+                user.getBirthDate()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
@@ -1,0 +1,25 @@
+package com.pokade.domain.user.dto.response;
+
+import com.pokade.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record PublicProfileResponse(
+        Long userId,
+        String nickname,
+        String profileImageUrl,
+        LocalDateTime joinedAt,
+        long completedTradeCount,
+        long activeListingCount
+) {
+    public static PublicProfileResponse of(User user, long completedTradeCount, long activeListingCount) {
+        return new PublicProfileResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.getCreated_At(),
+                completedTradeCount,
+                activeListingCount
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/ProfileService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/ProfileService.java
@@ -1,0 +1,45 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.dto.response.MyProfileResponse;
+import com.pokade.domain.user.dto.response.PublicProfileResponse;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.ListingCountPort;
+import com.pokade.global.port.TradeCountPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+    private final TradeCountPort tradeCountPort;
+    private final ListingCountPort listingCountPort;
+
+    // 공개 프로필을 조회한다 ( 확정 탈퇴 계정은 없는 것을 전제로 한다)
+    public PublicProfileResponse getPublicProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .filter(u -> u.getStatus() != UserStatus.DELETED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return PublicProfileResponse.of(
+                user,
+                tradeCountPort.countCompletedTrades(userId),
+                listingCountPort.countActiveListings(userId)
+        );
+    }
+
+    // 본인 상세 프로필을 조회한다
+
+    public MyProfileResponse getMyProfile(Long userId) {
+        return userRepository.findById(userId)
+                .map(MyProfileResponse::from)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/chat/query").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/chat/quick-questions").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
-                        .requestMatchers(RegexRequestMatcher.regexMatcher(HttpMethod.GET,"/api/users/\\d+")).permitAll()
+                        .requestMatchers(RegexRequestMatcher.regexMatcher(HttpMethod.GET, "/api/users/\\d+(\\?.*)?")).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.RegexRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -76,6 +77,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/chat/query").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/chat/quick-questions").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
+                        .requestMatchers(RegexRequestMatcher.regexMatcher(HttpMethod.GET,"/api/users/\\d+")).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/Pokade/src/main/java/com/pokade/global/port/ListingCountPort.java
+++ b/Pokade/src/main/java/com/pokade/global/port/ListingCountPort.java
@@ -1,0 +1,5 @@
+package com.pokade.global.port;
+
+public interface ListingCountPort {
+    long countActiveListings(Long sellerId);
+}

--- a/Pokade/src/main/java/com/pokade/global/port/TradeCountPort.java
+++ b/Pokade/src/main/java/com/pokade/global/port/TradeCountPort.java
@@ -1,0 +1,5 @@
+package com.pokade.global.port;
+
+public interface TradeCountPort {
+    long countCompletedTrades(Long userId);
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -1,9 +1,11 @@
 package com.pokade.domain.user.controller;
 
+import com.pokade.domain.user.dto.response.PublicProfileResponse;
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.service.ProfileService;
 import com.pokade.domain.user.service.UserService;
 import com.pokade.domain.user.service.WithdrawalService;
 import com.pokade.global.config.SecurityConfig;
@@ -32,7 +34,10 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -56,6 +61,8 @@ class UserControllerTest {
     private TokenBlacklistStore tokenBlacklistStore;                 // JwtAuthenticationFilter가 요구
     @MockitoBean
     private WithdrawalService withdrawalService;                     // UserController가 요구
+    @MockitoBean
+    private ProfileService profileService;                           // UserController가 요구
     @MockitoBean
     private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;      // SecurityConfig가 요구
     @MockitoBean
@@ -100,5 +107,39 @@ class UserControllerTest {
         mockMvc.perform(get("/api/users/me").with(userId(1L)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
+    }
+
+    // ===== 인가 회귀: 공개 프로필을 열면서 /me 까지 열리지 않았는지 =====
+
+    @Test
+    @DisplayName("인가: 토큰 없이 GET /api/users/me 는 컨트롤러까지 도달하지 못한다")
+    void getMyInfo_withoutToken_blocked() throws Exception {
+        mockMvc.perform(get("/api/users/me"));
+
+        then(userService).should(never()).getMyInfo(any());
+    }
+
+    @Test
+    @DisplayName("인가: 공개 프로필은 토큰 없이도 조회된다")
+    void getPublicProfile_withoutToken_ok() throws Exception {
+        given(profileService.getPublicProfile(1L)).willReturn(
+                new PublicProfileResponse(1L, "지우", "https://img/x.png", null, 3L, 2L));
+
+        mockMvc.perform(get("/api/users/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(1L))
+                .andExpect(jsonPath("$.data.nickname").value("지우"))
+                .andExpect(jsonPath("$.data.completedTradeCount").value(3))
+                .andExpect(jsonPath("$.data.activeListingCount").value(2));
+    }
+
+    @Test
+    @DisplayName("인가: 공개 프로필에 쿼리스트링이 붙어도 인증 없이 조회된다")
+    void getPublicProfile_withQueryString_ok() throws Exception {
+        given(profileService.getPublicProfile(1L)).willReturn(
+                new PublicProfileResponse(1L, "지우", null, null, 3L, 2L));
+
+        mockMvc.perform(get("/api/users/1?ref=search"))
+                .andExpect(status().isOk());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.user.controller;
 
+import com.pokade.domain.user.dto.response.MyProfileResponse;
 import com.pokade.domain.user.dto.response.PublicProfileResponse;
 import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.entity.type.Provider;
@@ -31,6 +32,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
@@ -45,7 +48,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(UserController.class)
 @AutoConfigureMockMvc
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class}) // 401 계약을 검증하려면 실물 엔트리포인트가 필요
 class UserControllerTest {
 
     @Autowired
@@ -55,8 +58,6 @@ class UserControllerTest {
     private UserService userService;
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;                 // 실제 JwtAuthenticationFilter가 요구
-    @MockitoBean
-    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint; // SecurityConfig가 요구
     @MockitoBean
     private TokenBlacklistStore tokenBlacklistStore;                 // JwtAuthenticationFilter가 요구
     @MockitoBean
@@ -109,12 +110,33 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"));
     }
 
+    @Test
+    @DisplayName("인증된 사용자가 내 프로필 상세를 조회하면 200과 상세 필드를 반환한다")
+    void getMyProfile_success() throws Exception {
+        MyProfileResponse res = new MyProfileResponse(
+                "user@pokade.com", "010-1234-5678", Provider.GOOGLE, true,
+                LocalDateTime.of(2026, 1, 2, 3, 4), LocalDate.of(1998, 7, 15));
+        given(profileService.getMyProfile(1L)).willReturn(res);
+
+        mockMvc.perform(get("/api/users/me/profile").with(userId(1L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.email").value("user@pokade.com"))
+                .andExpect(jsonPath("$.data.phoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.data.provider").value("GOOGLE"))
+                .andExpect(jsonPath("$.data.socialLinked").value(true))
+                .andExpect(jsonPath("$.data.birthDate").value("1998-07-15"));
+
+        then(profileService).should().getMyProfile(1L);
+    }
+
     // ===== 인가 회귀: 공개 프로필을 열면서 /me 까지 열리지 않았는지 =====
 
     @Test
-    @DisplayName("인가: 토큰 없이 GET /api/users/me 는 컨트롤러까지 도달하지 못한다")
+    @DisplayName("인가: 토큰 없이 GET /api/users/me 는 401이고 컨트롤러까지 도달하지 못한다")
     void getMyInfo_withoutToken_blocked() throws Exception {
-        mockMvc.perform(get("/api/users/me"));
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
 
         then(userService).should(never()).getMyInfo(any());
     }


### PR DESCRIPTION
## 📌 관련 이슈
- #233

## ✨ 작업 내용
- `GET /api/users/{userId}` 공개 프로필 조회(비로그인 허용) — 닉네임, 프로필 이미지, 가입일, 확정 거래 수, 판매 중 매물 수
- `GET /api/users/me/profile` 내 프로필 상세 조회(인증 필수) — 이메일, 연락처, 가입 경로, 소셜 연동 여부
- 거래 수는 `COMPLETED` 상태만 구매·판매 합산. 진행 중·취소 건까지 세면 신뢰 지표가 부풀어 공개 프로필의 목적과 어긋남
- 확정 탈퇴(`DELETED`)만 404, 유예 중(`WITHDRAWAL_PENDING`)은 정상 노출하고 탈퇴 예정 여부를 응답에 넣지 않음. 유예 기간에는 매물·거래가 아직 살아있어 판매자 화면이 깨지면 안 되고, 탈퇴 의사는 제3자에게 노출될 정보가 아님
- cross-domain 참조는 `global/port`의 `TradeCountPort`·`ListingCountPort`로만. user 도메인이 다른 도메인 Repository를 직접 주입하지 않는 기존 `UserAccessChecker` 구조를 그대로 따름
- 조회 로직은 `ProfileService`로 분리, `UserService`는 계정 변경 전용 유지
- FR-PROFILE-06(내 판매 중 매물)은 이미 `GET /api/listings/me`로 구현돼 있어 이번 범위에서 제외. 명세 경로(`/api/users/me/listings`)와 달라 명세 정정 필요

## 📸 스크린샷 / 테스트 결과
- 전체 테스트 673건 실행, `ProfileServiceTest` 7건 / `UserControllerTest` 5건 모두 통과
- 실패 36건은 develop에서도 동일하게 실패하는 기존 건이며, 이 PR로 새로 깨진 테스트는 없음(develop을 별도 worktree에서 돌려 실패 집합이 완전히 동일함을 확인)
  - 원인은 세 갈래: Testcontainers 베이스(`AbstractIntegrationTest`) 미상속으로 DB가 없어 컨텍스트 실패 / 슬라이스 테스트 빈 누락 / `TradeRepositoryTest`의 거래 상태 전이 위반
  - 담당 도메인이 달라 별도 이슈로 공유 예정

## 🔍 리뷰 포인트
- **SecurityConfig 인가 규칙**: `GET /api/users/*` 로 열면 `*`가 세그먼트를 통째로 먹어 `GET /api/users/me`까지 함께 공개됩니다. 이를 막으려고 `RegexRequestMatcher`로 숫자 id(`/api/users/\d+`)만 허용했습니다. 규칙 선언 순서에 의존하지 않는 방식이며, 회귀 테스트 3건으로 고정했습니다
- **port를 2개로 나눈 이유**: 하나로 묶으면 구현체를 trade 도메인에 몰아넣게 되어 "판매 중 매물 수를 trade가 세는" 구조가 됩니다
- **port 시그니처에 상태 enum을 노출하지 않은 이유**: `countTrades(userId, status)` 형태였다면 `ProfileService`가 `TradeStatus`를 알아야 해서 경계를 그은 의미가 사라집니다
- `GET /users/me`와 필드가 일부 겹치지만 엔드포인트를 분리했습니다. `/users/me`는 프론트 세션 복원마다 호출되는 경량 API라 연락처·생년월일 같은 PII를 상시 실어보낼 이유가 없습니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 내 프로필 조회 기능을 추가했습니다. 이메일, 전화번호, 가입일, 생년월일 및 소셜 연동 정보를 확인할 수 있습니다.
  * 공개 프로필 조회 기능을 추가했습니다. 닉네임, 프로필 이미지, 가입일, 완료 거래 수와 활성 매물 수를 제공합니다.
  * 공개 프로필은 로그인 없이 조회할 수 있습니다.

* **테스트**
  * 프로필 조회 및 인증 접근 제어에 대한 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->