### PR TITLE
[Fix] develop→main 자동 승격이 브랜치 정책에 막혀 배포가 중단되는 문제

### DIFF
--- a/.github/workflows/auto-promote-to-main.yml
+++ b/.github/workflows/auto-promote-to-main.yml
@@ -70,7 +70,11 @@ jobs:
 
       # --match-head-commit: PR HEAD가 이 워크플로가 빌드한 커밋과 다르면 병합을 거부한다.
       # 그 사이 develop이 갱신됐다는 뜻이므로, 검증되지 않은 변경이 main에 들어가지 않도록 실패시킨다.
+      #
+      # --admin: main 룰셋이 승인 4명을 요구하는데 자동 생성 PR에는 승인이 모이지 않는다.
+      # PROMOTE_TOKEN 소유자는 룰셋 bypass 허용자이므로, gh의 사전 검사를 건너뛰고 병합한다.
+      # (--auto는 답이 아니다 — 승인이 채워질 때까지 대기만 해서 워크플로만 초록불이 되고 배포는 안 된다.)
       - name: Merge PR
         run: |
-          gh pr merge ${{ steps.pr.outputs.number }} --merge \
+          gh pr merge ${{ steps.pr.outputs.number }} --merge --admin \
             --match-head-commit "${{ github.sha }}"


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (배포 파이프라인 긴급 수정)

## ✨ 작업 내용
- 승격 워크플로의 병합 명령에 `--admin` 추가

`develop → main` 자동 승격이 2026-08-18 06:39부터 실패해 **배포가 중단**됐습니다. 오늘 밀린 9커밋은 수동 bypass 병합으로 내보냈지만, 워크플로는 고장난 상태 그대로라 다음 push부터 다시 멈춥니다.

**원인**
- `main`에 룰셋(`main protection`)이 걸려 있고 **승인 리뷰 4명**을 요구합니다. 자동 생성되는 승격 PR에는 승인이 모이지 않습니다
- 실패 메시지(`the base branch policy prohibits the merge`)는 GitHub API가 거부한 것이 아니라 **gh CLI가 PR 상태(BLOCKED)를 보고 스스로 중단한 것**입니다. gh 자체가 로그에서 `--auto` 또는 `--admin` 사용을 안내했습니다
- `PROMOTE_TOKEN` 소유자는 룰셋의 bypass 허용자입니다. 실제로 사람이 UI에서 bypass 병합했을 때는 정상 통과했습니다

**왜 `--auto`가 아니라 `--admin`인가**
`--auto`는 정책을 우회하지 않고 **조건이 충족될 때까지 대기**합니다. 승인 4명이 영원히 모이지 않으므로 PR은 열린 채 남고 배포도 안 됩니다. 워크플로만 초록불이 되어 **실패가 눈에 띄지 않게 되는 쪽이 더 위험**하다고 판단했습니다. `--admin`은 gh의 사전 검사를 건너뛰고 병합을 시도하므로 bypass 권한이 있는 한 즉시 승격됩니다.

`--admin`으로도 실패한다면 토큰이 실제로 우회 권한을 잃은 것이고, 그때는 조용히 대기하는 대신 **실패해서 사람이 알아채는 것이 맞습니다.**

## 📸 스크린샷 / 테스트 결과
- YAML 파싱 확인: promote 잡의 스텝 4개 구조 유지, `Check PROMOTE_TOKEN`의 `if`/`fi` 정상
- 실제 검증은 이 PR이 develop에 머지되는 순간 승격 워크플로가 돌면서 이뤄집니다. 그 실행이 `success`이고 main이 갱신되면 해결된 것입니다

## 🔍 리뷰 포인트
- 이건 증상 대응입니다. 근본 원인은 **배포 파이프라인이 팀원 한 명의 개인 토큰(`PROMOTE_TOKEN`)에 묶여 있다는 점**이고, 그 토큰의 권한이 오늘 어떤 이유로 바뀐 것으로 보입니다. 토큰 재발급 또는 봇/Actions로의 이전은 별도 논의가 필요합니다
- `--match-head-commit` 안전장치는 그대로 유지했습니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가? — 워크플로 파일만 변경
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 해당 없음