### PR TITLE
[Fix] #243 프로필 이미지 S3 객체에 개인정보가 남는 문제 정리

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -149,7 +149,7 @@ public class User {
     }
 
     // 탈퇴 확정 — soft-delete + 회원정보 익명화(email·nickname은 UNIQUE라 재가입 재사용 위해 비충돌 값 치환)
-    public void confirmWithdrawal(LocalDateTime now, String anonToken) {
+    public String confirmWithdrawal(LocalDateTime now, String anonToken) {
         this.status = UserStatus.DELETED;
         this.deleted_At = now;
         this.email = "deleted_" + anonToken + "@pokade.invalid";
@@ -157,7 +157,9 @@ public class User {
         this.password = null;
         this.phoneNumber = null;
         this.birthDate = null;
+        String previousKey = this.profileImageUrl;
         this.profileImageUrl = null;
+        return previousKey;
     }
 
     // 프로필 이미지를 교체하고 S3 key를 돌려준다 (호출자가 이전 객체 정리하도록)

--- a/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/service/WithdrawalConfirmer.java
@@ -4,6 +4,7 @@ import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.domain.user.support.AnonymizationTokenGenerator;
+import com.pokade.global.event.ProfileImageCleanupEvent;
 import com.pokade.global.event.UserWithdrawnEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -30,10 +31,16 @@ public class WithdrawalConfirmer {
         if (user.getStatus() != UserStatus.WITHDRAWAL_PENDING) {
             return false; // 멱등 skip - 그새 철회(ACTIVE)됐거나 이미 확정 (DELETED)
         }
+
         String anonToken = anonTokenGenerator.generate();
-        user.confirmWithdrawal(LocalDateTime.now(), anonToken);
+        String previousImageKey = user.confirmWithdrawal(LocalDateTime.now(), anonToken);
         userRepository.flush();
+
         eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
+        if (previousImageKey != null) {
+            eventPublisher.publishEvent(new ProfileImageCleanupEvent(userId, previousImageKey));
+        }
+
         return true;
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -99,7 +100,7 @@ public class S3FileStorage {
         if (dot < 0 || dot == name.length() - 1) {
             return "";
         }
-        String ext = name.substring(dot + 1).toLowerCase();
+        String ext = name.substring(dot + 1).toLowerCase(Locale.ROOT);
         return ext.matches("[a-z0-9]{1,10}") ? "." + ext : "";
     }
 

--- a/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/storage/S3FileStorage.java
@@ -33,7 +33,7 @@ public class S3FileStorage {
     private String bucket;
 
     public String upload(MultipartFile file, String folder) {
-        String key = folder + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String key = folder + "/" + UUID.randomUUID() + extensionOf(file);
         try {
             PutObjectRequest request = PutObjectRequest.builder()
                     .bucket(bucket)
@@ -43,7 +43,7 @@ public class S3FileStorage {
                     .build();
             s3Client.putObject(request, RequestBody.fromBytes(file.getBytes()));
         } catch (IOException e) {
-            throw new UncheckedIOException("S3 업로드 실패: " + file.getOriginalFilename(), e);
+            throw new UncheckedIOException("S3 업로드 실패 (folder=" + folder + ")", e);
         }
         return key;
     }
@@ -90,6 +90,17 @@ public class S3FileStorage {
                         .key(key)
                         .build()
         );
+    }
+
+    // 원본 파일명은 사용자 입력이라 개인정보가 섞일 수 있어 key에 넣지 않고 확장자만 취한다.
+    private String extensionOf(MultipartFile file) {
+        String name = file.getOriginalFilename();
+        int dot = (name == null) ? -1 : name.lastIndexOf('.');
+        if (dot < 0 || dot == name.length() - 1) {
+            return "";
+        }
+        String ext = name.substring(dot + 1).toLowerCase();
+        return ext.matches("[a-z0-9]{1,10}") ? "." + ext : "";
     }
 
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.user.service;
 
+import com.pokade.domain.auth.service.WithdrawalCodeService;
+import com.pokade.global.event.ProfileImageCleanupEvent;
 import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Provider;
@@ -18,6 +20,8 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 import java.time.LocalDateTime;
 
@@ -31,6 +35,7 @@ import static org.mockito.Mockito.never;
  * Redis 스토어(RefreshTokenStore·TokenBlacklistStore)만 목으로 두고 호출 여부만 본다.
  */
 @DataJpaTest
+@RecordApplicationEvents
 @Import({WithdrawalService.class, WithdrawalConfirmer.class, AnonymizationTokenGenerator.class})
 class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
 
@@ -47,6 +52,9 @@ class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
     private RefreshTokenStore refreshTokenStore;    // Redis 없이 — 호출 여부만 검증
     @MockitoBean
     private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private WithdrawalCodeService withdrawalCodeService; // WithdrawalService 생성자 의존만 충족(이 테스트에선 미사용)
 
     @Test
     @DisplayName("실제 빈·DB: 유예 만료 유저를 배치가 DELETED 익명화하고 version을 올리며 토큰 정리를 호출한다")
@@ -84,6 +92,39 @@ class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
                 .isEqualTo(UserStatus.WITHDRAWAL_PENDING);
         then(refreshTokenStore).should().deleteAll(expiredId);
         then(refreshTokenStore).should(never()).deleteAll(freshId);
+    }
+
+    @Test
+    @DisplayName("실제 배선: 프로필 이미지가 있던 유저는 익명화되면서 S3 정리 이벤트가 발행된다")
+    void confirmExpired_publishesProfileImageCleanup(ApplicationEvents events) {
+        Long id = persistPending("e2e-image@pokade.test", "이미지보유", 8);
+        User target = userRepository.findById(id).orElseThrow();
+        target.changeProfile("profile/e2e-key.png");
+        em.flush();
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        em.flush();
+        em.clear();
+        // 컬럼은 비워지고
+        assertThat(userRepository.findById(id).orElseThrow().getProfileImageUrl()).isNull();
+        // 비워지기 전의 key가 정리 이벤트로 넘어가야 S3 객체를 지울 수 있다
+        assertThat(events.stream(ProfileImageCleanupEvent.class))
+                .singleElement()
+                .satisfies(e -> {
+                    assertThat(e.userId()).isEqualTo(id);
+                    assertThat(e.key()).isEqualTo("profile/e2e-key.png");
+                });
+    }
+
+    @Test
+    @DisplayName("실제 배선: 프로필 이미지가 없던 유저는 정리 이벤트를 발행하지 않는다")
+    void confirmExpired_noCleanupEventWithoutImage(ApplicationEvents events) {
+        persistPending("e2e-noimage@pokade.test", "이미지없음", 8);
+
+        withdrawalService.confirmExpiredWithdrawals();
+
+        assertThat(events.stream(ProfileImageCleanupEvent.class)).isEmpty();
     }
 
     // ACTIVE로 만든 뒤 도메인 메서드로 유예 전환 (requestedDaysAgo일 전 신청으로 기록)

--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmerTest.java
@@ -6,6 +6,7 @@ import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
 import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.domain.user.support.AnonymizationTokenGenerator;
+import com.pokade.global.event.ProfileImageCleanupEvent;
 import com.pokade.global.event.UserWithdrawnEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
 import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,6 +59,43 @@ class WithdrawalConfirmerTest {
         ArgumentCaptor<UserWithdrawnEvent> captor = ArgumentCaptor.forClass(UserWithdrawnEvent.class);
         then(eventPublisher).should().publishEvent(captor.capture());
         assertThat(captor.getValue().userId()).isEqualTo(2L); // payload userId까지 검증
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 있으면 익명화로 컬럼이 비워지기 전의 S3 key를 정리 이벤트로 넘긴다")
+    void confirm_withProfileImage_publishesCleanupEvent() {
+        User user = userWithStatus(2L, UserStatus.WITHDRAWAL_PENDING);
+        user.changeProfile("profile/old-key.png");
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+        given(anonTokenGenerator.generate()).willReturn("a1b2c3d4e5f6");
+
+        withdrawalConfirmer.confirm(2L);
+
+        // 컬럼은 비워지지만, 그 전에 읽어둔 key가 이벤트로 전달되어야 S3 객체를 지울 수 있다
+        assertThat(user.getProfileImageUrl()).isNull();
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        then(eventPublisher).should(times(2)).publishEvent(captor.capture());
+
+        ProfileImageCleanupEvent cleanup = captor.getAllValues().stream()
+                .filter(ProfileImageCleanupEvent.class::isInstance)
+                .map(ProfileImageCleanupEvent.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("ProfileImageCleanupEvent가 발행되지 않았다"));
+        assertThat(cleanup.userId()).isEqualTo(2L);
+        assertThat(cleanup.key()).isEqualTo("profile/old-key.png");
+    }
+
+    @Test
+    @DisplayName("프로필 이미지가 없으면 정리 이벤트를 발행하지 않는다")
+    void confirm_withoutProfileImage_noCleanupEvent() {
+        User user = userWithStatus(2L, UserStatus.WITHDRAWAL_PENDING);
+        given(userRepository.findById(2L)).willReturn(Optional.of(user));
+        given(anonTokenGenerator.generate()).willReturn("a1b2c3d4e5f6");
+
+        withdrawalConfirmer.confirm(2L);
+
+        then(eventPublisher).should(never()).publishEvent(any(ProfileImageCleanupEvent.class));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/global/infra/storage/S3FileStorageTest.java
+++ b/Pokade/src/test/java/com/pokade/global/infra/storage/S3FileStorageTest.java
@@ -1,0 +1,122 @@
+package com.pokade.global.infra.storage;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class S3FileStorageTest {
+
+    private static final String BUCKET = "test-bucket";
+
+    @Mock
+    private S3Client s3Client;
+
+    @InjectMocks
+    private S3FileStorage s3FileStorage;
+
+    private void injectBucket() {
+        ReflectionTestUtils.setField(s3FileStorage, "bucket", BUCKET);
+    }
+
+    private MultipartFile file(String originalName) {
+        return new MockMultipartFile("image", originalName, "image/png", new byte[]{1, 2, 3});
+    }
+
+    private PutObjectRequest capturePut() {
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        then(s3Client).should().putObject(captor.capture(), any(RequestBody.class));
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("업로드: key에 원본 파일명이 들어가지 않는다 (파일명에 개인정보가 섞일 수 있음)")
+    void upload_keyDoesNotContainOriginalFilename() {
+        injectBucket();
+
+        String key = s3FileStorage.upload(file("이력서_홍길동_010-1234-5678.png"), "profile");
+
+        assertThat(key).doesNotContain("홍길동").doesNotContain("010-1234-5678").doesNotContain("이력서");
+        assertThat(key).matches("profile/[0-9a-f-]{36}\\.png");
+        assertThat(capturePut().key()).isEqualTo(key);
+    }
+
+    @ParameterizedTest(name = "\"{0}\" → 확장자 \"{1}\"")
+    @DisplayName("업로드: 확장자만 취하고 비정상 확장자는 버린다")
+    @CsvSource(nullValues = "NULL", value = {
+            "photo.png,        .png",
+            "photo.JPEG,       .jpeg",
+            "a.b.c.png,        .png",
+            "noext,            ''",
+            "'trailing.',      ''",
+            "'x.한글',          ''",
+            "'x.pn g',         ''",
+            "'x.verylongextension', ''",
+            "NULL,             ''",
+    })
+    void upload_extensionHandling(String originalName, String expectedSuffix) {
+        injectBucket();
+
+        String key = s3FileStorage.upload(file(originalName), "profile");
+
+        // UUID 뒤에 허용된 확장자만 붙고, 그 외 문자는 key에 남지 않는다
+        assertThat(key).matches("profile/[0-9a-f-]{36}" + Pattern.quote(expectedSuffix));
+    }
+
+    @Test
+    @DisplayName("업로드: 같은 파일을 두 번 올려도 key가 겹치지 않는다")
+    void upload_keysAreUnique() {
+        injectBucket();
+
+        String first = s3FileStorage.upload(file("photo.png"), "profile");
+        String second = s3FileStorage.upload(file("photo.png"), "profile");
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    @DisplayName("업로드: 버킷·Content-Type·길이를 요청에 담는다")
+    void upload_putsRequestMetadata() {
+        injectBucket();
+
+        s3FileStorage.upload(file("photo.png"), "ai-grade");
+
+        PutObjectRequest request = capturePut();
+        assertThat(request.bucket()).isEqualTo(BUCKET);
+        assertThat(request.contentType()).isEqualTo("image/png");
+        assertThat(request.contentLength()).isEqualTo(3L);
+        assertThat(request.key()).startsWith("ai-grade/");
+    }
+
+    @Test
+    @DisplayName("삭제: 지정한 버킷과 key로 삭제를 요청한다")
+    void delete_requestsCorrectObject() {
+        injectBucket();
+
+        s3FileStorage.delete("profile/some-key.png");
+
+        ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        then(s3Client).should().deleteObject(captor.capture());
+        assertThat(captor.getValue().bucket()).isEqualTo(BUCKET);
+        assertThat(captor.getValue().key()).isEqualTo("profile/some-key.png");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #243

## ✨ 작업 내용

**① 탈퇴 확정 시 프로필 이미지가 S3에 남던 문제 (가장 시급, 이번에 발견)**
- `User.confirmWithdrawal()`이 `profileImageUrl = null`로 **컬럼만 비우고** key를 아무 데도 넘기지 않아, 사진 파일이 S3에 그대로 남았다. 이메일·연락처·생년월일·닉네임은 모두 익명화하면서 **사진만 남는** 상태였다
- 더 나쁜 점은 컬럼이 비워지면서 **어느 객체가 그 사용자 것이었는지 추적할 근거도 사라진다**는 것이다. 사후 정리가 가장 어려운 형태의 고아 객체가 된다
- `confirmWithdrawal()`이 직전 key를 반환하도록 바꾸고, `WithdrawalConfirmer`가 `ProfileImageCleanupEvent`를 발행하도록 했다. **새 리스너는 만들지 않았다** — #239에서 만든 `ProfileImageService.cleanupPreviousImage()`(`AFTER_COMMIT`)를 그대로 재사용한다. 탈퇴 확정이 S3 장애로 실패하면 안 되므로 실패를 삼키는 동작도 여기서 적절하다
- 배치는 건별 독립 트랜잭션(`WithdrawalConfirmer.confirm()`)이고 호출부가 유저마다 예외를 격리하므로, 한 명의 S3 정리 실패가 다른 사람 탈퇴를 막지 않는다

**② S3 key에 저장되던 원본 파일명 제거**
- `getOriginalFilename()`은 클라이언트가 보낸 값이라 `이력서_홍길동_010-1234-5678.png` 같은 개인정보가 key로 영구 저장됐다. #241에서 로그 쪽만 조치했고 저장 형식은 그대로였다
- `profile/{UUID}.png` 형태로 바꾸고, 확장자도 영숫자 1~10자만 허용한다. 확장자 역시 사용자 입력이라 한글·공백이 key에 섞일 수 있기 때문. 확장자를 버려도 동작에는 영향이 없다 — 응답 `Content-Type`은 S3 메타데이터에서 읽지 key에서 추론하지 않는다
- 업로드 실패 예외 메시지에도 파일명이 들어가 있어(`"S3 업로드 실패: " + getOriginalFilename()`) 스택트레이스로 로그에 남던 것을 폴더명만 남기도록 바꿨다. `AGENTS.md`의 "개인정보를 로그에 남기지 않는다" 규칙 대응을 완결했다
- `S3FileStorage.upload()`는 AI 도메인과 공유하는 메서드라 key 형식 변경이 그쪽에도 적용된다. 확인 결과 AI는 key를 `grade_result_images.image_url`에 **저장만** 하고 파싱하거나 DTO로 노출하는 곳이 없어 무영향이다

**③ 고아 객체 정리는 이번 PR에 포함하지 않았다**
- 최대 발생원이던 ①을 고쳤고, 남은 발생 경로는 S3 삭제 API 호출 자체가 실패하는 경우뿐이다
- 실패 빈도에 대한 데이터가 없는 상태에서 정리 로직을 만들면 **참조 중인 객체를 지울 위험**이 더 크다. #241에서 넣은 ERROR 로그로 관측하며 실제 사례가 확인되면 방식(주기적 스윕 / 라이프사이클 규칙 / 삭제 대기 테이블)을 정하겠다

**부수 수정** — `WithdrawalConfirmIntegrationTest`가 `WithdrawalCodeService` 빈 누락으로 컨텍스트 로딩부터 실패하고 있었다. 이 PR의 검증을 그 테스트에 넣어야 해서 함께 고쳤다(전체 실패 36건 → 34건).

## 📸 스크린샷 / 테스트 결과

**AI 등급진단 실측 회귀** — dev 환경에서 실제로 진단을 돌려 확인했다. 같은 날 수정 전 데이터가 대조군이 됐다.

```
09:42:26  ai-grade/75a0e303-...-219d6fd74224_앞면.png      ← 수정 전
09:42:26  ai-grade/0f98a8df-...-d43a8a1ac293_좌 하단.png   ← 한글 + 공백까지 key에
14:43:50  ai-grade/8c2761ee-fb43-4097-a69d-649a64508785.png  ← 수정 후
```

| 확인 | 결과 |
| --- | --- |
| 진단 동작 | 정상 완료 |
| S3 업로드 | `ai-grade/` 199 → 205 (6장) |
| key 형식 | `{UUID}.png` — 파일명·한글·공백 제거 확인 |
| DB 연결 | `grade_result_images` 6건, `photo_type`별 매핑 정확 |
| 기존 객체 | 그대로 유지 (마이그레이션 불필요) |

**테스트** — 726건 중 실패 34건, **이 PR로 새로 깨진 테스트 없음**. 기존 실패는 36 → 34로 줄었다.
- `S3FileStorageTest` 13건 신규 (이 클래스에는 테스트가 하나도 없었다). 핵심은 `이력서_홍길동_010-1234-5678.png`를 올려 key에 개인정보가 남지 않는지 직접 검증하는 케이스
- 확장자 처리 9케이스(대문자·점 없음·끝점·한글·공백·과다길이·null)
- `WithdrawalConfirmerTest` 2건 추가 — 익명화로 컬럼이 비워지는 것과 **비워지기 전의 key가 이벤트로 전달되는 것**을 함께 검증
- `WithdrawalConfirmIntegrationTest` 2건 추가 — 실제 Spring 배선에서 정리 이벤트가 발행되는지

## 🔍 리뷰 포인트

- **통합 테스트에서 S3 호출을 직접 검증하지 않은 이유**: `@DataJpaTest`는 테스트 트랜잭션을 롤백하므로 `AFTER_COMMIT` 리스너가 실행되지 않는다. `@RecordApplicationEvents`로 **실제 컨텍스트에서 이벤트가 발행되는지**까지 검증하고, 리스너 → S3 delete 호출은 `ProfileImageServiceTest`가, delete 요청의 버킷·key 정확성은 `S3FileStorageTest`가 나눠 덮는다
- **확장자 화이트리스트(`[a-z0-9]{1,10}`)**: 확장자도 사용자 입력이라 그대로 붙이면 k

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 회원 탈퇴 확정 시 기존 프로필 이미지가 자동으로 정리됩니다.
  - 탈퇴한 회원의 프로필 이미지가 남지 않아 개인정보 보호가 강화되었습니다.
  - 파일 업로드 시 원본 파일명이 저장 경로에 포함되지 않으며, 안전하게 생성된 식별자와 검증된 확장자가 사용됩니다.
  - 파일 확장자는 소문자로 정규화되고, 허용되지 않는 형식은 저장 경로에서 제외됩니다.
- **버그 수정**
  - 프로필 이미지가 없는 회원의 탈퇴 처리에서는 불필요한 이미지 정리 작업이 발생하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->