### PR TITLE
[Feature] #236 워치리스트 목표가 수정, 카드명 한글 표시, 카드 필터 캐싱

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -27,6 +27,7 @@ import com.pokade.global.web.PageableValidator;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.time.LocalDate;
 import java.util.Comparator;
@@ -183,7 +184,11 @@ public class CardService {
      * types/rarity_code는 원본이 다국어로 혼재돼 있어 리졸버 적용 후 표준명 기준으로 중복 제거한다
      * (예: 일본어 "草"와 영문 "Grass"가 함께 있으면 리졸버를 거쳐 "Grass" 하나로 합쳐짐).
      * 세트명은 아직 언어별 표준화가 없어 원본 그대로 반환한다.
+     *
+     * 동기화 완료를 알리는 이벤트/훅이 없어 캐시 무효화를 값 변경 시점에 걸 수 없으므로,
+     * TTL 1시간(CacheConfig의 "cardFacets" 캐시 설정) 기반으로 캐싱한다.
      */
+    @Cacheable(cacheNames = "cardFacets")
     @Transactional(readOnly = true)
     public CardFacetsResponse getFacets() {
         Set<String> types = new TreeSet<>(CardTypeEnResolver.resolve(cardRepository.findDistinctTypes()));

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.controller;
 
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
 import com.pokade.domain.watchlist.service.WatchlistService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,6 +37,15 @@ public class WatchlistController {
     @GetMapping
     public ApiResponse<List<WatchlistResponse>> getWatchlist(@AuthenticationPrincipal Long userId) {
         return ApiResponse.ok(watchlistService.getWatchlist(userId));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<WatchlistResponse> updateWatchlist(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody WatchlistUpdateRequest request
+    ) {
+        return ApiResponse.ok("목표가가 수정되었습니다.", watchlistService.updateWatchlist(userId, id, request));
     }
 
     @DeleteMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -12,6 +12,7 @@ public record WatchlistResponse(
         Long cardId,
         Long variantId,
         String cardName,
+        String cardNameKo,
         String setName,
         String imageUrl,
         Integer targetBuyPrice,
@@ -32,6 +33,7 @@ public record WatchlistResponse(
                 null,
                 null,
                 null,
+                null,
                 watchlist.getTargetBuyPrice(),
                 watchlist.getTargetSellPrice(),
                 watchlist.isNotified(),
@@ -44,13 +46,14 @@ public record WatchlistResponse(
 
 
     public static WatchlistResponse withPrice(
-            Watchlist watchlist, Card card, CardPriceSummaryResponse currentPrice,
+            Watchlist watchlist, Card card, String cardNameKo, CardPriceSummaryResponse currentPrice,
             BigDecimal changeRate, boolean targetReached) {
         return new WatchlistResponse(
                 watchlist.getId(),
                 watchlist.getCardId(),
                 watchlist.getVariantId(),
                 card != null ? card.getName() : null,
+                cardNameKo,
                 card != null ? card.getSetName() : null,
                 card != null ? resolveImageUrl(card) : null,
                 watchlist.getTargetBuyPrice(),

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.pokade.domain.watchlist.dto;
+
+import jakarta.validation.constraints.Positive;
+
+public record WatchlistUpdateRequest(
+        @Positive(message = "targetBuyPrice는 0보다 커야 합니다.")
+        Integer targetBuyPrice,
+
+        @Positive(message = "targetSellPrice는 0보다 커야 합니다.")
+        Integer targetSellPrice
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
@@ -7,6 +7,9 @@ public record WatchlistUpdateRequest(
         Integer targetBuyPrice,
 
         @Positive(message = "targetSellPrice는 0보다 커야 합니다.")
-        Integer targetSellPrice
+        Integer targetSellPrice,
+
+        // null/false 둘 다 "재알림 요청 없음"으로 취급 - Boolean.TRUE.equals()로 체크할 것(원시 boolean 언박싱 NPE 방지)
+        Boolean resendNotification
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "watchlist")
@@ -59,5 +60,17 @@ public class Watchlist {
 
     public void markAsNotified() {
         this.isNotified = true;
+    }
+
+    // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
+    // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
+    public void updateTargetPrices(Integer targetBuyPrice, Integer targetSellPrice) {
+        boolean changed = !Objects.equals(this.targetBuyPrice, targetBuyPrice)
+                || !Objects.equals(this.targetSellPrice, targetSellPrice);
+        this.targetBuyPrice = targetBuyPrice;
+        this.targetSellPrice = targetSellPrice;
+        if (changed) {
+            this.isNotified = false;
+        }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -62,15 +62,29 @@ public class Watchlist {
         this.isNotified = true;
     }
 
-    // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
-    // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
+    // updateTargetPrices()의 "가격이 실제로 바뀐 경우"에만 리셋하는 조건부 로직과 달리,
+    // 조건 없이 무조건 리셋한다 - 내부적으로 같은 resetNotification()을 공유
+    public void requestNotificationAgain() {
+        resetNotification();
+    }
+
+    private void resetNotification() {
+        this.isNotified = false;
+    }
+
+    // null로 온 필드는 "값을 지운다"가 아니라 "기존 값 유지"로 해석한다 - 부분 업데이트를 지원하기
+    // 위함. 두 필드를 한꺼번에 지우는 기능은 없음(전체 삭제는 DELETE로만 가능).
     public void updateTargetPrices(Integer targetBuyPrice, Integer targetSellPrice) {
-        boolean changed = !Objects.equals(this.targetBuyPrice, targetBuyPrice)
-                || !Objects.equals(this.targetSellPrice, targetSellPrice);
-        this.targetBuyPrice = targetBuyPrice;
-        this.targetSellPrice = targetSellPrice;
+        Integer resolvedBuyPrice = targetBuyPrice != null ? targetBuyPrice : this.targetBuyPrice;
+        Integer resolvedSellPrice = targetSellPrice != null ? targetSellPrice : this.targetSellPrice;
+        // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
+        // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
+        boolean changed = !Objects.equals(this.targetBuyPrice, resolvedBuyPrice)
+                || !Objects.equals(this.targetSellPrice, resolvedSellPrice);
+        this.targetBuyPrice = resolvedBuyPrice;
+        this.targetSellPrice = resolvedSellPrice;
         if (changed) {
-            this.isNotified = false;
+            resetNotification();
         }
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -8,6 +8,7 @@ import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
@@ -37,9 +38,7 @@ public class WatchlistService {
 
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
-        if (request.targetBuyPrice() == null && request.targetSellPrice() == null) {
-            throw new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED);
-        }
+        validateAtLeastOneTargetPrice(request.targetBuyPrice(), request.targetSellPrice());
 
         // 동시 등록 요청에서 "중복 체크 + 20개 제한 체크 + 저장" 구간이 원자적이도록, 같은 유저의 요청만
         // 트랜잭션 종료까지 직렬화한다(다른 유저는 영향 없음).
@@ -120,6 +119,23 @@ public class WatchlistService {
             return targetSellPrice;
         }
         return null;
+    }
+
+    @Transactional
+    public WatchlistResponse updateWatchlist(Long userId, Long watchlistId, WatchlistUpdateRequest request) {
+        validateAtLeastOneTargetPrice(request.targetBuyPrice(), request.targetSellPrice());
+
+        Watchlist watchlist = watchlistRepository.findByIdAndUserId(watchlistId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
+
+        watchlist.updateTargetPrices(request.targetBuyPrice(), request.targetSellPrice());
+        return WatchlistResponse.of(watchlist);
+    }
+
+    private void validateAtLeastOneTargetPrice(Integer targetBuyPrice, Integer targetSellPrice) {
+        if (targetBuyPrice == null && targetSellPrice == null) {
+            throw new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED);
+        }
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -129,12 +129,19 @@ public class WatchlistService {
 
     @Transactional
     public WatchlistResponse updateWatchlist(Long userId, Long watchlistId, WatchlistUpdateRequest request) {
-        validateAtLeastOneTargetPrice(request.targetBuyPrice(), request.targetSellPrice());
+        boolean resend = Boolean.TRUE.equals(request.resendNotification());
+        // 재알림만 요청할 때는 가격을 안 보낼 수 있음 - 필수 검증에서 예외로 취급
+        if (!resend) {
+            validateAtLeastOneTargetPrice(request.targetBuyPrice(), request.targetSellPrice());
+        }
 
         Watchlist watchlist = watchlistRepository.findByIdAndUserId(watchlistId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
 
         watchlist.updateTargetPrices(request.targetBuyPrice(), request.targetSellPrice());
+        if (resend) {
+            watchlist.requestNotificationAgain();
+        }
         return WatchlistResponse.of(watchlist);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
@@ -35,6 +36,7 @@ public class WatchlistService {
     private final PriceService priceService;
     private final CardRepository cardRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
+    private final CardNameKoResolver cardNameKoResolver;
 
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
@@ -91,12 +93,16 @@ public class WatchlistService {
         Map<Long, BigDecimal> changeRateByCardId = priceService.getChangeRates(cardIds);
 
         return watchlists.stream()
-                .map(watchlist -> WatchlistResponse.withPrice(
-                        watchlist,
-                        cardById.get(watchlist.getCardId()),
-                        priceByCardId.get(watchlist.getCardId()),
-                        changeRateByCardId.get(watchlist.getCardId()),
-                        isTargetReached(watchlist, rangeByCardId.get(watchlist.getCardId()))))
+                .map(watchlist -> {
+                    Card card = cardById.get(watchlist.getCardId());
+                    return WatchlistResponse.withPrice(
+                            watchlist,
+                            card,
+                            card != null ? cardNameKoResolver.resolve(card) : null,
+                            priceByCardId.get(watchlist.getCardId()),
+                            changeRateByCardId.get(watchlist.getCardId()),
+                            isTargetReached(watchlist, rangeByCardId.get(watchlist.getCardId())));
+                })
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/global/config/CacheConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/CacheConfig.java
@@ -1,0 +1,83 @@
+package com.pokade.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+// CachingConfigurer를 구현하는 이유: 느슨한 CacheErrorHandler 빈만 등록하면 @EnableCaching이
+// CachingConfigurer가 없을 때 자동으로 그 빈을 집어가지 않는다(스프링 캐시 프록시 설정은
+// CachingConfigurer 존재 여부만 확인함) - errorHandler()를 명시적으로 오버라이드해야 실제로 적용된다.
+@Slf4j
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig implements CachingConfigurer {
+
+    private static final String CARD_FACETS_CACHE = "cardFacets";
+
+    private final RedisConnectionFactory redisConnectionFactory;
+
+    @Override
+    @Bean
+    public CacheManager cacheManager() {
+        return buildRedisCacheManager(redisConnectionFactory);
+    }
+
+    // GenericJackson2JsonRedisSerializer는 Spring Data Redis 4.0부터 제거 예정(forRemoval=true)으로
+    // 표시돼 있다. 대체 클래스(GenericJacksonJsonRedisSerializer)는 Jackson 3(tools.jackson) 기반이라,
+    // 프로젝트 전체가 아직 Jackson 2(com.fasterxml.jackson)를 쓰는 현재 상태와 호환되지 않는다 -
+    // Jackson 3 마이그레이션은 이 작업(facets 캐싱) 범위를 벗어나므로 지금은 경고만 억제하고 기존
+    // 직렬화기를 사용한다. TODO: 실제로 이 클래스가 제거되는 Spring Data Redis 버전으로 올릴 때는
+    // 프로젝트가 Jackson 3로 이관된 뒤 GenericJacksonJsonRedisSerializer로 마이그레이션해야 한다.
+    @SuppressWarnings("removal")
+    private RedisCacheManager buildRedisCacheManager(RedisConnectionFactory connectionFactory) {
+        // 기본 직렬화(JdkSerializationRedisSerializer)는 값 타입이 Serializable이어야 하는데,
+        // CardFacetsResponse 등 응답 DTO는 일반 record라 그대로 쓰면 NotSerializableException이 난다.
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(GenericJackson2JsonRedisSerializer.builder().build()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultConfig)
+                // 세트/타입/레어도 데이터는 Scrydex 배치 동기화(보통 일 단위) 때만 바뀌므로 1시간 지연은
+                // 실사용상 무리 없음 - 동기화 완료 이벤트가 없어 무효화 훅을 걸 수 없는 상태라 TTL로 대체.
+                .withCacheConfiguration(CARD_FACETS_CACHE, defaultConfig.entryTtl(Duration.ofHours(1)))
+                .build();
+    }
+
+    // 목적: Redis 장애/미기동 시에도 /api/cards/facets가 500으로 죽지 않고 DB 조회로 정상 동작하게 하기 위함.
+    // 캐시 조회/쓰기 실패 각각 warn 레벨 로그를 남기고 예외는 삼켜서 원본 메서드(@Cacheable 대상)가
+    // 정상 실행되게 처리한다. 이 핸들러는 전역 적용이라 나중에 다른 캐시가 추가돼도 같은 정책이 자동 적용된다.
+    // 트레이드오프: 캐시가 조용히 실패하면 겉보기엔 정상이지만 매번 DB를 때리고 있을 수 있음 -
+    // 아래 warn 로그로 실패율을 확인할 수 있어야 한다.
+    @Override
+    @Bean
+    public CacheErrorHandler errorHandler() {
+        return new SimpleCacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+                log.warn("캐시 조회 실패, 원본 조회로 폴백합니다: cache={}, key={}", cache.getName(), key, exception);
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+                log.warn("캐시 저장 실패, 캐싱 없이 계속 진행합니다: cache={}, key={}", cache.getName(), key, exception);
+            }
+        };
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -173,7 +173,7 @@ class WatchlistControllerTest {
 
     @Test
     void 목표가_수정에_성공하면_200과_수정된_항목을_반환한다() throws Exception {
-        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null);
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null, null);
         WatchlistResponse response = new WatchlistResponse(
                 1L, 1L, null, null, null, null, null, 20000, null, false, LocalDateTime.now(), null, null, false);
 
@@ -191,7 +191,7 @@ class WatchlistControllerTest {
 
     @Test
     void 목표가_수정시_둘_다_없으면_400을_반환한다() throws Exception {
-        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null);
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null, null);
 
         given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED));
@@ -206,7 +206,7 @@ class WatchlistControllerTest {
 
     @Test
     void 존재하지_않는_항목_수정시_404를_반환한다() throws Exception {
-        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null);
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null, null);
 
         given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -93,7 +93,7 @@ class WatchlistControllerTest {
     void 등록에_성공하면_200과_등록된_항목을_반환한다() throws Exception {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
+                1L, 1L, null, "피카츄", null, "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
 
         given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
                 .willReturn(response);
@@ -141,7 +141,7 @@ class WatchlistControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
+                1L, 1L, null, "피카츄", null, "기본팩", "image.png", 10000, null, false, LocalDateTime.now(), null, null, false);
 
         given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
 
@@ -156,7 +156,7 @@ class WatchlistControllerTest {
         CardPriceSummaryResponse currentPrice =
                 new CardPriceSummaryResponse(1L, 9000, 8000, null, "KRW", null, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(),
+                1L, 1L, null, "피카츄", "피카츄", "기본팩", "image.png", 10000, null, false, LocalDateTime.now(),
                 currentPrice, new java.math.BigDecimal("3.25"), true);
 
         given(watchlistService.getWatchlist(100L)).willReturn(List.of(response));
@@ -164,6 +164,7 @@ class WatchlistControllerTest {
         mockMvc.perform(get("/api/watchlist").with(userId(100L)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data[0].cardName").value("피카츄"))
+                .andExpect(jsonPath("$.data[0].cardNameKo").value("피카츄"))
                 .andExpect(jsonPath("$.data[0].currentPrice.buyPrice").value(9000))
                 .andExpect(jsonPath("$.data[0].currentPrice.sellPrice").value(8000))
                 .andExpect(jsonPath("$.data[0].changeRate").value(3.25))
@@ -174,7 +175,7 @@ class WatchlistControllerTest {
     void 목표가_수정에_성공하면_200과_수정된_항목을_반환한다() throws Exception {
         WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null);
         WatchlistResponse response = new WatchlistResponse(
-                1L, 1L, null, null, null, null, 20000, null, false, LocalDateTime.now(), null, null, false);
+                1L, 1L, null, null, null, null, null, 20000, null, false, LocalDateTime.now(), null, null, false);
 
         given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
                 .willReturn(response);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
 import com.pokade.domain.watchlist.service.WatchlistService;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.exception.BusinessException;
@@ -40,6 +41,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -166,6 +168,54 @@ class WatchlistControllerTest {
                 .andExpect(jsonPath("$.data[0].currentPrice.sellPrice").value(8000))
                 .andExpect(jsonPath("$.data[0].changeRate").value(3.25))
                 .andExpect(jsonPath("$.data[0].targetReached").value(true));
+    }
+
+    @Test
+    void 목표가_수정에_성공하면_200과_수정된_항목을_반환한다() throws Exception {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null);
+        WatchlistResponse response = new WatchlistResponse(
+                1L, 1L, null, null, null, null, 20000, null, false, LocalDateTime.now(), null, null, false);
+
+        given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/api/watchlist/1")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.targetBuyPrice").value(20000));
+    }
+
+    @Test
+    void 목표가_수정시_둘_다_없으면_400을_반환한다() throws Exception {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null);
+
+        given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED));
+
+        mockMvc.perform(patch("/api/watchlist/1")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("TARGET_PRICE_REQUIRED"));
+    }
+
+    @Test
+    void 존재하지_않는_항목_수정시_404를_반환한다() throws Exception {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(20000, null);
+
+        given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
+
+        mockMvc.perform(patch("/api/watchlist/999")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("WATCHLIST_NOT_FOUND"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
@@ -49,7 +50,7 @@ class WatchlistConcurrencyTest {
 
     private WatchlistService newWatchlistService() {
         return new WatchlistService(watchlistRepository, mock(PriceService.class),
-                mock(CardRepository.class), mock(PriceTradeStatsRepository.class));
+                mock(CardRepository.class), mock(PriceTradeStatsRepository.class), mock(CardNameKoResolver.class));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
@@ -41,6 +42,7 @@ class WatchlistServiceTest {
     @Mock PriceService priceService;
     @Mock CardRepository cardRepository;
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
+    @Mock CardNameKoResolver cardNameKoResolver;
     @InjectMocks WatchlistService watchlistService;
 
     private Watchlist watchlist(Long userId, Long cardId) {
@@ -196,12 +198,28 @@ class WatchlistServiceTest {
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
         given(cardRepository.findAllById(List.of(10L))).willReturn(List.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("피카츄");
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result.get(0).cardName()).isEqualTo("피카츄");
+        assertThat(result.get(0).cardNameKo()).isEqualTo("피카츄");
         assertThat(result.get(0).setName()).isEqualTo("기본팩");
         assertThat(result.get(0).imageUrl()).isEqualTo("medium.png");
+    }
+
+    @Test
+    @DisplayName("목록 조회: 카드 정보를 찾지 못하면(삭제된 카드 등) cardNameKo는 resolver를 호출하지 않고 null이다")
+    void getWatchlist_cardNotFound_cardNameKoNull() {
+        Watchlist watchlist = watchlist(1L, 10L);
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
+        given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
+        given(cardRepository.findAllById(List.of(10L))).willReturn(List.of());
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result.get(0).cardNameKo()).isNull();
+        then(cardNameKoResolver).should(never()).resolve(any(Card.class));
     }
 
     // targetReached는 "지금 시세가 목표가보다 높은지/낮은지"가 아니라 "체결가가 그동안 오르내리며

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -8,6 +8,7 @@ import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
+import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
@@ -276,6 +277,54 @@ class WatchlistServiceTest {
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result.get(0).changeRate()).isEqualTo(new java.math.BigDecimal("3.25"));
+    }
+
+    // ===== 목표가 수정 =====
+    @Test
+    @DisplayName("수정: 목표가 둘 다 null이면 TARGET_PRICE_REQUIRED")
+    void updateWatchlist_targetPriceRequired() {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null);
+
+        assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.TARGET_PRICE_REQUIRED);
+        then(watchlistRepository).should(never()).findByIdAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("수정: 본인 소유가 아니거나 존재하지 않으면 WATCHLIST_NOT_FOUND")
+    void updateWatchlist_notFound() {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(2000, null);
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.WATCHLIST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("수정: 목표가가 실제로 바뀌면 isNotified가 false로 리셋된다")
+    void updateWatchlist_changedPrice_resetsIsNotified() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null));
+
+        assertThat(response.targetBuyPrice()).isEqualTo(2000);
+        assertThat(response.isNotified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("수정: 기존과 동일한 값으로 수정하면(no-op) isNotified는 유지된다")
+    void updateWatchlist_samePrice_keepsIsNotified() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null));
+
+        assertThat(response.isNotified()).isTrue();
     }
 
     // ===== 삭제 =====

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -301,7 +301,7 @@ class WatchlistServiceTest {
     @Test
     @DisplayName("수정: 목표가 둘 다 null이면 TARGET_PRICE_REQUIRED")
     void updateWatchlist_targetPriceRequired() {
-        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null);
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, null, null);
 
         assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, request))
                 .isInstanceOf(BusinessException.class)
@@ -312,7 +312,7 @@ class WatchlistServiceTest {
     @Test
     @DisplayName("수정: 본인 소유가 아니거나 존재하지 않으면 WATCHLIST_NOT_FOUND")
     void updateWatchlist_notFound() {
-        WatchlistUpdateRequest request = new WatchlistUpdateRequest(2000, null);
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(2000, null, null);
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, request))
@@ -327,7 +327,7 @@ class WatchlistServiceTest {
         target.markAsNotified();
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
 
-        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null));
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
 
         assertThat(response.targetBuyPrice()).isEqualTo(2000);
         assertThat(response.isNotified()).isFalse();
@@ -340,9 +340,48 @@ class WatchlistServiceTest {
         target.markAsNotified();
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
 
-        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null));
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null, null));
 
         assertThat(response.isNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("수정: 한쪽 목표가만 보내면 다른 쪽 기존 값은 유지된다(부분 업데이트)")
+    void updateWatchlist_partialUpdate_keepsOtherPrice() {
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).variantId(null)
+                .targetBuyPrice(1000).targetSellPrice(5000)
+                .build();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetBuyPrice()).isEqualTo(2000);
+        assertThat(response.targetSellPrice()).isEqualTo(5000);
+    }
+
+    @Test
+    @DisplayName("수정: resendNotification=true면 가격 없이도 통과하고 isNotified가 false로 리셋된다")
+    void updateWatchlist_resendNotification_resetsIsNotifiedWithoutPrice() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(null, null, true));
+
+        assertThat(response.targetBuyPrice()).isEqualTo(1000);
+        assertThat(response.isNotified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("수정: resendNotification=true 요청은 이미 isNotified=false여도 에러 없이 성공한다(멱등)")
+    void updateWatchlist_resendNotification_idempotentWhenAlreadyFalse() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(null, null, true));
+
+        assertThat(response.isNotified()).isFalse();
     }
 
     // ===== 삭제 =====

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.service.NotificationService;
@@ -105,7 +106,7 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
 
         NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore());
         WatchlistService watchlistService = new WatchlistService(watchlistRepository,
-                mock(PriceService.class), cardRepository, priceTradeStatsRepository);
+                mock(PriceService.class), cardRepository, priceTradeStatsRepository, mock(CardNameKoResolver.class));
         WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(
                 watchlistRepository, priceTradeStatsRepository, notificationService, watchlistService);
 

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
@@ -64,6 +65,9 @@ class WatchlistTargetPriceNoticeTransactionIsolationTest {
 
     @MockitoBean
     private PriceService priceService;
+
+    @MockitoBean
+    private CardNameKoResolver cardNameKoResolver;
 
     private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
             implements PriceTradeStatsRepository.CardPriceRangeView {


### PR DESCRIPTION
## 📌 관련 이슈
- #236 

## ✨ 작업 내용
- 워치리스트 목표가 수정 API 추가 (PATCH /api/watchlist/{id}), 값이 실제로 바뀐 경우에만 isNotified 리셋
- WatchlistResponse에 cardNameKo 추가 (기존 CardNameKoResolver 재사용)
- 카드 필터(facets) API에 Redis 캐싱 적용, TTL 1시간
- 워치리스트 재알림 요청 기능 추가 (PATCH /api/watchlist/{id}에 resendNotification 필드) 
   - 자동 재알림은 알림 폭탄 위험이 있어 사용자가 수동으로 요청하는 방식으로 결정
- 목표가 수정 시 부분 업데이트 미지원 버그 수정 
   - 구매가만 보내면 기존 판매가가 null로 삭제되던 문제, "필드 생략 = 기존 값 유지"로 변경

## 📸 스크린샷 / 테스트 결과
- 목표가 수정/cardNameKo 관련 케이스 테스트 통과
- 로컬 실측: 캐시 적중 시 SQL 미실행 확인, Redis 강제 종료 후에도 폴백으로 정상 응답 확인
- watchlist/card 도메인 전체 통과, 무관한 기존 실패는 develop과 동일
- 재알림 요청/부분 업데이트 관련 신규 테스트 4건 추가, 전체 통과
- curl로 실제 HTTP 요청 경로 재현 검증 

## 🔍 리뷰 포인트
- `global/config/CacheConfig.java`를 신규로 추가했습니다. 기존 공용 파일 수정이 아니라 새 파일 추가라 다른 도메인에 영향은 없지만, 
   Spring 선언적 캐싱(@Cacheable)을 도입했습니다.
- 기존은 StringRedisTemplate으로 Redis를 직접 다뤄왔는데(Redis가 원본 데이터 저장소인 경우), 
  이번 건은 원본이 DB고 Redis는 조회 부담을 줄이는 캐시라 성격이 달라 @Cacheable을 새로 썼습니다. 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?