### PR TITLE
[Fix] #246 내 정보 조회 응답에 프로필 이미지 S3 key가 그대로 나가는 문제

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/PublicProfileResponse.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.user.dto.response;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.support.ProfileImagePath;
 
 import java.time.LocalDateTime;
 
@@ -16,15 +17,11 @@ public record PublicProfileResponse(
         return new PublicProfileResponse(
                 user.getId(),
                 user.getNickname(),
-                toImagePath(user),
+                ProfileImagePath.of(user),
                 user.getCreated_At(),
                 completedTradeCount,
                 activeListingCount
         );
     }
 
-    // 내부 S3 key 대신 프록시 조회 경로를 내려준다 (이미지가 없으면 null)
-    private static String toImagePath(User user) {
-        return user.getProfileImageUrl() == null ? null : "/api/users/" + user.getId() + "/profile/image";
-    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/UserResponse.java
@@ -4,6 +4,7 @@ import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.support.ProfileImagePath;
 
 import java.time.LocalDateTime;
 
@@ -25,7 +26,7 @@ public record UserResponse(
                 user.getNickname(),
                 user.getRole(),
                 user.getStatus(),
-                user.getProfileImageUrl(),
+                ProfileImagePath.of(user),
                 user.getPointBalance(),
                 user.getProvider(),
                 user.getWithdrawalRequestedAt()

--- a/Pokade/src/main/java/com/pokade/domain/user/support/ProfileImagePath.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/support/ProfileImagePath.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.user.support;
+
+import com.pokade.domain.user.entity.User;
+
+// 프로필 이미지 응답 경로 규칙을 한곳에 모은다 (응답에 내부 S3 key를 싣지 않기 위함).
+public final class ProfileImagePath {
+
+    private ProfileImagePath() {
+    }
+
+    // 이미지가 없으면 null, 있으면 프록시 조회 경로를 반환한다 (ProfileImageController의 매핑과 짝을 이룬다).
+    public static String of(User user) {
+        return user.getProfileImageUrl() == null ? null : "/api/users/" + user.getId() + "/profile/image";
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/ProfileImageControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/ProfileImageControllerTest.java
@@ -1,0 +1,112 @@
+package com.pokade.domain.user.controller;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.service.ProfileImageService;
+import com.pokade.domain.user.support.ProfileImagePath;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProfileImageController.class)
+@AutoConfigureMockMvc
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class}) // 인가 계약을 검증하려면 실물 시큐리티 설정이 필요
+class ProfileImageControllerTest {
+
+    private static final Long USER_ID = 3L;
+    private static final String ETAG = "\"2ad5c2971e6b21e1247833b781d9ad55\"";
+    private static final byte[] PNG_BYTES = {(byte) 0x89, 'P', 'N', 'G'};
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProfileImageService profileImageService;                  // ProfileImageController가 요구
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;                        // 실제 JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;                  // JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;          // SecurityConfig가 요구
+    @MockitoBean
+    private RedisAuthorizationRequestRepository authorizationRequestRepository; // SecurityConfig가 요구
+
+    // 응답 DTO가 실제로 내려보내는 경로를 그대로 요청한다 - 컨트롤러 매핑이 바뀌면 여기서 404로 드러난다.
+    private String servePath() {
+        User user = User.builder().id(USER_ID).profileImageUrl("profile/9f3c2a.png").build();
+        return ProfileImagePath.of(user);
+    }
+
+    private ResponseEntity<org.springframework.core.io.Resource> imageResponse() {
+        return ResponseEntity.ok()
+                .eTag(ETAG)
+                .contentType(MediaType.IMAGE_PNG)
+                .body(new ByteArrayResource(PNG_BYTES));
+    }
+
+    @Test
+    @DisplayName("응답에 실려 나가는 경로로 요청하면 토큰 없이도 이미지가 내려온다")
+    void serve_withoutToken_ok() throws Exception {
+        given(profileImageService.serve(eq(USER_ID), isNull())).willReturn(imageResponse());
+
+        mockMvc.perform(get(servePath()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.IMAGE_PNG))
+                .andExpect(content().bytes(PNG_BYTES))
+                .andExpect(header().string(HttpHeaders.ETAG, ETAG));
+
+        then(profileImageService).should().serve(eq(USER_ID), isNull());
+    }
+
+    @Test
+    @DisplayName("캐시 무효화용 쿼리스트링이 붙어도 토큰 없이 조회된다")
+    void serve_withCacheBuster_ok() throws Exception {
+        given(profileImageService.serve(eq(USER_ID), isNull())).willReturn(imageResponse());
+
+        mockMvc.perform(get(servePath() + "?v=1755500000"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("If-None-Match 헤더가 서비스로 전달되고 변경이 없으면 304를 반환한다")
+    void serve_notModified() throws Exception {
+        given(profileImageService.serve(USER_ID, ETAG))
+                .willReturn(ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(ETAG).build());
+
+        mockMvc.perform(get(servePath()).header(HttpHeaders.IF_NONE_MATCH, ETAG))
+                .andExpect(status().isNotModified())
+                .andExpect(content().string(""));
+
+        then(profileImageService).should().serve(USER_ID, ETAG);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/user/service/ProfileServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/ProfileServiceTest.java
@@ -46,6 +46,15 @@ class ProfileServiceTest {
                 .build();
     }
 
+    private User userWithProfileImage(String profileImageKey) {
+        return User.builder()
+                .id(1L).email("user@pokade.com").password("ENCODED_PW")
+                .nickname("지우").role(Role.USER).provider(Provider.LOCAL)
+                .status(UserStatus.ACTIVE).pointBalance(0)
+                .profileImageUrl(profileImageKey)
+                .build();
+    }
+
     // ===== 공개 프로필 =====
 
     @Test
@@ -61,6 +70,17 @@ class ProfileServiceTest {
         assertThat(res.nickname()).isEqualTo("지우");
         assertThat(res.completedTradeCount()).isEqualTo(3L);
         assertThat(res.activeListingCount()).isEqualTo(2L);
+        assertThat(res.profileImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("공개 프로필: 프로필 이미지가 있으면 S3 key 대신 프록시 조회 경로를 내려준다")
+    void getPublicProfile_returnsImageProxyPath() {
+        given(userRepository.findById(1L)).willReturn(Optional.of(userWithProfileImage("profile/9f3c2a.png")));
+
+        PublicProfileResponse res = profileService.getPublicProfile(1L);
+
+        assertThat(res.profileImageUrl()).isEqualTo("/api/users/1/profile/image");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/UserServiceTest.java
@@ -49,7 +49,7 @@ class UserServiceTest {
                 .nickname("지우")
                 .role(Role.USER)
                 .status(UserStatus.ACTIVE)
-                .profileImageUrl("https://img/x.png")
+                .profileImageUrl("profile/9f3c2a.png")
                 .pointBalance(30)
                 .build();
     }
@@ -90,7 +90,7 @@ class UserServiceTest {
         assertThat(res.nickname()).isEqualTo("지우");
         assertThat(res.role()).isEqualTo(Role.USER);
         assertThat(res.status()).isEqualTo(UserStatus.ACTIVE);
-        assertThat(res.profileImageUrl()).isEqualTo("https://img/x.png");
+        assertThat(res.profileImageUrl()).isEqualTo("/api/users/1/profile/image");
         assertThat(res.pointBalance()).isEqualTo(30);
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/user/support/ProfileImagePathTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/support/ProfileImagePathTest.java
@@ -1,0 +1,39 @@
+package com.pokade.domain.user.support;
+
+import com.pokade.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProfileImagePathTest {
+
+    private User userWith(String profileImageKey) {
+        return User.builder()
+                .id(7L)
+                .email("user@pokade.com")
+                .nickname("지우")
+                .profileImageUrl(profileImageKey)
+                .build();
+    }
+
+    @Test
+    @DisplayName("이미지가 있으면 프록시 조회 경로를 반환한다")
+    void of_withImage() {
+        assertThat(ProfileImagePath.of(userWith("profile/9f3c2a.png")))
+                .isEqualTo("/api/users/7/profile/image");
+    }
+
+    @Test
+    @DisplayName("반환 경로에 내부 S3 key가 섞이지 않는다")
+    void of_doesNotExposeKey() {
+        assertThat(ProfileImagePath.of(userWith("profile/9f3c2a.png")))
+                .doesNotContain("9f3c2a");
+    }
+
+    @Test
+    @DisplayName("이미지가 없으면 null을 반환한다")
+    void of_withoutImage() {
+        assertThat(ProfileImagePath.of(userWith(null))).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #246

## ✨ 작업 내용
- 프로필 이미지 응답 경로 규칙을 `domain/user/support/ProfileImagePath`로 분리
- `UserResponse.from()`이 이 변환을 거치도록 수정 — 기존에는 DB 컬럼값(S3 객체 key)을 그대로 내려줘서 FE가 쓸 수 없었고 내부 저장소 구조가 노출됐다
- `PublicProfileResponse`의 private `toImagePath()`를 같은 헬퍼 호출로 교체 (동작 변화 없음)
- 경로 문자열을 한곳으로 모은 이유: 프로필 이미지를 담을 응답이 앞으로 더 생길 여지가 있고(매물 판매자, 채팅 상대), 서빙 방식을 바꿀 때 고칠 곳을 하나로 유지하기 위함

## 📸 스크린샷 / 테스트 결과
로컬 실응답 확인 (test1, userId 3)

| 확인 | 결과 |
| --- | --- |
| 이미지 없는 계정 `GET /api/users/me` | `profileImageUrl: null` |
| 업로드 후 `GET /api/users/me` | `/api/users/3/profile/image` |
| 공개 프로필 `GET /api/users/3` | 동일 경로 (두 API 일치) |
| 해당 경로 비로그인 GET | 200, `Content-Type: image/png`, PNG 수신 |
| `If-None-Match` 재요청 | 304 |
| `?v=` 캐시버스터 | 200 |

테스트: user 도메인 81건 전부 통과 (신규 `ProfileImagePathTest` 3건 포함)
- `ProfileImagePathTest` — 이미지 있음/없음, 반환값에 S3 key 미포함
- `ProfileServiceTest` — 공개 프로필 경로 변환 검증 추가 (기존에는 이 변환을 검증하는 테스트가 없었다)
- `UserServiceTest` — 기대값을 프록시 경로로 수정, 픽스처 값도 실제 저장 형태(key)에 맞춤

## 🔍 리뷰 포인트
- `ProfileImagePath`의 위치를 `domain/user/support`로 잡았습니다. DTO의 static 팩토리에서 호출해야 해서 `@Component` 대신 정적 유틸로 뒀는데, 다른 위치가 더 낫다면 의견 주세요
- 응답을 절대 URL이 아닌 상대 경로로 유지했습니다. 절대 URL을 박으면 로컬·배포 환경마다 도메인 설정이 필요해지고, 공개 프로필도 이미 상대 경로 규칙입니다
- `UserResponse.profileImageUrl`의 의미가 바뀌지만, 이 DTO를 쓰는 곳은 `getMyInfo()` 하나이고 FE에도 이 필드를 읽는 코드가 아직 없어 영향받는 화면은 없습니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 해당 없음