### PR TITLE
[Fix] #250 워치리스트 목표가 수정 응답 targetReached 반영 및 재알림 테스트 보강

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -24,11 +24,7 @@ public record WatchlistResponse(
         boolean targetReached
 ) {
 
-    /** 등록 직후 응답 - 아직 카드/현재 시세를 조회하지 않은 상태라 카드 정보·currentPrice·등락률은 없다. */
-    public static WatchlistResponse of(Watchlist watchlist) {
-        return of(watchlist, false);
-    }
-
+    /** 등록/수정 직후 응답 - 아직 카드/현재 시세를 조회하지 않은 상태라 카드 정보·currentPrice·등락률은 없다. */
     public static WatchlistResponse of(Watchlist watchlist, boolean targetReached) {
         return new WatchlistResponse(
                 watchlist.getId(),

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistResponse.java
@@ -26,6 +26,10 @@ public record WatchlistResponse(
 
     /** 등록 직후 응답 - 아직 카드/현재 시세를 조회하지 않은 상태라 카드 정보·currentPrice·등락률은 없다. */
     public static WatchlistResponse of(Watchlist watchlist) {
+        return of(watchlist, false);
+    }
+
+    public static WatchlistResponse of(Watchlist watchlist, boolean targetReached) {
         return new WatchlistResponse(
                 watchlist.getId(),
                 watchlist.getCardId(),
@@ -40,7 +44,7 @@ public record WatchlistResponse(
                 watchlist.getCreatedAt(),
                 null,
                 null,
-                false
+                targetReached
         );
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -28,7 +28,12 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
 
     // 알림 생성 "권한"을 조건부 원자적 UPDATE로 선점한다. is_notified=false인 행만 갱신되므로,
     // 삭제됐거나 다른 트랜잭션/인스턴스가 이미 선점한 경우 0을 반환해 중복/유령 알림 생성을 막는다.
-    @Modifying
+    // flushAutomatically=true가 필요한 이유: 이 bulk UPDATE는 Hibernate dirty-checking을 거치지 않고 DB의
+    // 현재 커밋 상태만 보는데, 호출 전에 같은 트랜잭션에서 isNotified를 바꾼(예: requestNotificationAgain())
+    // 아직 flush 안 된 변경이 있으면 그걸 못 보고 WHERE 조건이 틀리게 평가된다 - 먼저 flush해서 최신 상태로
+    // 판정하게 한다. clearAutomatically는 절대 켜지 않는다 - 켜면 영속성 컨텍스트가 비워져서 이후 호출부의
+    // watchlist.markAsNotified()가 detached 엔티티에 적용돼 추적되지 않는다.
+    @Modifying(flushAutomatically = true)
     @Query("UPDATE Watchlist w SET w.isNotified = true WHERE w.id = :id AND w.isNotified = false")
     int markAsNotifiedIfNotYet(@Param("id") Long id);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -3,6 +3,7 @@ package com.pokade.domain.watchlist.service;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
@@ -37,6 +38,7 @@ public class WatchlistService {
     private final CardRepository cardRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
     private final CardNameKoResolver cardNameKoResolver;
+    private final NotificationService notificationService;
 
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
@@ -71,11 +73,14 @@ public class WatchlistService {
                     .stream()
                     .findFirst()
                     .orElse(null);
-            boolean targetReached = isTargetReached(saved, range);
+            Integer reachedTargetPrice = resolveReachedTargetPrice(saved, range);
+            boolean targetReached = reachedTargetPrice != null;
             // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
-            // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차를 없애기 위함.
+            // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
             if (targetReached) {
                 saved.markAsNotified();
+                cardRepository.findById(saved.getCardId())
+                        .ifPresent(card -> notificationService.createPriceTargetNotification(saved, card.getName(), reachedTargetPrice));
             }
             return WatchlistResponse.of(saved, targetReached);
         } catch (DataIntegrityViolationException e) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -79,13 +79,17 @@ public class WatchlistService {
             // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
             if (targetReached) {
                 saved.markAsNotified();
-                cardRepository.findById(saved.getCardId())
-                        .ifPresent(card -> notificationService.createPriceTargetNotification(saved, card.getName(), reachedTargetPrice));
+                notifyIfTargetAlreadyReached(saved, reachedTargetPrice);
             }
             return WatchlistResponse.of(saved, targetReached);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
+    }
+
+    private void notifyIfTargetAlreadyReached(Watchlist saved, Integer reachedTargetPrice) {
+        cardRepository.findById(saved.getCardId())
+                .ifPresent(card -> notificationService.createPriceTargetNotification(saved, card.getName(), reachedTargetPrice));
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -77,14 +77,29 @@ public class WatchlistService {
             boolean targetReached = reachedTargetPrice != null;
             // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
             // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
-            if (targetReached) {
-                saved.markAsNotified();
-                notifyIfTargetAlreadyReached(saved, reachedTargetPrice);
-            }
+            notifyIfNewlyReached(saved, reachedTargetPrice);
             return WatchlistResponse.of(saved, targetReached);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
+    }
+
+    // 목표가에 새로 도달한 경우(아직 알림 안 간 상태에서 도달)에만 markAsNotified + 실제 알림 생성을 한다.
+    // "이미 알림 갔는지"는 메모리 값이 아니라 markAsNotifiedIfNotYet()의 원자적 조건부 UPDATE(DB 기준)로
+    // 판정한다 - 배치(WatchlistTargetPriceNoticeProcessor)가 그 사이 먼저 선점했을 수 있어서, 메모리에 로드된
+    // isNotified만 믿으면 중복 알림이 생길 수 있다. claimed>0일 때만 엔티티도 true로 맞춰서, 이 메서드가
+    // 반환하는 WatchlistResponse의 isNotified가 실제 DB 상태와 일치하게 한다(배치는 응답 DTO가 없어서 이
+    // 동기화가 필요 없었던 것과 다른 점).
+    private void notifyIfNewlyReached(Watchlist watchlist, Integer reachedTargetPrice) {
+        if (reachedTargetPrice == null) {
+            return;
+        }
+        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
+        if (claimed == 0) {
+            return;
+        }
+        watchlist.markAsNotified();
+        notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
     }
 
     private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
@@ -171,12 +186,7 @@ public class WatchlistService {
                 .orElse(null);
         Integer reachedTargetPrice = resolveReachedTargetPrice(watchlist, range);
         boolean targetReached = reachedTargetPrice != null;
-        // isNotified가 false인 상태에서 도달했을 때만 알린다 - 가격변경으로 리셋됐든 resend로 리셋됐든
-        // 이유는 안 가리고, 이미 true면(직전에 같은 요청에서 방금 알렸어도) 중복으로 다시 알리지 않는다.
-        if (targetReached && !watchlist.isNotified()) {
-            watchlist.markAsNotified();
-            notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
-        }
+        notifyIfNewlyReached(watchlist, reachedTargetPrice);
         return WatchlistResponse.of(watchlist, targetReached);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -65,7 +65,19 @@ public class WatchlistService {
         // 위 잠금으로 정상 경로에서는 걸릴 일이 없지만, 방어적으로 DB UNIQUE 제약 위반도 안전하게 변환한다.
         try {
             Watchlist saved = watchlistRepository.save(watchlist);
-            return WatchlistResponse.of(saved);
+
+            PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
+                    .findPriceRangesByCardIds(List.of(saved.getCardId()), null, TradeStatus.COMPLETED)
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
+            boolean targetReached = isTargetReached(saved, range);
+            // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
+            // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차를 없애기 위함.
+            if (targetReached) {
+                saved.markAsNotified();
+            }
+            return WatchlistResponse.of(saved, targetReached);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -142,7 +142,13 @@ public class WatchlistService {
         if (resend) {
             watchlist.requestNotificationAgain();
         }
-        return WatchlistResponse.of(watchlist);
+
+        PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
+                .findPriceRangesByCardIds(List.of(watchlist.getCardId()), null, TradeStatus.COMPLETED)
+                .stream()
+                .findFirst()
+                .orElse(null);
+        return WatchlistResponse.of(watchlist, isTargetReached(watchlist, range));
     }
 
     private void validateAtLeastOneTargetPrice(Integer targetBuyPrice, Integer targetSellPrice) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -87,9 +87,9 @@ public class WatchlistService {
         }
     }
 
-    private void notifyIfTargetAlreadyReached(Watchlist saved, Integer reachedTargetPrice) {
-        cardRepository.findById(saved.getCardId())
-                .ifPresent(card -> notificationService.createPriceTargetNotification(saved, card.getName(), reachedTargetPrice));
+    private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
+        cardRepository.findById(watchlist.getCardId())
+                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice));
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {
@@ -169,7 +169,15 @@ public class WatchlistService {
                 .stream()
                 .findFirst()
                 .orElse(null);
-        return WatchlistResponse.of(watchlist, isTargetReached(watchlist, range));
+        Integer reachedTargetPrice = resolveReachedTargetPrice(watchlist, range);
+        boolean targetReached = reachedTargetPrice != null;
+        // isNotified가 false인 상태에서 도달했을 때만 알린다 - 가격변경으로 리셋됐든 resend로 리셋됐든
+        // 이유는 안 가리고, 이미 true면(직전에 같은 요청에서 방금 알렸어도) 중복으로 다시 알리지 않는다.
+        if (targetReached && !watchlist.isNotified()) {
+            watchlist.markAsNotified();
+            notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
+        }
+        return WatchlistResponse.of(watchlist, targetReached);
     }
 
     private void validateAtLeastOneTargetPrice(Integer targetBuyPrice, Integer targetSellPrice) {

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -18,6 +18,7 @@ import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
 import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -33,11 +34,13 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -187,6 +190,26 @@ class WatchlistControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id").value(1L))
                 .andExpect(jsonPath("$.data.targetBuyPrice").value(20000));
+    }
+
+    @Test
+    void 목표가_수정_요청의_resendNotification_필드가_실제로_역직렬화된다() throws Exception {
+        WatchlistResponse response = new WatchlistResponse(
+                1L, 1L, null, null, null, null, null, 1000, null, false, LocalDateTime.now(), null, null, false);
+
+        given(watchlistService.updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/api/watchlist/1")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"resendNotification\":true}"))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<WatchlistUpdateRequest> requestCaptor = ArgumentCaptor.forClass(WatchlistUpdateRequest.class);
+        verify(watchlistService).updateWatchlist(anyLong(), anyLong(), requestCaptor.capture());
+        assertThat(requestCaptor.getValue().resendNotification()).isTrue();
+        assertThat(requestCaptor.getValue().targetBuyPrice()).isNull();
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
@@ -33,7 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 // WatchlistService.addWatchlist()의 동시 등록 방어(유저 단위 잠금 + UNIQUE 위반 변환)를 실제 DB로 검증한다.
-// addWatchlist()가 PriceService/CardRepository/PriceTradeStatsRepository를 쓰지 않으므로, 실제 빈이 아니라
+// 여기서 검증하는 중복/제한 체크는 targetReached(체결가 조회) 결과와 무관하고, mock인 PriceTradeStatsRepository는
+// 기본값(빈 리스트)만 반환해 항상 targetReached=false로 끝나므로(CardRepository/NotificationService 호출 없음)
 // WatchlistRepository만 진짜로 연결하고 나머지는 mock으로 채운 WatchlistService를 직접 생성해 사용한다.
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -50,7 +52,8 @@ class WatchlistConcurrencyTest {
 
     private WatchlistService newWatchlistService() {
         return new WatchlistService(watchlistRepository, mock(PriceService.class),
-                mock(CardRepository.class), mock(PriceTradeStatsRepository.class), mock(CardNameKoResolver.class));
+                mock(CardRepository.class), mock(PriceTradeStatsRepository.class), mock(CardNameKoResolver.class),
+                mock(NotificationService.class));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -123,6 +123,7 @@ class WatchlistServiceTest {
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
         Card card = Card.builder().id(1L).name("리자몽").build();
@@ -159,6 +160,7 @@ class WatchlistServiceTest {
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
         given(cardRepository.findById(1L)).willReturn(Optional.empty());
@@ -466,6 +468,23 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(9000, null, null));
 
         assertThat(response.targetReached()).isFalse();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("수정: 배치가 그 사이 먼저 선점했으면(claimed=0) 도달 상태여도 중복 알림을 만들지 않는다")
+    void updateWatchlist_batchAlreadyClaimed_skipsDuplicateNotification() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false(메모리 스냅샷 - 배치가 이미 선점한 상황을 재현)
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(0);
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isFalse();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
     }
 
     @Test
@@ -473,6 +492,7 @@ class WatchlistServiceTest {
     void updateWatchlist_newlyReachedByPriceChange_marksNotifiedAndNotifies() {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
@@ -507,6 +527,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
         target.markAsNotified();
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 800, 1200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
@@ -523,6 +544,7 @@ class WatchlistServiceTest {
     void updateWatchlist_resendAndPriceChangeBothReached_notifiesOnce() {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
@@ -539,6 +561,7 @@ class WatchlistServiceTest {
     void updateWatchlist_targetReachedButCardNotFound_skipsNotification() {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         given(cardRepository.findById(10L)).willReturn(Optional.empty());

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -384,6 +384,33 @@ class WatchlistServiceTest {
         assertThat(response.isNotified()).isFalse();
     }
 
+    @Test
+    @DisplayName("수정: 변경된 목표가가 체결가 구간 안에 있으면 targetReached=true가 실제로 반영된다")
+    void updateWatchlist_targetReached_reflectsActualPriceRange() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetBuyPrice()).isEqualTo(2000);
+        assertThat(response.targetReached()).isTrue();
+    }
+
+    @Test
+    @DisplayName("수정: 변경된 목표가가 체결가 구간 밖이면 targetReached=false로 유지된다")
+    void updateWatchlist_targetReached_falseWhenOutOfRange() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(9000, null, null));
+
+        assertThat(response.targetReached()).isFalse();
+    }
+
     // ===== 삭제 =====
     @Test
     @DisplayName("삭제: 존재하지 않으면 WATCHLIST_NOT_FOUND")

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -35,6 +35,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class WatchlistServiceTest {
@@ -465,6 +466,88 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(9000, null, null));
 
         assertThat(response.targetReached()).isFalse();
+    }
+
+    @Test
+    @DisplayName("수정: 미도달 상태에서 가격 변경으로 새로 도달하면 isNotified=true가 되고 실제 알림이 생성된다")
+    void updateWatchlist_newlyReachedByPriceChange_marksNotifiedAndNotifies() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+        given(cardRepository.findById(10L)).willReturn(Optional.of(card));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
+    }
+
+    @Test
+    @DisplayName("수정: 이미 알림이 간 상태에서 가격 변경 없이(no-op) 수정하면 도달해 있어도 다시 알리지 않는다")
+    void updateWatchlist_alreadyNotified_samePrice_doesNotReNotify() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 800, 1200)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null, null));
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("수정: 이미 도달 범위 안인 상태에서 재알림(resend) 요청만 오면 즉시 다시 알림이 생성된다")
+    void updateWatchlist_resendWhenAlreadyInRange_notifiesImmediately() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 800, 1200)));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+        given(cardRepository.findById(10L)).willReturn(Optional.of(card));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(null, null, true));
+
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(1000));
+    }
+
+    @Test
+    @DisplayName("수정: resend와 가격변경(신규 도달)이 동시에 와도 알림은 정확히 한 번만 생성된다")
+    void updateWatchlist_resendAndPriceChangeBothReached_notifiesOnce() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+        Card card = Card.builder().id(10L).name("리자몽").build();
+        given(cardRepository.findById(10L)).willReturn(Optional.of(card));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, true));
+
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should(times(1)).createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
+    }
+
+    @Test
+    @DisplayName("수정: 목표가 도달했지만 카드를 찾지 못하면 알림 생성은 스킵되고 targetReached/isNotified는 정상 반영된다")
+    void updateWatchlist_targetReachedButCardNotFound_skipsNotification() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
+        given(cardRepository.findById(10L)).willReturn(Optional.empty());
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
     }
 
     // ===== 삭제 =====

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.watchlist.service;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
@@ -43,6 +44,7 @@ class WatchlistServiceTest {
     @Mock CardRepository cardRepository;
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
     @Mock CardNameKoResolver cardNameKoResolver;
+    @Mock NotificationService notificationService;
     @InjectMocks WatchlistService watchlistService;
 
     private Watchlist watchlist(Long userId, Long cardId) {
@@ -122,11 +124,14 @@ class WatchlistServiceTest {
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
         given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
+        Card card = Card.builder().id(1L).name("리자몽").build();
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
 
         WatchlistResponse response = watchlistService.addWatchlist(1L, request);
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
     }
 
     @Test
@@ -143,6 +148,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isFalse();
         assertThat(response.isNotified()).isFalse();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -152,6 +152,24 @@ class WatchlistServiceTest {
     }
 
     @Test
+    @DisplayName("등록: 목표가 도달했지만 카드를 찾지 못하면 알림 생성은 스킵되고 targetReached/isNotified는 정상 반영된다")
+    void addWatchlist_targetReachedButCardNotFound_skipsNotification() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 2000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
+        given(cardRepository.findById(1L)).willReturn(Optional.empty());
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isTrue();
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+    }
+
+    @Test
     @DisplayName("등록: 사전 체크를 통과했지만 저장 시점에 DB UNIQUE 제약을 위반하면(동시 등록 경합) DUPLICATE_WATCHLIST로 변환된다")
     void addWatchlist_saveThrowsDataIntegrityViolation_convertsToDuplicateWatchlist() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -114,6 +114,38 @@ class WatchlistServiceTest {
     }
 
     @Test
+    @DisplayName("등록: 등록 시점에 이미 체결가가 목표가 구간 안이면 targetReached=true와 isNotified=true가 함께 반영된다")
+    void addWatchlist_targetAlreadyReached_marksAsNotified() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 2000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.targetReached()).isTrue();
+        assertThat(response.isNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("등록: 체결가가 목표가 구간 밖이면 targetReached/isNotified 모두 false로 유지된다")
+    void addWatchlist_targetNotReached_keepsNotifiedFalse() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 9000, null);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.targetReached()).isFalse();
+        assertThat(response.isNotified()).isFalse();
+    }
+
+    @Test
     @DisplayName("등록: 사전 체크를 통과했지만 저장 시점에 DB UNIQUE 제약을 위반하면(동시 등록 경합) DUPLICATE_WATCHLIST로 변환된다")
     void addWatchlist_saveThrowsDataIntegrityViolation_convertsToDuplicateWatchlist() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -106,7 +106,8 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
 
         NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore());
         WatchlistService watchlistService = new WatchlistService(watchlistRepository,
-                mock(PriceService.class), cardRepository, priceTradeStatsRepository, mock(CardNameKoResolver.class));
+                mock(PriceService.class), cardRepository, priceTradeStatsRepository, mock(CardNameKoResolver.class),
+                notificationService);
         WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(
                 watchlistRepository, priceTradeStatsRepository, notificationService, watchlistService);
 


### PR DESCRIPTION
## 📌 관련 이슈
- #250 

## ✨ 작업 내용
- 목표가 수정/등록 시 targetReached가 항상 false로 와서 상태 배지가 새로고침 전까지 안 바뀌던 버그 수정 
  (updateWatchlist/addWatchlist 둘 다 실제 계산값 반영)
- 이미 도달한 경우 배치를 기다리지 않고 즉시 실제 알림 생성 + SSE push
- 배치와 API가 동시에 처리할 때 생기는 중복 알림 레이스를 원자적 UPDATE로 해결
- resendNotification 필드 JSON 역직렬화 검증 테스트 추가
- 목표가 부분 업데이트 시 다른 값이 지워지던 버그 수정

## 📸 스크린샷 / 테스트 결과
- 신규/보강 테스트 다수, 기존 테스트 영향 없음
- 실서버 curl로 targetReached 정확성 및 중복 알림 방지 재현 검증

## 🔍 리뷰 포인트
- 실제 스레드 동시성 테스트는 이번 범위 제외 - 단위테스트+curl 검증으로 충분하다 판단, 필요시 후속 개선

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?