### PR TITLE
[Feature] #239 프로필 이미지 업로드/삭제 (FR-PROFILE-03, 04)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -9,6 +9,7 @@ import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import com.pokade.global.web.PageableValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +49,7 @@ public class AiGradeService {
     // private static final int GRADE_COST = 100;
 
     private final ChatClient chatClient;
-    private final S3UploadService s3UploadService;
+    private final S3FileStorage s3FileStorage;
     private final ImageQualityChecker imageQualityChecker;
     private final GradeResultRepository gradeResultRepository;
     private final GradeResultImageRepository gradeResultImageRepository;
@@ -166,7 +167,7 @@ public class AiGradeService {
 
         Map<PhotoType, String> urls = new LinkedHashMap<>();
         files.forEach((type, file) ->
-                urls.put(type, s3UploadService.upload(file, "ai-grade")));
+                urls.put(type, s3FileStorage.upload(file, "ai-grade")));
         return urls;
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/ProfileImageController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/ProfileImageController.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.user.controller;
+
+public class ProfileImageController {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/ProfileImageController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/ProfileImageController.java
@@ -1,4 +1,24 @@
 package com.pokade.domain.user.controller;
 
+import com.pokade.domain.user.service.ProfileImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class ProfileImageController {
+
+    private final ProfileImageService profileImageService;
+
+    @GetMapping("/{userId}/profile/image")
+    public ResponseEntity<Resource> getProfile(
+            @PathVariable Long userId,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) String ifNoneMatch
+    ) {
+        return profileImageService.serve(userId, ifNoneMatch);
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.pokade.domain.user.dto.request.WithdrawalRequest;
 import com.pokade.domain.user.dto.response.MyProfileResponse;
 import com.pokade.domain.user.dto.response.PublicProfileResponse;
 import com.pokade.domain.user.dto.response.UserResponse;
+import com.pokade.domain.user.service.ProfileImageService;
 import com.pokade.domain.user.service.ProfileService;
 import com.pokade.domain.user.service.UserService;
 import com.pokade.domain.user.service.WithdrawalService;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
@@ -23,6 +25,7 @@ public class UserController {
     private final UserService userService;
     private final WithdrawalService withdrawalService;
     private final ProfileService profileService;
+    private final ProfileImageService profileImageService;
 
     @GetMapping("/me")
     public ApiResponse<UserResponse> getMyInfo(@AuthenticationPrincipal Long userId) {
@@ -70,5 +73,18 @@ public class UserController {
     public ApiResponse<Void> sendWithdrawalCode(@AuthenticationPrincipal Long userId) {
         withdrawalService.sendWithdrawalCode(userId);
         return ApiResponse.ok("탈퇴 인증 코드가 발송되었습니다.");
+    }
+
+    @PostMapping("/me/profile/image")
+    public ApiResponse<Void> uploadProfileImage(@AuthenticationPrincipal Long userId,
+                                                @RequestPart MultipartFile image) {
+        profileImageService.upload(userId, image);
+        return ApiResponse.ok("프로필 이미지가 등록되었습니다.");
+    }
+
+    @DeleteMapping("/me/profile/image")
+    public ApiResponse<Void> deleteProfileImage(@AuthenticationPrincipal Long userId) {
+        profileImageService.delete(userId);
+        return ApiResponse.ok("프로필 이미지가 삭제되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
@@ -16,10 +16,15 @@ public record PublicProfileResponse(
         return new PublicProfileResponse(
                 user.getId(),
                 user.getNickname(),
-                user.getProfileImageUrl(),
+                toImagePath(user),
                 user.getCreated_At(),
                 completedTradeCount,
                 activeListingCount
         );
+    }
+
+    // 내부 S3 key 대신 프록시 조회 경로를 내려준다 (이미지가 없으면 null)
+    private static String toImagePath(User user) {
+        return user.getProfileImageUrl() == null ? null : "/api/users/" + user.getId() + "/profile/image";
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -159,4 +159,18 @@ public class User {
         this.birthDate = null;
         this.profileImageUrl = null;
     }
+
+    // 프로필 이미지를 교체하고 S3 key를 돌려준다 (호출자가 이전 객체 정리하도록)
+    public String changeProfile(String newKey) {
+        String previousKey = this.profileImageUrl;
+        this.profileImageUrl = newKey;
+        return previousKey;
+    }
+
+    // 프로필 이미지를 제거하고 직전 S3 key를 돌려준다
+    public String removeProfile() {
+        String previousKey = this.profileImageUrl;
+        this.profileImageUrl = null;
+        return previousKey;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
@@ -1,4 +1,116 @@
 package com.pokade.domain.user.service;
 
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
 public class ProfileImageService {
+
+    private static final long MAX_SIZE_BYTES = 5 * 1024 * 1024;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/jpg", "image/png");
+    private static final String FOLDER = "profile";
+
+    private final UserRepository userRepository;
+    private final S3FileStorage s3FileStorage;
+
+    // 프로필 이미지를 업로드하고 기존 이미지를 정리한다.
+    @Transactional
+    public void upload(Long userId, MultipartFile file) {
+        validate(file);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String newKey = s3FileStorage.upload(file, FOLDER);
+        String previousKey = user.changeProfile(newKey);
+        deleteQuietly(previousKey);
+    }
+
+    // 프로필 이미지를 제거하고 기본 이미지로 되돌린다.
+    @Transactional
+    public void delete(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getProfileImageUrl() == null) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_NOT_SET);
+        }
+
+        String previousKey = user.removeProfile();
+        deleteQuietly(previousKey);
+    }
+
+    public ResponseEntity<Resource> serve(Long userId, String ifNoneMatch) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String key = user.getProfileImageUrl();
+        if (key == null) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_NOT_SET);
+        }
+
+        HeadObjectResponse metadata;
+        try {
+            metadata = s3FileStorage.head(key);
+        } catch (NoSuchKeyException e) {
+            throw new BusinessException(ErrorCode.PROFILE_IMAGE_NOT_SET);
+        }
+
+        String eTag = metadata.eTag();
+        if (eTag != null && eTag.equals(ifNoneMatch)) {
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(eTag).build();
+        }
+
+        Resource body = new InputStreamResource(s3FileStorage.openStream(key));
+        return ResponseEntity.ok()
+                .eTag(eTag)
+                .contentType(MediaType.parseMediaType(metadata.contentType()))
+                .contentLength(metadata.contentLength())
+                .cacheControl(CacheControl.noCache())
+                .body(body);
+    }
+
+    private void validate(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (file.getSize() > MAX_SIZE_BYTES) {
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
+        }
+        if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+        }
+    }
+
+    // S3 정리 실패가 이미지 교체, 삭제를 막지 않도록 로그만 남긴다.
+    private void deleteQuietly(String key) {
+        if (key == null) {
+            return;
+        }
+        try {
+            s3FileStorage.delete(key);
+        } catch (RuntimeException e) {
+            log.warn("프로필 이미지 S3 객체 삭제 실패 - key={}", key, e);
+        }
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.user.service;
+
+public class ProfileImageService {
+}

--- a/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
@@ -2,22 +2,26 @@ package com.pokade.domain.user.service;
 
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.ProfileImageCleanupEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.util.Set;
 
@@ -32,6 +36,7 @@ public class ProfileImageService {
 
     private final UserRepository userRepository;
     private final S3FileStorage s3FileStorage;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 프로필 이미지를 업로드하고 기존 이미지를 정리한다.
     @Transactional
@@ -43,7 +48,9 @@ public class ProfileImageService {
 
         String newKey = s3FileStorage.upload(file, FOLDER);
         String previousKey = user.changeProfile(newKey);
-        deleteQuietly(previousKey);
+
+        // 커밋이 확정된 뒤에 옛 객체를 지운다 - 롤백되면 DB는 예ㅛ key를 유지하므로 객체가 살아있어야 한다.
+        publishCleanup(userId, previousKey);
     }
 
     // 프로필 이미지를 제거하고 기본 이미지로 되돌린다.
@@ -57,7 +64,7 @@ public class ProfileImageService {
         }
 
         String previousKey = user.removeProfile();
-        deleteQuietly(previousKey);
+        publishCleanup(userId, previousKey);
     }
 
     public ResponseEntity<Resource> serve(Long userId, String ifNoneMatch) {
@@ -72,8 +79,12 @@ public class ProfileImageService {
         HeadObjectResponse metadata;
         try {
             metadata = s3FileStorage.head(key);
-        } catch (NoSuchKeyException e) {
-            throw new BusinessException(ErrorCode.PROFILE_IMAGE_NOT_SET);
+        } catch (S3Exception e) {
+            // 없는 객체(404)만 "이미지 없음"으로 바꾸고, 권한 오류 등 나머지는 그대로 올린다
+            if (e.statusCode() == 404) {
+                throw new BusinessException(ErrorCode.PROFILE_IMAGE_NOT_SET);
+            }
+            throw e;
         }
 
         String eTag = metadata.eTag();
@@ -102,15 +113,24 @@ public class ProfileImageService {
         }
     }
 
-    // S3 정리 실패가 이미지 교체, 삭제를 막지 않도록 로그만 남긴다.
-    private void deleteQuietly(String key) {
-        if (key == null) {
-            return;
+    private void publishCleanup(Long userId, String key) {
+        if (key != null) {
+            eventPublisher.publishEvent(new ProfileImageCleanupEvent(userId, key));
         }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void cleanupPreviousImage(ProfileImageCleanupEvent event) {
         try {
-            s3FileStorage.delete(key);
+            s3FileStorage.delete(event.key());
         } catch (RuntimeException e) {
-            log.warn("프로필 이미지 S3 객체 삭제 실패 - key={}", key, e);
+            log.error("프로필 이미지 S3 객체 삭제 실패 - userId={} (고아 객체 잔존)", event.userId(), e);
         }
+    }
+
+    private String extensionOf(MultipartFile file) {
+        String name = file.getOriginalFilename();
+        int dot = (name == null) ? -1 : name.lastIndexOf('.');
+        return (dot < 0) ? "" : name.substring(dot).toLowerCase();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/ProfileImageService.java
@@ -49,7 +49,7 @@ public class ProfileImageService {
         String newKey = s3FileStorage.upload(file, FOLDER);
         String previousKey = user.changeProfile(newKey);
 
-        // 커밋이 확정된 뒤에 옛 객체를 지운다 - 롤백되면 DB는 예ㅛ key를 유지하므로 객체가 살아있어야 한다.
+        // 커밋이 확정된 뒤에 옛 객체를 지운다 - 롤백되면 DB는 옛 key를 유지하므로 객체가 살아있어야 한다.
         publishCleanup(userId, previousKey);
     }
 
@@ -119,6 +119,9 @@ public class ProfileImageService {
         }
     }
 
+    /**
+     * 커밋 확정 후에만 옛 S3 객체를 지운다. 정리 실패가 본 작업을 되돌리지 않도록 예외를 삼키되,
+     * 고아 객체가 남는 상황이므로 ERROR로 남긴다(개인정보 노출 방지를 위해 key는 기록하지 않는다)*/
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void cleanupPreviousImage(ProfileImageCleanupEvent event) {
         try {
@@ -128,9 +131,4 @@ public class ProfileImageService {
         }
     }
 
-    private String extensionOf(MultipartFile file) {
-        String name = file.getOriginalFilename();
-        int dot = (name == null) ? -1 : name.lastIndexOf('.');
-        return (dot < 0) ? "" : name.substring(dot).toLowerCase();
-    }
 }

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -79,6 +79,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/analytics/visits").permitAll()
                         .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
                         .requestMatchers(RegexRequestMatcher.regexMatcher(HttpMethod.GET, "/api/users/\\d+(\\?.*)?")).permitAll()
+                        .requestMatchers(RegexRequestMatcher.regexMatcher(HttpMethod.GET, "/api/users/\\d+/profile/image(\\?.*)?")).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/Pokade/src/main/java/com/pokade/global/event/ProfileImageCleanupEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/ProfileImageCleanupEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record ProfileImageCleanupEvent(Long userId, String key) {
+}

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -8,6 +8,8 @@ public enum ErrorCode {
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "요청 값이 올바르지 않습니다."),
     FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 파일 용량을 초과했습니다."),
+    UNSUPPORTED_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "jpg 또는 png 이미지만 업로드할 수 있습니다."),
+    PROFILE_IMAGE_NOT_SET(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지가 없습니다."),
     INVALID_LISTING_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 처리할 수 없는 매물입니다."),
     INVALID_TRADE_STATUS(HttpStatus.BAD_REQUEST, "현재 상태에서는 처리할 수 없는 거래입니다."),
     SELF_PURCHASE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "본인이 등록한 매물은 구매할 수 없습니다."),

--- a/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
@@ -1,13 +1,13 @@
-package com.pokade.domain.ai.service;
+package com.pokade.global.infra.storage;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
@@ -22,7 +22,7 @@ import java.util.UUID;
  */
 @Service
 @RequiredArgsConstructor
-public class S3UploadService {
+public class S3FileStorage {
 
     private static final Duration PRESIGNED_URL_EXPIRATION = Duration.ofMinutes(10);
 
@@ -61,4 +61,35 @@ public class S3UploadService {
 
         return s3Presigner.presignGetObject(presignRequest).url().toString();
     }
+
+    // 객체 메타데이터만 조회한다 (본문은 받지 않음) - ETag 비교용
+    public HeadObjectResponse head(String key) {
+        return s3Client.headObject(
+                HeadObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build()
+        );
+    }
+
+    // 객체 본문 스트림을 연다 - 호출자가 닫아야 한다
+    public ResponseInputStream<GetObjectResponse> openStream(String key) {
+        return s3Client.getObject(
+                GetObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build()
+        );
+    }
+
+    // 객체를 삭제한다
+    public void delete(String key) {
+        s3Client.deleteObject(
+                DeleteObjectRequest.builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build()
+        );
+    }
+
 }

--- a/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
+import com.pokade.global.infra.storage.S3FileStorage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,7 @@ class AiGradeServiceTest {
     private ChatClient chatClient;
 
     @Mock
-    private S3UploadService s3UploadService;
+    private S3FileStorage s3FileStorage;
 
     @Mock
     private ImageQualityChecker imageQualityChecker;

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.pokade.domain.user.dto.response.UserResponse;
 import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.service.ProfileImageService;
 import com.pokade.domain.user.service.ProfileService;
 import com.pokade.domain.user.service.UserService;
 import com.pokade.domain.user.service.WithdrawalService;
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
@@ -38,11 +40,14 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -64,6 +69,8 @@ class UserControllerTest {
     private WithdrawalService withdrawalService;                     // UserController가 요구
     @MockitoBean
     private ProfileService profileService;                           // UserController가 요구
+    @MockitoBean
+    private ProfileImageService profileImageService;                 // UserController가 요구
     @MockitoBean
     private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;      // SecurityConfig가 요구
     @MockitoBean
@@ -163,5 +170,38 @@ class UserControllerTest {
 
         mockMvc.perform(get("/api/users/1?ref=search"))
                 .andExpect(status().isOk());
+    }
+
+    // ===== 인가 회귀: 프로필 이미지 =====
+
+    @Test
+    @DisplayName("인가: 토큰 없이 프로필 이미지를 업로드하면 401이고 서비스까지 도달하지 못한다")
+    void uploadProfileImage_withoutToken_blocked() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("image", "a.png", "image/png", new byte[]{1, 2, 3});
+
+        mockMvc.perform(multipart("/api/users/me/profile/image").file(image))
+                .andExpect(status().isUnauthorized());
+
+        then(profileImageService).should(never()).upload(any(), any());
+    }
+
+    @Test
+    @DisplayName("인가: 토큰 없이 프로필 이미지를 삭제하면 401이고 서비스까지 도달하지 못한다")
+    void deleteProfileImage_withoutToken_blocked() throws Exception {
+        mockMvc.perform(delete("/api/users/me/profile/image"))
+                .andExpect(status().isUnauthorized());
+
+        then(profileImageService).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("인가: 인증된 사용자는 프로필 이미지를 업로드할 수 있다")
+    void uploadProfileImage_success() throws Exception {
+        MockMultipartFile image = new MockMultipartFile("image", "a.png", "image/png", new byte[]{1, 2, 3});
+
+        mockMvc.perform(multipart("/api/users/me/profile/image").file(image).with(userId(1L)))
+                .andExpect(status().isOk());
+
+        then(profileImageService).should().upload(eq(1L), any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/service/ProfileImageServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/ProfileImageServiceTest.java
@@ -1,0 +1,243 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import java.io.ByteArrayInputStream;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileImageServiceTest {
+
+    private static final String ETAG = "\"abc123\"";
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private S3FileStorage s3FileStorage;
+
+    @InjectMocks
+    private ProfileImageService profileImageService;
+
+    private User userWithImage(String key) {
+        User user = User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+        if (key != null) {
+            user.changeProfile(key);
+        }
+        return user;
+    }
+
+    private MultipartFile png(long size) {
+        return new MockMultipartFile("image", "a.png", "image/png", new byte[(int) size]);
+    }
+
+    // ===== 업로드 =====
+
+    @Test
+    @DisplayName("업로드: S3에 저장하고 사용자 프로필 이미지 key를 갱신한다")
+    void upload_success() {
+        User user = userWithImage(null);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(s3FileStorage.upload(any(), any())).willReturn("profile/new-key.png");
+
+        profileImageService.upload(1L, png(1024));
+
+        assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
+        then(s3FileStorage).should(never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("업로드: 교체 시 기존 S3 객체를 삭제한다")
+    void upload_replacesAndDeletesPrevious() {
+        User user = userWithImage("profile/old-key.png");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(s3FileStorage.upload(any(), any())).willReturn("profile/new-key.png");
+
+        profileImageService.upload(1L, png(1024));
+
+        assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
+        then(s3FileStorage).should().delete("profile/old-key.png");
+    }
+
+    @Test
+    @DisplayName("업로드: 5MB를 넘으면 FILE_TOO_LARGE, S3에 올리지 않는다")
+    void upload_tooLarge() {
+        assertThatThrownBy(() -> profileImageService.upload(1L, png(5 * 1024 * 1024 + 1)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FILE_TOO_LARGE);
+
+        then(s3FileStorage).should(never()).upload(any(), any());
+    }
+
+    @Test
+    @DisplayName("업로드: 미지원 형식이면 UNSUPPORTED_IMAGE_TYPE, S3에 올리지 않는다")
+    void upload_unsupportedType() {
+        MultipartFile pdf = new MockMultipartFile("image", "a.pdf", "application/pdf", new byte[10]);
+
+        assertThatThrownBy(() -> profileImageService.upload(1L, pdf))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+
+        then(s3FileStorage).should(never()).upload(any(), any());
+    }
+
+    @Test
+    @DisplayName("업로드: S3 삭제가 실패해도 교체 자체는 성공한다")
+    void upload_s3DeleteFailureIsSwallowed() {
+        User user = userWithImage("profile/old-key.png");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(s3FileStorage.upload(any(), any())).willReturn("profile/new-key.png");
+        willThrow(new RuntimeException("S3 장애")).given(s3FileStorage).delete("profile/old-key.png");
+
+        profileImageService.upload(1L, png(1024));
+
+        assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
+    }
+
+    // ===== 삭제 =====
+
+    @Test
+    @DisplayName("삭제: 이미지를 지우고 컬럼을 비운다")
+    void delete_success() {
+        User user = userWithImage("profile/old-key.png");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        profileImageService.delete(1L);
+
+        assertThat(user.getProfileImageUrl()).isNull();
+        then(s3FileStorage).should().delete("profile/old-key.png");
+    }
+
+    @Test
+    @DisplayName("삭제: 이미 기본 이미지면 PROFILE_IMAGE_NOT_SET")
+    void delete_notSet() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage(null)));
+
+        assertThatThrownBy(() -> profileImageService.delete(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
+
+        then(s3FileStorage).should(never()).delete(anyString());
+    }
+
+    // ===== 프록시 서빙 =====
+
+    @Test
+    @DisplayName("서빙: ETag가 같으면 304를 반환하고 S3 본문을 읽지 않는다")
+    void serve_notModified() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png")).willReturn(
+                HeadObjectResponse.builder().eTag(ETAG).contentType("image/png").contentLength(10L).build());
+
+        ResponseEntity<Resource> res = profileImageService.serve(1L, ETAG);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.NOT_MODIFIED);
+        assertThat(res.getBody()).isNull();
+        assertThat(res.getHeaders().getETag()).isEqualTo(ETAG);
+        then(s3FileStorage).should(never()).openStream(anyString());
+    }
+
+    @Test
+    @DisplayName("서빙: ETag가 다르면 200과 이미지 본문을 반환한다")
+    void serve_modified() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png")).willReturn(
+                HeadObjectResponse.builder().eTag(ETAG).contentType("image/png").contentLength(3L).build());
+        given(s3FileStorage.openStream("profile/key.png")).willReturn(stream(new byte[]{1, 2, 3}));
+
+        ResponseEntity<Resource> res = profileImageService.serve(1L, "\"stale\"");
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(res.getBody()).isNotNull();
+        assertThat(res.getHeaders().getETag()).isEqualTo(ETAG);
+        assertThat(res.getHeaders().getContentType()).hasToString("image/png");
+        assertThat(res.getHeaders().getContentLength()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("서빙: If-None-Match가 없으면 200과 본문을 반환한다")
+    void serve_withoutIfNoneMatch() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png")).willReturn(
+                HeadObjectResponse.builder().eTag(ETAG).contentType("image/png").contentLength(3L).build());
+        given(s3FileStorage.openStream("profile/key.png")).willReturn(stream(new byte[]{1, 2, 3}));
+
+        ResponseEntity<Resource> res = profileImageService.serve(1L, null);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
+        then(s3FileStorage).should().openStream("profile/key.png");
+    }
+
+    @Test
+    @DisplayName("서빙: 이미지가 없는 사용자면 PROFILE_IMAGE_NOT_SET (USER_NOT_FOUND 아님)")
+    void serve_imageNotSet() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage(null)));
+
+        assertThatThrownBy(() -> profileImageService.serve(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
+    }
+
+    @Test
+    @DisplayName("서빙: 존재하지 않는 사용자면 USER_NOT_FOUND")
+    void serve_userNotFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> profileImageService.serve(99L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("서빙: DB에 key가 있어도 S3 객체가 없으면 PROFILE_IMAGE_NOT_SET")
+    void serve_objectMissingInS3() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png"))
+                .willThrow(NoSuchKeyException.builder().message("not found").build());
+
+        assertThatThrownBy(() -> profileImageService.serve(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
+    }
+
+    private ResponseInputStream<GetObjectResponse> stream(byte[] bytes) {
+        return new ResponseInputStream<>(
+                GetObjectResponse.builder().build(),
+                AbortableInputStream.create(new ByteArrayInputStream(bytes)));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/ProfileImageServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/ProfileImageServiceTest.java
@@ -5,15 +5,18 @@ import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.ProfileImageCleanupEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +27,7 @@ import software.amazon.awssdk.http.AbortableInputStream;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.ByteArrayInputStream;
 import java.util.Optional;
@@ -46,6 +50,8 @@ class ProfileImageServiceTest {
     private UserRepository userRepository;
     @Mock
     private S3FileStorage s3FileStorage;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private ProfileImageService profileImageService;
@@ -69,7 +75,7 @@ class ProfileImageServiceTest {
     // ===== 업로드 =====
 
     @Test
-    @DisplayName("업로드: S3에 저장하고 사용자 프로필 이미지 key를 갱신한다")
+    @DisplayName("업로드: S3에 저장하고 사용자 프로필 이미지 key를 갱신한다 (이전 이미지가 없으면 정리 이벤트도 없다)")
     void upload_success() {
         User user = userWithImage(null);
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -78,12 +84,13 @@ class ProfileImageServiceTest {
         profileImageService.upload(1L, png(1024));
 
         assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
+        then(eventPublisher).should(never()).publishEvent(any(Object.class));
         then(s3FileStorage).should(never()).delete(anyString());
     }
 
     @Test
-    @DisplayName("업로드: 교체 시 기존 S3 객체를 삭제한다")
-    void upload_replacesAndDeletesPrevious() {
+    @DisplayName("업로드: 교체 시 옛 key 정리를 이벤트로 넘기고 커밋 전에는 직접 삭제하지 않는다")
+    void upload_replacesAndPublishesCleanup() {
         User user = userWithImage("profile/old-key.png");
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
         given(s3FileStorage.upload(any(), any())).willReturn("profile/new-key.png");
@@ -91,7 +98,9 @@ class ProfileImageServiceTest {
         profileImageService.upload(1L, png(1024));
 
         assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
-        then(s3FileStorage).should().delete("profile/old-key.png");
+        assertThat(publishedCleanup().key()).isEqualTo("profile/old-key.png");
+        // 커밋 전에 지우면 롤백 시 DB가 가리키는 객체가 사라진다
+        then(s3FileStorage).should(never()).delete(anyString());
     }
 
     @Test
@@ -116,23 +125,30 @@ class ProfileImageServiceTest {
         then(s3FileStorage).should(never()).upload(any(), any());
     }
 
+    // ===== 커밋 이후 정리 (AFTER_COMMIT 리스너) =====
+
     @Test
-    @DisplayName("업로드: S3 삭제가 실패해도 교체 자체는 성공한다")
-    void upload_s3DeleteFailureIsSwallowed() {
-        User user = userWithImage("profile/old-key.png");
-        given(userRepository.findById(1L)).willReturn(Optional.of(user));
-        given(s3FileStorage.upload(any(), any())).willReturn("profile/new-key.png");
+    @DisplayName("정리: 커밋 이후 리스너가 옛 S3 객체를 삭제한다")
+    void cleanup_deletesPreviousObject() {
+        profileImageService.cleanupPreviousImage(new ProfileImageCleanupEvent(1L, "profile/old-key.png"));
+
+        then(s3FileStorage).should().delete("profile/old-key.png");
+    }
+
+    @Test
+    @DisplayName("정리: S3 삭제가 실패해도 예외를 밖으로 던지지 않는다 (고아 객체만 남김)")
+    void cleanup_swallowsS3Failure() {
         willThrow(new RuntimeException("S3 장애")).given(s3FileStorage).delete("profile/old-key.png");
 
-        profileImageService.upload(1L, png(1024));
+        profileImageService.cleanupPreviousImage(new ProfileImageCleanupEvent(1L, "profile/old-key.png"));
 
-        assertThat(user.getProfileImageUrl()).isEqualTo("profile/new-key.png");
+        then(s3FileStorage).should().delete("profile/old-key.png");
     }
 
     // ===== 삭제 =====
 
     @Test
-    @DisplayName("삭제: 이미지를 지우고 컬럼을 비운다")
+    @DisplayName("삭제: 컬럼을 비우고 옛 key 정리를 이벤트로 넘긴다")
     void delete_success() {
         User user = userWithImage("profile/old-key.png");
         given(userRepository.findById(1L)).willReturn(Optional.of(user));
@@ -140,7 +156,8 @@ class ProfileImageServiceTest {
         profileImageService.delete(1L);
 
         assertThat(user.getProfileImageUrl()).isNull();
-        then(s3FileStorage).should().delete("profile/old-key.png");
+        assertThat(publishedCleanup().key()).isEqualTo("profile/old-key.png");
+        then(s3FileStorage).should(never()).delete(anyString());
     }
 
     @Test
@@ -152,6 +169,7 @@ class ProfileImageServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
 
+        then(eventPublisher).should(never()).publishEvent(any(Object.class));
         then(s3FileStorage).should(never()).delete(anyString());
     }
 
@@ -224,15 +242,49 @@ class ProfileImageServiceTest {
     }
 
     @Test
-    @DisplayName("서빙: DB에 key가 있어도 S3 객체가 없으면 PROFILE_IMAGE_NOT_SET")
+    @DisplayName("서빙: DB에 key가 있어도 S3에 객체가 없으면(404) PROFILE_IMAGE_NOT_SET")
     void serve_objectMissingInS3() {
         given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
-        given(s3FileStorage.head("profile/key.png"))
-                .willThrow(NoSuchKeyException.builder().message("not found").build());
+        given(s3FileStorage.head("profile/key.png")).willThrow(s3Error(404));
 
         assertThatThrownBy(() -> profileImageService.serve(1L, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
+    }
+
+    @Test
+    @DisplayName("서빙: NoSuchKeyException도 404로 취급해 PROFILE_IMAGE_NOT_SET")
+    void serve_noSuchKeyIsTreatedAs404() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png")).willThrow(
+                (NoSuchKeyException) NoSuchKeyException.builder()
+                        .statusCode(404).message("not found").build());
+
+        assertThatThrownBy(() -> profileImageService.serve(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PROFILE_IMAGE_NOT_SET);
+    }
+
+    @Test
+    @DisplayName("서빙: 404가 아닌 S3 오류(403 등)는 이미지 없음으로 뭉개지 않고 그대로 전파한다")
+    void serve_nonNotFoundS3ErrorPropagates() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithImage("profile/key.png")));
+        given(s3FileStorage.head("profile/key.png")).willThrow(s3Error(403));
+
+        assertThatThrownBy(() -> profileImageService.serve(1L, null))
+                .isInstanceOf(S3Exception.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ProfileImageCleanupEvent publishedCleanup() {
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        then(eventPublisher).should().publishEvent(captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(ProfileImageCleanupEvent.class);
+        return (ProfileImageCleanupEvent) captor.getValue();
+    }
+
+    private S3Exception s3Error(int statusCode) {
+        return (S3Exception) S3Exception.builder().statusCode(statusCode).message("s3 error").build();
     }
 
     private ResponseInputStream<GetObjectResponse> stream(byte[] bytes) {

--- a/Pokade/src/test/java/com/pokade/domain/user/service/ProfileServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/ProfileServiceTest.java
@@ -1,0 +1,140 @@
+package com.pokade.domain.user.service;
+
+import com.pokade.domain.user.dto.response.MyProfileResponse;
+import com.pokade.domain.user.dto.response.PublicProfileResponse;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.ListingCountPort;
+import com.pokade.global.port.TradeCountPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TradeCountPort tradeCountPort;
+    @Mock
+    private ListingCountPort listingCountPort;
+
+    @InjectMocks
+    private ProfileService profileService;
+
+    private User userWith(UserStatus status) {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(status).pointBalance(0)
+                .build();
+    }
+
+    // ===== 공개 프로필 =====
+
+    @Test
+    @DisplayName("공개 프로필: 거래 수와 판매 중 매물 수를 함께 반환한다")
+    void getPublicProfile_success() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.ACTIVE)));
+        given(tradeCountPort.countCompletedTrades(1L)).willReturn(3L);
+        given(listingCountPort.countActiveListings(1L)).willReturn(2L);
+
+        PublicProfileResponse res = profileService.getPublicProfile(1L);
+
+        assertThat(res.userId()).isEqualTo(1L);
+        assertThat(res.nickname()).isEqualTo("지우");
+        assertThat(res.completedTradeCount()).isEqualTo(3L);
+        assertThat(res.activeListingCount()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("공개 프로필: 존재하지 않는 userId면 USER_NOT_FOUND")
+    void getPublicProfile_notFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> profileService.getPublicProfile(99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공개 프로필: 확정 탈퇴 계정은 존재하지 않는 것으로 취급한다")
+    void getPublicProfile_deletedTreatedAsNotFound() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.DELETED)));
+
+        assertThatThrownBy(() -> profileService.getPublicProfile(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공개 프로필: 탈퇴 유예 중인 계정은 정상 노출된다")
+    void getPublicProfile_withdrawalPendingIsVisible() {
+        User user = userWith(UserStatus.ACTIVE);
+        user.requestWithdrawal(LocalDateTime.now()); // ACTIVE -> WITHDRAWAL_PENDING
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+        given(tradeCountPort.countCompletedTrades(1L)).willReturn(1L);
+        given(listingCountPort.countActiveListings(1L)).willReturn(0L);
+
+        PublicProfileResponse res = profileService.getPublicProfile(1L);
+
+        assertThat(res.nickname()).isEqualTo("지우");
+        assertThat(res.completedTradeCount()).isEqualTo(1L);
+    }
+
+    // ===== 내 프로필 상세 =====
+
+    @Test
+    @DisplayName("내 프로필: 로컬 계정이면 socialLinked 가 false")
+    void getMyProfile_localAccount() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWith(UserStatus.ACTIVE)));
+
+        MyProfileResponse res = profileService.getMyProfile(1L);
+
+        assertThat(res.email()).isEqualTo("user@pokade.com");
+        assertThat(res.provider()).isEqualTo(Provider.LOCAL);
+        assertThat(res.socialLinked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("내 프로필: 소셜 계정이면 socialLinked 가 true")
+    void getMyProfile_socialAccount() {
+        User user = User.builder()
+                .id(1L).email("user@pokade.com")
+                .nickname("지우").role(Role.USER).provider(Provider.GOOGLE)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .build();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        MyProfileResponse res = profileService.getMyProfile(1L);
+
+        assertThat(res.provider()).isEqualTo(Provider.GOOGLE);
+        assertThat(res.socialLinked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("내 프로필: 존재하지 않는 userId면 USER_NOT_FOUND")
+    void getMyProfile_notFound() {
+        given(userRepository.findById(99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> profileService.getMyProfile(99L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #239

## ✨ 작업 내용

- FR-PROFILE-03(업로드), FR-PROFILE-04(삭제) 구현. 서빙을 위해 `GET /api/users/{userId}/profile/image`를 추가했다(명세에 없는 엔드포인트지만 프록시 방식을 택한 이상 필요)
- **서빙 방식으로 BE 프록시를 택했다.** 이미지를 실제로 노출하는 첫 사례라 따라야 할 기존 패턴이 없었다 — `S3UploadService`는 업로드에만 쓰였고 `generatePresignedUrl()`은 코드 어디에서도 호출되지 않는 상태였다
  - 버킷 `5team-storage`가 공개 접근을 4중 차단(`BlockPublicAcls`/`IgnorePublicAcls`/`BlockPublicPolicy`/`RestrictPublicBuckets` 모두 true)하고 있어 공개 URL 방식은 인프라 정책 변경이 선행되어야 한다
  - presigned URL은 TTL이 태생적으로 따라온다(서명에 만료 시각이 들어가야 유출돼도 영원히 열리지 않음). 짧으면 페이지를 오래 연 사용자의 이미지가 깨지고, 길면 유출 시 그만큼 열려 있다. 게다가 URL이 매번 달라져 브라우저 캐시·CDN이 무력화된다
  - 판단 기준은 **이미지의 재사용성과 수명**이었다. AI 등급진단 이미지는 진단 1회를 위한 일회성 입력이지만, 프로필 이미지는 여러 화면에서 반복 노출되는 장수명 자산이라 고정 URL + 캐시가 맞다
- **캐시 무효화는 ETag로 처리한다.** URL이 고정이라 이미지를 바꿔도 브라우저가 옛 사진을 보여줄 수 있다(사용자에겐 업로드 실패로 보인다). S3 객체의 ETag를 응답에 실어주고 `If-None-Match`에 304로 답한다. 지문은 S3가 자동 생성하므로 별도 계산이 없다
- **응답에는 S3 key가 아니라 API 경로를 담는다.** `PublicProfileResponse.profileImageUrl`이 `/api/users/{userId}/profile/image`를 반환하고, 이미지가 없으면 `null`. 내부 저장 구조가 API 밖으로 새지 않게 한다
- **교체·삭제 시 기존 S3 객체를 제거하되, 삭제 실패는 로그만 남기고 진행한다**(`deleteQuietly`). S3 정리 실패로 예외가 나면 트랜잭션이 롤백되어 이미지 교체 자체가 실패하는데, 정리는 부수 작업이라 본 작업을 막으면 안 된다
- `S3UploadService`를 `domain/ai/service` → **`global/infra/storage/S3FileStorage`** 로 옮겼다. 프로필에서 쓰는 순간 user 도메인이 ai 도메인을 import하게 되는데, #233에서 `global/port`로 세운 도메인 경계와 어긋난다. S3는 특정 도메인 소유가 아닌 공용 인프라이고, `global/infra/mail`이 이미 같은 규칙을 쓰고 있다. 삭제·조회까지 하게 되어 이름도 함께 바꿨다
- **5MB 초과는 413(`FILE_TOO_LARGE`) 재사용.** `spring.servlet.multipart.max-file-size`가 10MB(AI 진단이 파일당 10MB × 6장을 쓴다)라 10MB 초과는 Spring이 413으로 잘라내는데, 5MB 초과만 400으로 두면 같은 "파일이 너무 큼"이 크기에 따라 두 코드로 갈린다. **명세의 "5MB 초과(400)"는 413으로 정정이 필요하다**
- `User.profileImageUrl` 컬럼을 재사용해 DB 마이그레이션이 없다. 컬럼명은 URL이지만 실제 저장값은 S3 key다

## 📸 스크린샷 / 테스트 결과

dev 프로파일 + 실제 버킷(`5team-storage`)으로 e2e 확인했다.

| 확인 | 결과 |
| --- | --- |
| 업로드 | 200, S3에 객체 생성 |
| 프록시 조회(비로그인) | 200, `Content-Type: image/png`, `Content-Length: 178`, 실제 PNG 수신 |
| 같은 ETag 재요청 | **304, 본문 0바이트** |
| 다른 ETag | 200 + 본문 |
| 이미지 교체 | ETag 변경(`3d1c…` → `b67a…`), **옛 S3 객체 자동 정리**(객체 1개만 잔존) |
| 6MB 업로드 | 413 `FILE_TOO_LARGE` |
| pdf 업로드 | 400 `UNSUPPORTED_IMAGE_TYPE` |
| 삭제 / 재삭제 | 200 / 400 `PROFILE_IMAGE_NOT_SET` |
| 공개 프로필 응답 | `"/api/users/3/profile/image"` (key 미노출), 해당 경로가 실제 PNG 반환 |
| 검증 후 | S3 객체 0개, DB 컬럼 null로 원상복구 |

단위·인가 테스트 32건을 추가했다. 전체 706건 중 실패 36건은 develop에서도 동일하게 실패하는 기존 건이며(Testcontainers 베이스 미상속 / 슬라이스 빈 누락 / 거래 상태 전이), **이 PR로 새로 깨진 테스트는 없다.**

## 🔍 리뷰 포인트

- **`head` → 304 → 그 다음에야 `getObject`** 순서가 이 설계의 핵심이다. 항상 `getObject`부터 하면 S3에서는 매번 본문을 다 받아놓고 브라우저에만 안 보내는 꼴이 되어 프록시 이점이 사라진다. `ProfileImageServiceTest.serve_notModified`가 "304일 때 `openStream`이 호출되지 않음"까지 검증한다
- **본문은 `InputStreamResource`로 스트리밍한다.** `byte[]`로 통째 읽으면 5MB × 동시 요청이 힙을 친다
- **`serve()`에는 `@Transactional`을 붙이지 않았다.** 스트림을 반환한 뒤에 실제 전송이 일어나므로, 트랜잭션을 걸면 응답이 다 나갈 때까지 DB 커넥션을 붙잡는다
- **`CacheControl.noCache()`는 "캐시 금지"가 아니라 "저장하되 쓰기 전에 재검증"** 이다. 저장 자체를 막는 것은 `noStore()`다
- 파일 형식을 `contentType`만으로 판단한다. 브라우저가 보낸 값이라 위조 가능하지만, 버킷이 프록시를 통해서만 노출되고 응답 `Content-Type`도 우리가 통제해서 이번 범위에서는 매직 바이트 검사를 넣지 않았다. 필요하다는 의견 있으면 반영하겠다
- `generatePresignedUrl()`은 지금 쓰지 않지만 남겨뒀다. AI 도메인이 나중에 이미지 노출을 완성할 때 쓸 수 있어 이번 이슈에서 임의로 걷어내지 않았다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 프로필 이미지를 업로드, 변경, 삭제하고 조회할 수 있습니다.
  - 공개 프로필에 프로필 이미지 조회 경로가 표시됩니다.
  - 이미지 조회 시 ETag 기반 캐싱을 지원합니다.
  - 지원하지 않는 형식, 빈 파일, 용량 초과 이미지를 검증합니다.
  - 프로필 이미지 조회는 인증 없이 이용할 수 있습니다.

- **버그 수정**
  - 이미지 교체·삭제 시 기존 저장 파일을 정리합니다.
  - 이미지가 설정되지 않은 경우 적절한 오류를 제공합니다.

- **테스트**
  - 프로필 이미지 관리 및 접근 권한 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->