### PR TITLE
[Feature] #247 게시글 형태의 1:1 문의 시스템 구현

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
@@ -1,30 +1,48 @@
 package com.pokade.domain.admin.controller;
 
+import com.pokade.domain.admin.dto.request.InquiryStatusUpdateRequest;
 import com.pokade.domain.admin.service.AdminInquiryService;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin/inquiries")
 @RequiredArgsConstructor
 public class AdminInquiryController {
 
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
     private final AdminInquiryService adminInquiryService;
 
     @GetMapping
-    public ApiResponse<List<InquiryResponse>> getInquiries() {
-        return ApiResponse.ok(adminInquiryService.getInquiries());
+    public ApiResponse<Page<InquiryResponse>> getInquiries(
+            @RequestParam(required = false) InquiryCategory category,
+            @PageableDefault(size = DEFAULT_PAGE_SIZE) Pageable pageable) {
+        return ApiResponse.ok(adminInquiryService.getInquiries(category, pageable));
     }
 
     @GetMapping("/{id}")
     public ApiResponse<InquiryResponse> getInquiry(@PathVariable Long id) {
         return ApiResponse.ok(adminInquiryService.getInquiry(id));
+    }
+
+    @PatchMapping("/{id}/status")
+    public ApiResponse<InquiryResponse> updateStatus(
+            @PathVariable Long id,
+            @Valid @RequestBody InquiryStatusUpdateRequest request) {
+        return ApiResponse.ok(adminInquiryService.updateStatus(id, request.status()));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
@@ -1,0 +1,30 @@
+package com.pokade.domain.admin.controller;
+
+import com.pokade.domain.admin.service.AdminInquiryService;
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/inquiries")
+@RequiredArgsConstructor
+public class AdminInquiryController {
+
+    private final AdminInquiryService adminInquiryService;
+
+    @GetMapping
+    public ApiResponse<List<InquiryResponse>> getInquiries() {
+        return ApiResponse.ok(adminInquiryService.getInquiries());
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<InquiryResponse> getInquiry(@PathVariable Long id) {
+        return ApiResponse.ok(adminInquiryService.getInquiry(id));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminInquiryController.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.admin.controller;
 
+import com.pokade.domain.admin.dto.request.InquiryAnswerRequest;
 import com.pokade.domain.admin.dto.request.InquiryStatusUpdateRequest;
 import com.pokade.domain.admin.service.AdminInquiryService;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
@@ -44,5 +45,12 @@ public class AdminInquiryController {
             @PathVariable Long id,
             @Valid @RequestBody InquiryStatusUpdateRequest request) {
         return ApiResponse.ok(adminInquiryService.updateStatus(id, request.status()));
+    }
+
+    @PatchMapping("/{id}/answer")
+    public ApiResponse<InquiryResponse> answerInquiry(
+            @PathVariable Long id,
+            @Valid @RequestBody InquiryAnswerRequest request) {
+        return ApiResponse.ok("답변이 등록되었습니다.", adminInquiryService.answerInquiry(id, request.content()));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/admin/dto/request/InquiryAnswerRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/dto/request/InquiryAnswerRequest.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record InquiryAnswerRequest(
+        @NotBlank(message = "답변 내용은 필수입니다.")
+        String content
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/dto/request/InquiryStatusUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/dto/request/InquiryStatusUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.pokade.domain.admin.dto.request;
+
+import com.pokade.domain.inquiry.entity.InquiryStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record InquiryStatusUpdateRequest(
+        @NotNull(message = "상태 값은 필수입니다.")
+        InquiryStatus status
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -58,6 +58,17 @@ public class AdminInquiryService {
         return InquiryResponse.of(inquiry, imageUrls);
     }
 
+    @Transactional
+    public InquiryResponse answerInquiry(Long id, String content) {
+        Inquiry inquiry = inquiryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.answer(content);
+        List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
+                .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
+                .toList();
+        return InquiryResponse.of(inquiry, imageUrls);
+    }
+
     private Map<Long, List<String>> loadImageUrls(List<Inquiry> inquiries) {
         if (inquiries.isEmpty()) {
             return Map.of();

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -68,8 +68,11 @@ public class AdminInquiryService {
     public InquiryResponse answerInquiry(Long id, String content) {
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        boolean isFirstAnswer = inquiry.getAnswerContent() == null;
         inquiry.answer(content);
-        notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
+        if (isFirstAnswer) {
+            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
+        }
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
                 .toList();

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -7,6 +7,7 @@ import com.pokade.domain.inquiry.entity.InquiryImage;
 import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
@@ -28,6 +29,7 @@ public class AdminInquiryService {
     private final InquiryRepository inquiryRepository;
     private final InquiryImageRepository inquiryImageRepository;
     private final S3FileStorage s3FileStorage;
+    private final NotificationService notificationService;
 
     public Page<InquiryResponse> getInquiries(InquiryCategory category, Pageable pageable) {
         Page<Inquiry> inquiries = category != null
@@ -51,7 +53,11 @@ public class AdminInquiryService {
     public InquiryResponse updateStatus(Long id, InquiryStatus status) {
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        InquiryStatus previousStatus = inquiry.getStatus();
         inquiry.changeStatus(status);
+        if (previousStatus != InquiryStatus.HANDLED && status == InquiryStatus.HANDLED) {
+            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
+        }
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
                 .toList();
@@ -63,6 +69,7 @@ public class AdminInquiryService {
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
         inquiry.answer(content);
+        notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
                 .toList();

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -2,14 +2,19 @@ package com.pokade.domain.admin.service;
 
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,16 +22,34 @@ import java.util.List;
 public class AdminInquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryImageRepository inquiryImageRepository;
+    private final S3FileStorage s3FileStorage;
 
     public List<InquiryResponse> getInquiries() {
-        return inquiryRepository.findAllByOrderByCreatedAtDesc().stream()
-                .map(InquiryResponse::of)
+        List<Inquiry> inquiries = inquiryRepository.findAllByOrderByCreatedAtDesc();
+        Map<Long, List<String>> imageUrlsByInquiryId = loadImageUrls(inquiries);
+        return inquiries.stream()
+                .map(inquiry -> InquiryResponse.of(inquiry, imageUrlsByInquiryId.getOrDefault(inquiry.getId(), List.of())))
                 .toList();
     }
 
     public InquiryResponse getInquiry(Long id) {
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
-        return InquiryResponse.of(inquiry);
+        List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
+                .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
+                .toList();
+        return InquiryResponse.of(inquiry, imageUrls);
+    }
+
+    private Map<Long, List<String>> loadImageUrls(List<Inquiry> inquiries) {
+        if (inquiries.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> ids = inquiries.stream().map(Inquiry::getId).toList();
+        return inquiryImageRepository.findByInquiryIdInOrderByIdAsc(ids).stream()
+                .collect(Collectors.groupingBy(
+                        InquiryImage::getInquiryId,
+                        Collectors.mapping(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()), Collectors.toList())));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -1,0 +1,32 @@
+package com.pokade.domain.admin.service;
+
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminInquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    public List<InquiryResponse> getInquiries() {
+        return inquiryRepository.findAllByOrderByCreatedAtDesc().stream()
+                .map(InquiryResponse::of)
+                .toList();
+    }
+
+    public InquiryResponse getInquiry(Long id) {
+        Inquiry inquiry = inquiryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        return InquiryResponse.of(inquiry);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -2,13 +2,17 @@ package com.pokade.domain.admin.service;
 
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,17 +29,29 @@ public class AdminInquiryService {
     private final InquiryImageRepository inquiryImageRepository;
     private final S3FileStorage s3FileStorage;
 
-    public List<InquiryResponse> getInquiries() {
-        List<Inquiry> inquiries = inquiryRepository.findAllByOrderByCreatedAtDesc();
-        Map<Long, List<String>> imageUrlsByInquiryId = loadImageUrls(inquiries);
-        return inquiries.stream()
-                .map(inquiry -> InquiryResponse.of(inquiry, imageUrlsByInquiryId.getOrDefault(inquiry.getId(), List.of())))
-                .toList();
+    public Page<InquiryResponse> getInquiries(InquiryCategory category, Pageable pageable) {
+        Page<Inquiry> inquiries = category != null
+                ? inquiryRepository.findByCategoryOrderByCreatedAtDesc(category, pageable)
+                : inquiryRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Map<Long, List<String>> imageUrlsByInquiryId = loadImageUrls(inquiries.getContent());
+        return inquiries.map(inquiry ->
+                InquiryResponse.of(inquiry, imageUrlsByInquiryId.getOrDefault(inquiry.getId(), List.of())));
     }
 
     public InquiryResponse getInquiry(Long id) {
         Inquiry inquiry = inquiryRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
+                .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
+                .toList();
+        return InquiryResponse.of(inquiry, imageUrls);
+    }
+
+    @Transactional
+    public InquiryResponse updateStatus(Long id, InquiryStatus status) {
+        Inquiry inquiry = inquiryRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        inquiry.changeStatus(status);
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
                 .toList();

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
@@ -6,12 +6,14 @@ import com.pokade.domain.inquiry.service.InquiryService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -22,11 +24,12 @@ public class InquiryController {
 
     private final InquiryService inquiryService;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<InquiryResponse> createInquiry(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody InquiryCreateRequest request) {
-        return ApiResponse.ok("문의가 접수되었습니다.", inquiryService.createInquiry(userId, request));
+            @Valid @RequestPart("request") InquiryCreateRequest request,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images) {
+        return ApiResponse.ok("문의가 접수되었습니다.", inquiryService.createInquiry(userId, request, images));
     }
 
     @GetMapping("/me")

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.inquiry.controller;
+
+import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.service.InquiryService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    @PostMapping
+    public ApiResponse<InquiryResponse> createInquiry(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody InquiryCreateRequest request) {
+        return ApiResponse.ok("문의가 접수되었습니다.", inquiryService.createInquiry(userId, request));
+    }
+
+    @GetMapping("/me")
+    public ApiResponse<List<InquiryResponse>> getMyInquiries(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.ok(inquiryService.getMyInquiries(userId));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryCreateRequest.java
@@ -1,9 +1,13 @@
 package com.pokade.domain.inquiry.dto.request;
 
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record InquiryCreateRequest(
+        @NotNull(message = "문의 유형은 필수입니다.")
+        InquiryCategory category,
         @NotBlank(message = "제목은 필수입니다.")
         @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
         String title,

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryCreateRequest.java
@@ -1,0 +1,13 @@
+package com.pokade.domain.inquiry.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InquiryCreateRequest(
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        String title,
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
@@ -1,0 +1,24 @@
+package com.pokade.domain.inquiry.dto.response;
+
+import com.pokade.domain.inquiry.entity.Inquiry;
+
+import java.time.LocalDateTime;
+
+public record InquiryResponse(
+        Long id,
+        Long userId,
+        String title,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static InquiryResponse of(Inquiry inquiry) {
+        return new InquiryResponse(
+                inquiry.getId(),
+                inquiry.getUserId(),
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                inquiry.getCreatedAt()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
@@ -15,7 +15,9 @@ public record InquiryResponse(
         String title,
         String content,
         List<String> imageUrls,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        String answerContent,
+        LocalDateTime answeredAt
 ) {
 
     public static InquiryResponse of(Inquiry inquiry, List<String> imageUrls) {
@@ -27,7 +29,9 @@ public record InquiryResponse(
                 inquiry.getTitle(),
                 inquiry.getContent(),
                 imageUrls,
-                inquiry.getCreatedAt()
+                inquiry.getCreatedAt(),
+                inquiry.getAnswerContent(),
+                inquiry.getAnsweredAt()
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
@@ -2,6 +2,7 @@ package com.pokade.domain.inquiry.dto.response;
 
 import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,6 +11,7 @@ public record InquiryResponse(
         Long id,
         Long userId,
         InquiryCategory category,
+        InquiryStatus status,
         String title,
         String content,
         List<String> imageUrls,
@@ -21,6 +23,7 @@ public record InquiryResponse(
                 inquiry.getId(),
                 inquiry.getUserId(),
                 inquiry.getCategory(),
+                inquiry.getStatus(),
                 inquiry.getTitle(),
                 inquiry.getContent(),
                 imageUrls,

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/response/InquiryResponse.java
@@ -1,23 +1,29 @@
 package com.pokade.domain.inquiry.dto.response;
 
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record InquiryResponse(
         Long id,
         Long userId,
+        InquiryCategory category,
         String title,
         String content,
+        List<String> imageUrls,
         LocalDateTime createdAt
 ) {
 
-    public static InquiryResponse of(Inquiry inquiry) {
+    public static InquiryResponse of(Inquiry inquiry, List<String> imageUrls) {
         return new InquiryResponse(
                 inquiry.getId(),
                 inquiry.getUserId(),
+                inquiry.getCategory(),
                 inquiry.getTitle(),
                 inquiry.getContent(),
+                imageUrls,
                 inquiry.getCreatedAt()
         );
     }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
@@ -1,0 +1,47 @@
+package com.pokade.domain.inquiry.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "inquiries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inquiry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // User 엔티티는 별도 담당자 파트 - FK만 보관
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Inquiry(Long userId, String title, String content) {
+        this.userId = userId;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
@@ -44,6 +44,12 @@ public class Inquiry {
     @Column(nullable = false, length = 20)
     private InquiryStatus status;
 
+    @Column(name = "answer_content", columnDefinition = "TEXT")
+    private String answerContent;
+
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -59,5 +65,11 @@ public class Inquiry {
 
     public void changeStatus(InquiryStatus status) {
         this.status = status;
+    }
+
+    public void answer(String answerContent) {
+        this.answerContent = answerContent;
+        this.answeredAt = LocalDateTime.now();
+        this.status = InquiryStatus.HANDLED;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
@@ -40,6 +40,10 @@ public class Inquiry {
     @Column(nullable = false, length = 20)
     private InquiryCategory category;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InquiryStatus status;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -50,5 +54,10 @@ public class Inquiry {
         this.title = title;
         this.content = content;
         this.category = category;
+        this.status = InquiryStatus.UNHANDLED;
+    }
+
+    public void changeStatus(InquiryStatus status) {
+        this.status = status;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
@@ -2,6 +2,8 @@ package com.pokade.domain.inquiry.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,14 +36,19 @@ public class Inquiry {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InquiryCategory category;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
-    public Inquiry(Long userId, String title, String content) {
+    public Inquiry(Long userId, String title, String content, InquiryCategory category) {
         this.userId = userId;
         this.title = title;
         this.content = content;
+        this.category = category;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryCategory.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryCategory.java
@@ -1,0 +1,8 @@
+package com.pokade.domain.inquiry.entity;
+
+public enum InquiryCategory {
+    INFO,
+    SECURITY,
+    PAYMENT,
+    ETC
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryImage.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryImage.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.inquiry.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiry_images")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InquiryImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "inquiry_id", nullable = false)
+    private Long inquiryId;
+
+    // S3 key를 저장한다 (버킷이 프라이빗이라 실제 URL은 조회 시점에 presigned URL로 발급) - S3FileStorage 참고
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Builder
+    public InquiryImage(Long inquiryId, String imageUrl) {
+        this.inquiryId = inquiryId;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryStatus.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/InquiryStatus.java
@@ -1,0 +1,6 @@
+package com.pokade.domain.inquiry.entity;
+
+public enum InquiryStatus {
+    UNHANDLED,
+    HANDLED
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryImageRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryImageRepository.java
@@ -1,0 +1,13 @@
+package com.pokade.domain.inquiry.repository;
+
+import com.pokade.domain.inquiry.entity.InquiryImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryImageRepository extends JpaRepository<InquiryImage, Long> {
+
+    List<InquiryImage> findByInquiryIdOrderByIdAsc(Long inquiryId);
+
+    List<InquiryImage> findByInquiryIdInOrderByIdAsc(List<Long> inquiryIds);
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,13 @@
+package com.pokade.domain.inquiry.repository;
+
+import com.pokade.domain.inquiry.entity.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+
+    List<Inquiry> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    List<Inquiry> findAllByOrderByCreatedAtDesc();
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryRepository.java
@@ -1,6 +1,9 @@
 package com.pokade.domain.inquiry.repository;
 
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +12,7 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
     List<Inquiry> findByUserIdOrderByCreatedAtDesc(Long userId);
 
-    List<Inquiry> findAllByOrderByCreatedAtDesc();
+    Page<Inquiry> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Page<Inquiry> findByCategoryOrderByCreatedAtDesc(InquiryCategory category, Pageable pageable);
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.inquiry.service;
+
+import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Transactional
+    public InquiryResponse createInquiry(Long userId, InquiryCreateRequest request) {
+        Inquiry inquiry = Inquiry.builder()
+                .userId(userId)
+                .title(request.title())
+                .content(request.content())
+                .build();
+        inquiryRepository.save(inquiry);
+        return InquiryResponse.of(inquiry);
+    }
+
+    public List<InquiryResponse> getMyInquiries(Long userId) {
+        return inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(InquiryResponse::of)
+                .toList();
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
@@ -3,34 +3,92 @@ package com.pokade.domain.inquiry.service;
 import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class InquiryService {
 
+    private static final int MAX_IMAGE_COUNT = 3;
+    private static final long MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/jpg", "image/png");
+    private static final String FOLDER = "inquiries";
+
     private final InquiryRepository inquiryRepository;
+    private final InquiryImageRepository inquiryImageRepository;
+    private final S3FileStorage s3FileStorage;
 
     @Transactional
-    public InquiryResponse createInquiry(Long userId, InquiryCreateRequest request) {
+    public InquiryResponse createInquiry(Long userId, InquiryCreateRequest request, List<MultipartFile> images) {
+        List<MultipartFile> files = images == null ? List.of() : images;
+        validateImages(files);
+
         Inquiry inquiry = Inquiry.builder()
                 .userId(userId)
                 .title(request.title())
                 .content(request.content())
+                .category(request.category())
                 .build();
         inquiryRepository.save(inquiry);
-        return InquiryResponse.of(inquiry);
+
+        List<String> imageUrls = files.stream()
+                .map(file -> s3FileStorage.upload(file, FOLDER))
+                .peek(key -> inquiryImageRepository.save(
+                        InquiryImage.builder().inquiryId(inquiry.getId()).imageUrl(key).build()))
+                .map(s3FileStorage::generatePresignedUrl)
+                .toList();
+
+        return InquiryResponse.of(inquiry, imageUrls);
     }
 
     public List<InquiryResponse> getMyInquiries(Long userId) {
-        return inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
-                .map(InquiryResponse::of)
+        List<Inquiry> inquiries = inquiryRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        Map<Long, List<String>> imageUrlsByInquiryId = loadImageUrls(inquiries);
+        return inquiries.stream()
+                .map(inquiry -> InquiryResponse.of(inquiry, imageUrlsByInquiryId.getOrDefault(inquiry.getId(), List.of())))
                 .toList();
+    }
+
+    private void validateImages(List<MultipartFile> files) {
+        if (files.size() > MAX_IMAGE_COUNT) {
+            throw new BusinessException(ErrorCode.INQUIRY_IMAGE_LIMIT_EXCEEDED);
+        }
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+            if (file.getSize() > MAX_IMAGE_SIZE_BYTES) {
+                throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
+            }
+            if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+                throw new BusinessException(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+            }
+        }
+    }
+
+    private Map<Long, List<String>> loadImageUrls(List<Inquiry> inquiries) {
+        if (inquiries.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> ids = inquiries.stream().map(Inquiry::getId).toList();
+        return inquiryImageRepository.findByInquiryIdInOrderByIdAsc(ids).stream()
+                .collect(Collectors.groupingBy(
+                        InquiryImage::getInquiryId,
+                        Collectors.mapping(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()), Collectors.toList())));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
@@ -10,15 +10,20 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -46,14 +51,35 @@ public class InquiryService {
                 .build();
         inquiryRepository.save(inquiry);
 
-        List<String> imageUrls = files.stream()
-                .map(file -> s3FileStorage.upload(file, FOLDER))
-                .peek(key -> inquiryImageRepository.save(
-                        InquiryImage.builder().inquiryId(inquiry.getId()).imageUrl(key).build()))
-                .map(s3FileStorage::generatePresignedUrl)
-                .toList();
+        List<String> imageUrls = uploadImages(inquiry.getId(), files);
 
         return InquiryResponse.of(inquiry, imageUrls);
+    }
+
+    // 업로드된 S3 key를 추적하다가, 중간에 실패하면 이미 올라간 객체를 지우고 예외를 다시 던진다 -
+    // @Transactional은 DB만 롤백할 뿐 이미 성공한 S3 PutObject는 되돌리지 않으므로 고아 객체가 남는다.
+    private List<String> uploadImages(Long inquiryId, List<MultipartFile> files) {
+        List<String> uploadedKeys = new ArrayList<>();
+        try {
+            return files.stream()
+                    .map(file -> {
+                        String key = s3FileStorage.upload(file, FOLDER);
+                        uploadedKeys.add(key);
+                        inquiryImageRepository.save(InquiryImage.builder().inquiryId(inquiryId).imageUrl(key).build());
+                        return key;
+                    })
+                    .map(s3FileStorage::generatePresignedUrl)
+                    .toList();
+        } catch (RuntimeException e) {
+            for (String key : uploadedKeys) {
+                try {
+                    s3FileStorage.delete(key);
+                } catch (RuntimeException deleteEx) {
+                    log.error("문의 첨부 이미지 업로드 실패 후 S3 객체 정리 실패 - inquiryId={} (고아 객체 잔존)", inquiryId, deleteEx);
+                }
+            }
+            throw e;
+        }
     }
 
     public List<InquiryResponse> getMyInquiries(Long userId) {
@@ -75,10 +101,26 @@ public class InquiryService {
             if (file.getSize() > MAX_IMAGE_SIZE_BYTES) {
                 throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
             }
-            if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            // Content-Type은 클라이언트가 보낸 헤더라 위조 가능 - 실제 파일 시그니처(매직 바이트)로 검증한다.
+            if (!ALLOWED_CONTENT_TYPES.contains(file.getContentType()) || !isJpegOrPng(file)) {
                 throw new BusinessException(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
             }
         }
+    }
+
+    private boolean isJpegOrPng(MultipartFile file) {
+        byte[] header = new byte[8];
+        try (InputStream in = file.getInputStream()) {
+            int read = in.readNBytes(header, 0, header.length);
+            if (read < 3) {
+                return false;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        boolean isPng = (header[0] & 0xFF) == 0x89 && header[1] == 0x50 && header[2] == 0x4E && header[3] == 0x47;
+        boolean isJpeg = (header[0] & 0xFF) == 0xFF && (header[1] & 0xFF) == 0xD8 && (header[2] & 0xFF) == 0xFF;
+        return isPng || isJpeg;
     }
 
     private Map<Long, List<String>> loadImageUrls(List<Inquiry> inquiries) {

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
@@ -4,5 +4,6 @@ package com.pokade.domain.notification.entity;
 public enum NotificationType {
     PRICE_TARGET,
     TRADE_CONFIRMED,
-    LISTING_STALE
+    LISTING_STALE,
+    INQUIRY_HANDLED
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/event/NotificationPushEvent.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/event/NotificationPushEvent.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.notification.event;
+
+import com.pokade.domain.notification.dto.NotificationResponse;
+
+// 알림 저장 트랜잭션이 실제로 커밋된 뒤에만 SSE로 밀어주기 위한 이벤트.
+public record NotificationPushEvent(Long userId, NotificationResponse response) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -73,6 +73,19 @@ public class NotificationService {
         return String.format("%s 카드가 %s 목표가 %,d원에 도달했습니다.", cardName, targetLabel, reachedTargetPrice);
     }
 
+    // 1:1 문의 처리 완료 알림 생성 - 관리자의 답변 등록, 또는 상태를 HANDLED로 변경한 경우 호출된다.
+    @Transactional
+    public void createInquiryHandledNotification(Long userId, String inquiryTitle) {
+        Notification notification = Notification.builder()
+                .userId(userId)
+                .type(NotificationType.INQUIRY_HANDLED)
+                .message(String.format("'%s' 문의가 처리 완료되었습니다.", inquiryTitle))
+                .build();
+
+        notificationRepository.save(notification);
+        pushToSubscribers(userId, NotificationResponse.of(notification));
+    }
+
     // 로그인 유저의 SSE 구독을 등록한다. 인증은 기존 JwtAuthenticationFilter가 처리하므로
     // 여기서는 이미 인증된 userId를 받아 Emitter를 저장소에 등록하는 역할만 한다.
     public SseEmitter subscribe(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.pokade.domain.notification.service;
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.event.NotificationPushEvent;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -10,9 +11,13 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -33,6 +38,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final SseEmitterStore sseEmitterStore;
+    private final ApplicationEventPublisher eventPublisher;
 
     public List<NotificationResponse> getNotifications(Long userId) {
         return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
@@ -74,6 +80,9 @@ public class NotificationService {
     }
 
     // 1:1 문의 처리 완료 알림 생성 - 관리자의 답변 등록, 또는 상태를 HANDLED로 변경한 경우 호출된다.
+    // 알림 저장은 호출자 트랜잭션에 그대로 포함시키되, SSE 푸시는 커밋이 실제로 성공한 뒤에만 보낸다 -
+    // 커밋 전에 푸시하면 이후 같은 트랜잭션 안에서 다른 작업이 실패해 롤백되는 경우, 유저는 이미 알림을
+    // 받았는데 문의 상태/알림 레코드는 존재하지 않는 불일치가 생긴다.
     @Transactional
     public void createInquiryHandledNotification(Long userId, String inquiryTitle) {
         Notification notification = Notification.builder()
@@ -83,7 +92,16 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
-        pushToSubscribers(userId, NotificationResponse.of(notification));
+        eventPublisher.publishEvent(new NotificationPushEvent(userId, NotificationResponse.of(notification)));
+    }
+
+    // 트랜잭션이 없는 컨텍스트(단위 테스트 등)에서도 그대로 실행되도록 fallbackExecution=true.
+    // AFTER_COMMIT 리스너는 이미 커밋되어 끝난 트랜잭션 밖에서 호출되므로, 클래스 레벨 @Transactional을
+    // 그대로 상속하면 Spring이 기동 시점에 예외를 던진다 - NOT_SUPPORTED로 명시적으로 트랜잭션을 배제한다.
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onNotificationPush(NotificationPushEvent event) {
+        pushToSubscribers(event.userId(), event.response());
     }
 
     // 로그인 유저의 SSE 구독을 등록한다. 인증은 기존 JwtAuthenticationFilter가 처리하므로

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     WATCHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "워치리스트 항목을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+    INQUIRY_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "첨부 이미지는 최대 3장까지 가능합니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
     TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다."),

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     PRIMARY_VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 변형이 지정되지 않은 카드입니다."),
     WATCHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "워치리스트 항목을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
     TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다."),

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -334,13 +334,15 @@ CREATE TABLE IF NOT EXISTS inquiries (
     id           BIGSERIAL PRIMARY KEY,
     user_id      BIGINT NOT NULL REFERENCES users(id),
     category     VARCHAR(20) NOT NULL DEFAULT 'ETC',
+    status       VARCHAR(20) NOT NULL DEFAULT 'UNHANDLED',
     title        VARCHAR(200) NOT NULL,
     content      TEXT NOT NULL,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- inquiries가 이미 존재하는 기존 DB는 CREATE TABLE IF NOT EXISTS가 스킵되므로 category 컬럼을 별도로 추가한다.
+-- inquiries가 이미 존재하는 기존 DB는 CREATE TABLE IF NOT EXISTS가 스킵되므로 category/status 컬럼을 별도로 추가한다.
 ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS category VARCHAR(20) NOT NULL DEFAULT 'ETC';
+ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'UNHANDLED';
 
 CREATE TABLE IF NOT EXISTS inquiry_images (
     id           BIGSERIAL PRIMARY KEY,

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -333,7 +333,18 @@ CREATE TABLE IF NOT EXISTS user_sanctions (
 CREATE TABLE IF NOT EXISTS inquiries (
     id           BIGSERIAL PRIMARY KEY,
     user_id      BIGINT NOT NULL REFERENCES users(id),
+    category     VARCHAR(20) NOT NULL DEFAULT 'ETC',
     title        VARCHAR(200) NOT NULL,
     content      TEXT NOT NULL,
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- inquiries가 이미 존재하는 기존 DB는 CREATE TABLE IF NOT EXISTS가 스킵되므로 category 컬럼을 별도로 추가한다.
+ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS category VARCHAR(20) NOT NULL DEFAULT 'ETC';
+
+CREATE TABLE IF NOT EXISTS inquiry_images (
+    id           BIGSERIAL PRIMARY KEY,
+    inquiry_id   BIGINT NOT NULL REFERENCES inquiries(id),
+    image_url    VARCHAR(255) NOT NULL,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -286,7 +286,7 @@ CREATE TABLE IF NOT EXISTS watchlist (
 CREATE TABLE IF NOT EXISTS notifications (
     id           BIGSERIAL PRIMARY KEY,
     user_id      BIGINT NOT NULL REFERENCES users(id),
-    type         VARCHAR(30) NOT NULL,                          -- PRICE_TARGET / TRADE_CONFIRMED / LISTING_STALE 등
+    type         VARCHAR(30) NOT NULL,                          -- PRICE_TARGET / TRADE_CONFIRMED / LISTING_STALE / INQUIRY_HANDLED 등
     message      VARCHAR(255),
     is_read      BOOLEAN NOT NULL DEFAULT FALSE,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -331,18 +331,22 @@ CREATE TABLE IF NOT EXISTS user_sanctions (
 -- ---------- 7. 1:1 문의 ----------
 
 CREATE TABLE IF NOT EXISTS inquiries (
-    id           BIGSERIAL PRIMARY KEY,
-    user_id      BIGINT NOT NULL REFERENCES users(id),
-    category     VARCHAR(20) NOT NULL DEFAULT 'ETC',
-    status       VARCHAR(20) NOT NULL DEFAULT 'UNHANDLED',
-    title        VARCHAR(200) NOT NULL,
-    content      TEXT NOT NULL,
-    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT NOT NULL REFERENCES users(id),
+    category        VARCHAR(20) NOT NULL DEFAULT 'ETC',
+    status          VARCHAR(20) NOT NULL DEFAULT 'UNHANDLED',
+    title           VARCHAR(200) NOT NULL,
+    content         TEXT NOT NULL,
+    answer_content  TEXT,
+    answered_at     TIMESTAMP,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- inquiries가 이미 존재하는 기존 DB는 CREATE TABLE IF NOT EXISTS가 스킵되므로 category/status 컬럼을 별도로 추가한다.
+-- inquiries가 이미 존재하는 기존 DB는 CREATE TABLE IF NOT EXISTS가 스킵되므로 신규 컬럼을 별도로 추가한다.
 ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS category VARCHAR(20) NOT NULL DEFAULT 'ETC';
 ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS status VARCHAR(20) NOT NULL DEFAULT 'UNHANDLED';
+ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS answer_content TEXT;
+ALTER TABLE inquiries ADD COLUMN IF NOT EXISTS answered_at TIMESTAMP;
 
 CREATE TABLE IF NOT EXISTS inquiry_images (
     id           BIGSERIAL PRIMARY KEY,

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -327,3 +327,13 @@ CREATE TABLE IF NOT EXISTS user_sanctions (
 
 -- 참고: Refresh Token은 Redis 기반 블랙리스트 관리로, 관계형 DB 테이블로 별도 생성하지 않음
 -- 참고: 매물 5분 임시잠금은 Redis(TTL)로 처리 권장, DB 컬럼 추가 안 함
+
+-- ---------- 7. 1:1 문의 ----------
+
+CREATE TABLE IF NOT EXISTS inquiries (
+    id           BIGSERIAL PRIMARY KEY,
+    user_id      BIGINT NOT NULL REFERENCES users(id),
+    title        VARCHAR(200) NOT NULL,
+    content      TEXT NOT NULL,
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.admin.controller;
 import com.pokade.domain.admin.service.AdminInquiryService;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -18,6 +19,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,10 +31,13 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -79,15 +85,29 @@ class AdminInquiryControllerTest {
         return authentication(auth);
     }
 
+    private InquiryResponse response() {
+        return new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+    }
+
     @Test
     void 관리자가_문의_목록을_조회하면_200과_목록을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
-        given(adminInquiryService.getInquiries()).willReturn(List.of(response));
+        given(adminInquiryService.getInquiries(any(), any()))
+                .willReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 20), 1));
 
         mockMvc.perform(get("/api/admin/inquiries").with(admin()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].title").value("제목"));
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].title").value("제목"));
+    }
+
+    @Test
+    void 카테고리를_지정하면_해당_카테고리로_필터링해_조회한다() throws Exception {
+        given(adminInquiryService.getInquiries(eq(InquiryCategory.PAYMENT), any()))
+                .willReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/admin/inquiries").param("category", "PAYMENT").with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content.length()").value(1));
     }
 
     @Test
@@ -98,8 +118,7 @@ class AdminInquiryControllerTest {
 
     @Test
     void 관리자가_문의_상세를_조회하면_200을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
-        given(adminInquiryService.getInquiry(1L)).willReturn(response);
+        given(adminInquiryService.getInquiry(1L)).willReturn(response());
 
         mockMvc.perform(get("/api/admin/inquiries/{id}", 1L).with(admin()))
                 .andExpect(status().isOk())
@@ -112,6 +131,41 @@ class AdminInquiryControllerTest {
                 .given(adminInquiryService).getInquiry(999L);
 
         mockMvc.perform(get("/api/admin/inquiries/{id}", 999L).with(admin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INQUIRY_NOT_FOUND"));
+    }
+
+    @Test
+    void 관리자가_상태를_변경하면_200과_변경된_상태를_반환한다() throws Exception {
+        InquiryResponse handled = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.HANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+        given(adminInquiryService.updateStatus(1L, InquiryStatus.HANDLED)).willReturn(handled);
+
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/status", 1L)
+                        .with(admin())
+                        .contentType("application/json")
+                        .content("{\"status\":\"HANDLED\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("HANDLED"));
+    }
+
+    @Test
+    void 관리자가_아니면_상태_변경시_403을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/status", 1L)
+                        .with(user())
+                        .contentType("application/json")
+                        .content("{\"status\":\"HANDLED\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 존재하지_않는_문의의_상태_변경시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INQUIRY_NOT_FOUND))
+                .given(adminInquiryService).updateStatus(999L, InquiryStatus.HANDLED);
+
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/status", 999L)
+                        .with(admin())
+                        .contentType("application/json")
+                        .content("{\"status\":\"HANDLED\"}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("INQUIRY_NOT_FOUND"));
     }

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
@@ -86,7 +86,7 @@ class AdminInquiryControllerTest {
     }
 
     private InquiryResponse response() {
-        return new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+        return new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now(), null, null);
     }
 
     @Test
@@ -137,7 +137,7 @@ class AdminInquiryControllerTest {
 
     @Test
     void 관리자가_상태를_변경하면_200과_변경된_상태를_반환한다() throws Exception {
-        InquiryResponse handled = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.HANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+        InquiryResponse handled = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.HANDLED, "제목", "내용", List.of(), LocalDateTime.now(), null, null);
         given(adminInquiryService.updateStatus(1L, InquiryStatus.HANDLED)).willReturn(handled);
 
         mockMvc.perform(patch("/api/admin/inquiries/{id}/status", 1L)
@@ -166,6 +166,51 @@ class AdminInquiryControllerTest {
                         .with(admin())
                         .contentType("application/json")
                         .content("{\"status\":\"HANDLED\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INQUIRY_NOT_FOUND"));
+    }
+
+    @Test
+    void 관리자가_답변을_등록하면_200과_HANDLED_상태의_답변을_반환한다() throws Exception {
+        InquiryResponse answered = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.HANDLED, "제목", "내용", List.of(), LocalDateTime.now(), "답변 내용입니다.", LocalDateTime.now());
+        given(adminInquiryService.answerInquiry(1L, "답변 내용입니다.")).willReturn(answered);
+
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/answer", 1L)
+                        .with(admin())
+                        .contentType("application/json")
+                        .content("{\"content\":\"답변 내용입니다.\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.answerContent").value("답변 내용입니다."))
+                .andExpect(jsonPath("$.data.status").value("HANDLED"));
+    }
+
+    @Test
+    void 답변_내용이_비어있으면_400을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/answer", 1L)
+                        .with(admin())
+                        .contentType("application/json")
+                        .content("{\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 관리자가_아니면_답변_등록시_403을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/answer", 1L)
+                        .with(user())
+                        .contentType("application/json")
+                        .content("{\"content\":\"답변 내용입니다.\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 존재하지_않는_문의에_답변시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INQUIRY_NOT_FOUND))
+                .given(adminInquiryService).answerInquiry(999L, "답변 내용입니다.");
+
+        mockMvc.perform(patch("/api/admin/inquiries/{id}/answer", 999L)
+                        .with(admin())
+                        .contentType("application/json")
+                        .content("{\"content\":\"답변 내용입니다.\"}"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value("INQUIRY_NOT_FOUND"));
     }

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
@@ -1,0 +1,117 @@
+package com.pokade.domain.admin.controller;
+
+import com.pokade.domain.admin.service.AdminInquiryService;
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminInquiryController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class AdminInquiryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminInquiryService adminInquiryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private RedisAuthorizationRequestRepository redisAuthorizationRequestRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    private RequestPostProcessor admin() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                1L, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        return authentication(auth);
+    }
+
+    private RequestPostProcessor user() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                1L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    @Test
+    void 관리자가_문의_목록을_조회하면_200과_목록을_반환한다() throws Exception {
+        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        given(adminInquiryService.getInquiries()).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/admin/inquiries").with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("제목"));
+    }
+
+    @Test
+    void 관리자가_아니면_문의_목록_조회시_403을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/admin/inquiries").with(user()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 관리자가_문의_상세를_조회하면_200을_반환한다() throws Exception {
+        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        given(adminInquiryService.getInquiry(1L)).willReturn(response);
+
+        mockMvc.perform(get("/api/admin/inquiries/{id}", 1L).with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").value("내용"));
+    }
+
+    @Test
+    void 존재하지_않는_문의_상세_조회시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INQUIRY_NOT_FOUND))
+                .given(adminInquiryService).getInquiry(999L);
+
+        mockMvc.perform(get("/api/admin/inquiries/{id}", 999L).with(admin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("INQUIRY_NOT_FOUND"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminInquiryControllerTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.admin.controller;
 
 import com.pokade.domain.admin.service.AdminInquiryService;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -80,7 +81,7 @@ class AdminInquiryControllerTest {
 
     @Test
     void 관리자가_문의_목록을_조회하면_200과_목록을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
         given(adminInquiryService.getInquiries()).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/admin/inquiries").with(admin()))
@@ -97,7 +98,7 @@ class AdminInquiryControllerTest {
 
     @Test
     void 관리자가_문의_상세를_조회하면_200을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
         given(adminInquiryService.getInquiry(1L)).willReturn(response);
 
         mockMvc.perform(get("/api/admin/inquiries/{id}", 1L).with(admin()))

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -173,7 +173,7 @@ class AdminInquiryServiceTest {
     }
 
     @Test
-    @DisplayName("이미 답변한 문의에 다시 답변하면 답변 내용/시각이 갱신되고 알림도 다시 보낸다")
+    @DisplayName("이미 답변한 문의를 다시 답변(수정)해도 답변 내용/시각만 갱신되고 알림은 최초 1회만 보낸다")
     void answerInquiry_updatesExistingAnswer() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
@@ -183,7 +183,7 @@ class AdminInquiryServiceTest {
         InquiryResponse response = adminInquiryService.answerInquiry(1L, "수정된 답변");
 
         assertThat(response.answerContent()).isEqualTo("수정된 답변");
-        then(notificationService).should(times(2)).createInquiryHandledNotification(1L, "제목");
+        then(notificationService).should(times(1)).createInquiryHandledNotification(1L, "제목");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -4,6 +4,7 @@ import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.global.exception.BusinessException;
@@ -15,6 +16,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +28,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
 class AdminInquiryServiceTest {
@@ -37,18 +44,37 @@ class AdminInquiryServiceTest {
     @InjectMocks
     private AdminInquiryService adminInquiryService;
 
+    private final Pageable pageable = PageRequest.of(0, 20);
+
     @Test
-    @DisplayName("전체 문의 목록은 최신순으로 내려온 것을 이미지와 함께 응답으로 변환한다")
-    void getInquiries_returnsMappedResponses() {
+    @DisplayName("카테고리 없이 조회하면 전체 문의를 최신순 페이지로 이미지와 함께 응답으로 변환한다")
+    void getInquiries_withoutCategory_returnsAllPaged() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
-        given(inquiryRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(inquiry));
+        given(inquiryRepository.findAllByOrderByCreatedAtDesc(pageable))
+                .willReturn(new PageImpl<>(List.of(inquiry), pageable, 1));
         given(inquiryImageRepository.findByInquiryIdInOrderByIdAsc(any())).willReturn(List.of());
 
-        List<InquiryResponse> responses = adminInquiryService.getInquiries();
+        Page<InquiryResponse> responses = adminInquiryService.getInquiries(null, pageable);
 
-        assertThat(responses).hasSize(1);
-        assertThat(responses.get(0).title()).isEqualTo("제목");
-        assertThat(responses.get(0).imageUrls()).isEmpty();
+        assertThat(responses.getContent()).hasSize(1);
+        assertThat(responses.getContent().get(0).title()).isEqualTo("제목");
+        assertThat(responses.getContent().get(0).imageUrls()).isEmpty();
+        then(inquiryRepository).should(never()).findByCategoryOrderByCreatedAtDesc(any(), any());
+    }
+
+    @Test
+    @DisplayName("카테고리를 지정하면 해당 카테고리만 필터링된 조회 메서드를 사용한다")
+    void getInquiries_withCategory_filtersByCategory() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("결제 문의").content("내용").category(InquiryCategory.PAYMENT).build();
+        given(inquiryRepository.findByCategoryOrderByCreatedAtDesc(InquiryCategory.PAYMENT, pageable))
+                .willReturn(new PageImpl<>(List.of(inquiry), pageable, 1));
+        given(inquiryImageRepository.findByInquiryIdInOrderByIdAsc(any())).willReturn(List.of());
+
+        Page<InquiryResponse> responses = adminInquiryService.getInquiries(InquiryCategory.PAYMENT, pageable);
+
+        assertThat(responses.getContent()).hasSize(1);
+        assertThat(responses.getContent().get(0).category()).isEqualTo(InquiryCategory.PAYMENT);
+        then(inquiryRepository).should(never()).findAllByOrderByCreatedAtDesc(any());
     }
 
     @Test
@@ -73,5 +99,28 @@ class AdminInquiryServiceTest {
         InquiryResponse response = adminInquiryService.getInquiry(1L);
 
         assertThat(response.imageUrls()).containsExactly("https://s3/presigned");
+    }
+
+    @Test
+    @DisplayName("상태를 변경하면 엔티티에 반영되고 변경된 상태로 응답한다")
+    void updateStatus_changesStatus() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
+
+        InquiryResponse response = adminInquiryService.updateStatus(1L, InquiryStatus.HANDLED);
+
+        assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
+        assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문의의 상태를 변경하려 하면 BusinessException(INQUIRY_NOT_FOUND)을 던진다")
+    void updateStatus_notFound_throws() {
+        given(inquiryRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminInquiryService.updateStatus(999L, InquiryStatus.HANDLED))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INQUIRY_NOT_FOUND);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -1,0 +1,52 @@
+package com.pokade.domain.admin.service;
+
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AdminInquiryServiceTest {
+
+    @Mock
+    private InquiryRepository inquiryRepository;
+
+    @InjectMocks
+    private AdminInquiryService adminInquiryService;
+
+    @Test
+    @DisplayName("전체 문의 목록은 최신순으로 내려온 것을 그대로 응답으로 변환한다")
+    void getInquiries_returnsMappedResponses() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").build();
+        given(inquiryRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(inquiry));
+
+        List<InquiryResponse> responses = adminInquiryService.getInquiries();
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문의를 조회하면 BusinessException(INQUIRY_NOT_FOUND)을 던진다")
+    void getInquiry_notFound_throws() {
+        given(inquiryRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminInquiryService.getInquiry(999L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INQUIRY_NOT_FOUND);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -2,9 +2,13 @@ package com.pokade.domain.admin.service;
 
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
+import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,20 +29,26 @@ class AdminInquiryServiceTest {
 
     @Mock
     private InquiryRepository inquiryRepository;
+    @Mock
+    private InquiryImageRepository inquiryImageRepository;
+    @Mock
+    private S3FileStorage s3FileStorage;
 
     @InjectMocks
     private AdminInquiryService adminInquiryService;
 
     @Test
-    @DisplayName("전체 문의 목록은 최신순으로 내려온 것을 그대로 응답으로 변환한다")
+    @DisplayName("전체 문의 목록은 최신순으로 내려온 것을 이미지와 함께 응답으로 변환한다")
     void getInquiries_returnsMappedResponses() {
-        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").build();
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
         given(inquiryRepository.findAllByOrderByCreatedAtDesc()).willReturn(List.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdInOrderByIdAsc(any())).willReturn(List.of());
 
         List<InquiryResponse> responses = adminInquiryService.getInquiries();
 
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).title()).isEqualTo("제목");
+        assertThat(responses.get(0).imageUrls()).isEmpty();
     }
 
     @Test
@@ -48,5 +59,19 @@ class AdminInquiryServiceTest {
         assertThatThrownBy(() -> adminInquiryService.getInquiry(999L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INQUIRY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("문의 상세 조회는 첨부 이미지를 presigned URL로 변환해 응답한다")
+    void getInquiry_returnsPresignedImageUrls() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.SECURITY).build();
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L))
+                .willReturn(List.of(InquiryImage.builder().inquiryId(1L).imageUrl("inquiries/key.png").build()));
+        given(s3FileStorage.generatePresignedUrl("inquiries/key.png")).willReturn("https://s3/presigned");
+
+        InquiryResponse response = adminInquiryService.getInquiry(1L);
+
+        assertThat(response.imageUrls()).containsExactly("https://s3/presigned");
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -123,4 +123,42 @@ class AdminInquiryServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INQUIRY_NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("답변을 등록하면 답변 내용/시각이 저장되고 상태가 HANDLED로 전환된다")
+    void answerInquiry_savesAnswerAndMarksHandled() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
+
+        InquiryResponse response = adminInquiryService.answerInquiry(1L, "답변 내용입니다.");
+
+        assertThat(response.answerContent()).isEqualTo("답변 내용입니다.");
+        assertThat(response.answeredAt()).isNotNull();
+        assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
+        assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
+    }
+
+    @Test
+    @DisplayName("이미 답변한 문의에 다시 답변하면 답변 내용/시각이 갱신된다")
+    void answerInquiry_updatesExistingAnswer() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
+        adminInquiryService.answerInquiry(1L, "첫 답변");
+
+        InquiryResponse response = adminInquiryService.answerInquiry(1L, "수정된 답변");
+
+        assertThat(response.answerContent()).isEqualTo("수정된 답변");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문의에 답변하려 하면 BusinessException(INQUIRY_NOT_FOUND)을 던진다")
+    void answerInquiry_notFound_throws() {
+        given(inquiryRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> adminInquiryService.answerInquiry(999L, "답변 내용입니다."))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INQUIRY_NOT_FOUND);
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -7,6 +7,7 @@ import com.pokade.domain.inquiry.entity.InquiryImage;
 import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class AdminInquiryServiceTest {
@@ -40,6 +42,8 @@ class AdminInquiryServiceTest {
     private InquiryImageRepository inquiryImageRepository;
     @Mock
     private S3FileStorage s3FileStorage;
+    @Mock
+    private NotificationService notificationService;
 
     @InjectMocks
     private AdminInquiryService adminInquiryService;
@@ -112,6 +116,34 @@ class AdminInquiryServiceTest {
 
         assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
         assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
+        then(notificationService).should().createInquiryHandledNotification(1L, "제목");
+    }
+
+    @Test
+    @DisplayName("이미 HANDLED인 문의를 다시 HANDLED로 바꿔도 중복 알림을 보내지 않는다")
+    void updateStatus_alreadyHandled_doesNotNotifyAgain() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        inquiry.changeStatus(InquiryStatus.HANDLED);
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
+
+        adminInquiryService.updateStatus(1L, InquiryStatus.HANDLED);
+
+        then(notificationService).should(never()).createInquiryHandledNotification(any(), any());
+    }
+
+    @Test
+    @DisplayName("HANDLED를 UNHANDLED로 되돌릴 때는 알림을 보내지 않는다")
+    void updateStatus_toUnhandled_doesNotNotify() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        inquiry.changeStatus(InquiryStatus.HANDLED);
+        given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
+
+        InquiryResponse response = adminInquiryService.updateStatus(1L, InquiryStatus.UNHANDLED);
+
+        assertThat(response.status()).isEqualTo(InquiryStatus.UNHANDLED);
+        then(notificationService).should(never()).createInquiryHandledNotification(any(), any());
     }
 
     @Test
@@ -137,10 +169,11 @@ class AdminInquiryServiceTest {
         assertThat(response.answeredAt()).isNotNull();
         assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
         assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
+        then(notificationService).should().createInquiryHandledNotification(1L, "제목");
     }
 
     @Test
-    @DisplayName("이미 답변한 문의에 다시 답변하면 답변 내용/시각이 갱신된다")
+    @DisplayName("이미 답변한 문의에 다시 답변하면 답변 내용/시각이 갱신되고 알림도 다시 보낸다")
     void answerInquiry_updatesExistingAnswer() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
@@ -150,6 +183,7 @@ class AdminInquiryServiceTest {
         InquiryResponse response = adminInquiryService.answerInquiry(1L, "수정된 답변");
 
         assertThat(response.answerContent()).isEqualTo("수정된 답변");
+        then(notificationService).should(times(2)).createInquiryHandledNotification(1L, "제목");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.inquiry.controller;
 
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.service.InquiryService;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
@@ -78,7 +79,7 @@ class InquiryControllerTest {
 
     @Test
     void 로그인한_사용자가_문의를_작성하면_200을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
         given(inquiryService.createInquiry(eq(100L), any(), any())).willReturn(response);
 
         mockMvc.perform(multipart("/api/inquiries")
@@ -97,7 +98,7 @@ class InquiryControllerTest {
 
     @Test
     void 본인_문의_목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
         given(inquiryService.getMyInquiries(100L)).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/inquiries/me").with(userId(100L)))

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
@@ -79,7 +79,7 @@ class InquiryControllerTest {
 
     @Test
     void 로그인한_사용자가_문의를_작성하면_200을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now(), null, null);
         given(inquiryService.createInquiry(eq(100L), any(), any())).willReturn(response);
 
         mockMvc.perform(multipart("/api/inquiries")
@@ -98,7 +98,7 @@ class InquiryControllerTest {
 
     @Test
     void 본인_문의_목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, InquiryStatus.UNHANDLED, "제목", "내용", List.of(), LocalDateTime.now(), null, null);
         given(inquiryService.getMyInquiries(100L)).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/inquiries/me").with(userId(100L)))

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,0 +1,102 @@
+package com.pokade.domain.inquiry.controller;
+
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.service.InquiryService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InquiryController.class)
+@AutoConfigureMockMvc
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class}) // 401 계약을 검증하려면 실물 엔트리포인트가 필요
+class InquiryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private InquiryService inquiryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private RedisAuthorizationRequestRepository redisAuthorizationRequestRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    private RequestPostProcessor userId(Long userId) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    @Test
+    void 로그인한_사용자가_문의를_작성하면_200을_반환한다() throws Exception {
+        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        given(inquiryService.createInquiry(eq(100L), any())).willReturn(response);
+
+        mockMvc.perform(post("/api/inquiries").with(userId(100L))
+                        .contentType("application/json")
+                        .content("{\"title\":\"제목\",\"content\":\"내용\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("제목"));
+    }
+
+    @Test
+    void 로그인하지_않으면_문의_작성시_401을_반환한다() throws Exception {
+        mockMvc.perform(post("/api/inquiries")
+                        .contentType("application/json")
+                        .content("{\"title\":\"제목\",\"content\":\"내용\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 본인_문의_목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
+        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        given(inquiryService.getMyInquiries(100L)).willReturn(List.of(response));
+
+        mockMvc.perform(get("/api/inquiries/me").with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("제목"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.inquiry.controller;
 
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.domain.inquiry.service.InquiryService;
 import com.pokade.global.config.SecurityConfig;
 import com.pokade.global.security.JwtAuthenticationEntryPoint;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -22,6 +24,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,7 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -69,29 +72,32 @@ class InquiryControllerTest {
         return authentication(auth);
     }
 
+    private MockMultipartFile requestPart(String json) {
+        return new MockMultipartFile("request", "", "application/json", json.getBytes(StandardCharsets.UTF_8));
+    }
+
     @Test
     void 로그인한_사용자가_문의를_작성하면_200을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
-        given(inquiryService.createInquiry(eq(100L), any())).willReturn(response);
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
+        given(inquiryService.createInquiry(eq(100L), any(), any())).willReturn(response);
 
-        mockMvc.perform(post("/api/inquiries").with(userId(100L))
-                        .contentType("application/json")
-                        .content("{\"title\":\"제목\",\"content\":\"내용\"}"))
+        mockMvc.perform(multipart("/api/inquiries")
+                        .file(requestPart("{\"category\":\"INFO\",\"title\":\"제목\",\"content\":\"내용\"}"))
+                        .with(userId(100L)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("제목"));
     }
 
     @Test
     void 로그인하지_않으면_문의_작성시_401을_반환한다() throws Exception {
-        mockMvc.perform(post("/api/inquiries")
-                        .contentType("application/json")
-                        .content("{\"title\":\"제목\",\"content\":\"내용\"}"))
+        mockMvc.perform(multipart("/api/inquiries")
+                        .file(requestPart("{\"category\":\"INFO\",\"title\":\"제목\",\"content\":\"내용\"}")))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
     void 본인_문의_목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
-        InquiryResponse response = new InquiryResponse(1L, 100L, "제목", "내용", LocalDateTime.now());
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.INFO, "제목", "내용", List.of(), LocalDateTime.now());
         given(inquiryService.getMyInquiries(100L)).willReturn(List.of(response));
 
         mockMvc.perform(get("/api/inquiries/me").with(userId(100L)))

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.global.exception.BusinessException;
@@ -61,6 +62,7 @@ class InquiryServiceTest {
         assertThat(captor.getValue().getTitle()).isEqualTo("제목");
         assertThat(captor.getValue().getContent()).isEqualTo("내용");
         assertThat(captor.getValue().getCategory()).isEqualTo(InquiryCategory.PAYMENT);
+        assertThat(captor.getValue().getStatus()).isEqualTo(InquiryStatus.UNHANDLED);
         assertThat(response.title()).isEqualTo("제목");
         assertThat(response.imageUrls()).isEmpty();
         then(s3FileStorage).should(never()).upload(any(), anyString());

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -45,8 +45,12 @@ class InquiryServiceTest {
     @InjectMocks
     private InquiryService inquiryService;
 
+    private static final byte[] PNG_SIGNATURE = {(byte) 0x89, 0x50, 0x4E, 0x47};
+
     private MultipartFile png(long size) {
-        return new MockMultipartFile("images", "a.png", "image/png", new byte[(int) size]);
+        byte[] content = new byte[(int) size];
+        System.arraycopy(PNG_SIGNATURE, 0, content, 0, Math.min(PNG_SIGNATURE.length, content.length));
+        return new MockMultipartFile("images", "a.png", "image/png", content);
     }
 
     @Test
@@ -103,6 +107,35 @@ class InquiryServiceTest {
         assertThatThrownBy(() -> inquiryService.createInquiry(1L, request, images))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.FILE_TOO_LARGE);
+    }
+
+    @Test
+    @DisplayName("문의 작성: Content-Type만 image/png고 실제 내용은 이미지가 아니면 UNSUPPORTED_IMAGE_TYPE")
+    void createInquiry_spoofedContentType_rejected() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.ETC, "제목", "내용");
+        MultipartFile fakeImage = new MockMultipartFile("images", "a.png", "image/png", "not-an-image".getBytes());
+
+        assertThatThrownBy(() -> inquiryService.createInquiry(1L, request, List.of(fakeImage)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+
+        then(inquiryRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("문의 작성: 이미지 업로드 중 하나가 실패하면 이미 올라간 S3 객체를 정리하고 예외를 전파한다")
+    void createInquiry_uploadFailsMidway_cleansUpUploadedObjects() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.ETC, "제목", "내용");
+        MultipartFile first = png(10);
+        MultipartFile second = png(10);
+        given(s3FileStorage.upload(first, "inquiries")).willReturn("inquiries/first.png");
+        given(s3FileStorage.upload(second, "inquiries")).willThrow(new RuntimeException("S3 장애"));
+
+        assertThatThrownBy(() -> inquiryService.createInquiry(1L, request, List.of(first, second)))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 장애");
+
+        then(s3FileStorage).should().delete("inquiries/first.png");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -3,7 +3,13 @@ package com.pokade.domain.inquiry.service;
 import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.entity.InquiryCategory;
+import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,11 +17,18 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
 import static org.mockito.BDDMockito.then;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,34 +36,85 @@ class InquiryServiceTest {
 
     @Mock
     private InquiryRepository inquiryRepository;
+    @Mock
+    private InquiryImageRepository inquiryImageRepository;
+    @Mock
+    private S3FileStorage s3FileStorage;
 
     @InjectMocks
     private InquiryService inquiryService;
 
-    @Test
-    @DisplayName("문의를 작성하면 작성자 id로 저장하고 응답으로 돌려준다")
-    void createInquiry_savesWithUserId() {
-        InquiryCreateRequest request = new InquiryCreateRequest("제목", "내용");
+    private MultipartFile png(long size) {
+        return new MockMultipartFile("images", "a.png", "image/png", new byte[(int) size]);
+    }
 
-        InquiryResponse response = inquiryService.createInquiry(1L, request);
+    @Test
+    @DisplayName("문의를 작성하면 작성자 id와 카테고리로 저장하고 응답으로 돌려준다")
+    void createInquiry_savesWithUserId() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.PAYMENT, "제목", "내용");
+
+        InquiryResponse response = inquiryService.createInquiry(1L, request, null);
 
         ArgumentCaptor<Inquiry> captor = ArgumentCaptor.forClass(Inquiry.class);
         then(inquiryRepository).should().save(captor.capture());
         assertThat(captor.getValue().getUserId()).isEqualTo(1L);
         assertThat(captor.getValue().getTitle()).isEqualTo("제목");
         assertThat(captor.getValue().getContent()).isEqualTo("내용");
+        assertThat(captor.getValue().getCategory()).isEqualTo(InquiryCategory.PAYMENT);
         assertThat(response.title()).isEqualTo("제목");
+        assertThat(response.imageUrls()).isEmpty();
+        then(s3FileStorage).should(never()).upload(any(), anyString());
     }
 
     @Test
-    @DisplayName("본인 문의 목록은 최신순으로 내려온 것을 그대로 응답으로 변환한다")
+    @DisplayName("문의 작성: 첨부 이미지는 S3에 업로드하고 key를 저장한 뒤 presigned URL로 응답한다")
+    void createInquiry_uploadsImages() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.INFO, "제목", "내용");
+        given(s3FileStorage.upload(any(), eq("inquiries"))).willReturn("inquiries/key.png");
+        given(s3FileStorage.generatePresignedUrl("inquiries/key.png")).willReturn("https://s3/presigned");
+
+        InquiryResponse response = inquiryService.createInquiry(1L, request, List.of(png(1024)));
+
+        then(inquiryImageRepository).should().save(any(InquiryImage.class));
+        assertThat(response.imageUrls()).containsExactly("https://s3/presigned");
+    }
+
+    @Test
+    @DisplayName("문의 작성: 이미지가 4장 이상이면 INQUIRY_IMAGE_LIMIT_EXCEEDED, 아무것도 저장하지 않는다")
+    void createInquiry_tooManyImages() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.ETC, "제목", "내용");
+        List<MultipartFile> images = List.of(png(10), png(10), png(10), png(10));
+
+        assertThatThrownBy(() -> inquiryService.createInquiry(1L, request, images))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_IMAGE_LIMIT_EXCEEDED);
+
+        then(inquiryRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("문의 작성: 5MB를 넘는 이미지가 있으면 FILE_TOO_LARGE")
+    void createInquiry_imageTooLarge() {
+        InquiryCreateRequest request = new InquiryCreateRequest(InquiryCategory.ETC, "제목", "내용");
+        List<MultipartFile> images = List.of(png(5 * 1024 * 1024 + 1));
+
+        assertThatThrownBy(() -> inquiryService.createInquiry(1L, request, images))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FILE_TOO_LARGE);
+    }
+
+    @Test
+    @DisplayName("본인 문의 목록은 최신순으로 내려온 것을 이미지와 함께 응답으로 변환한다")
     void getMyInquiries_returnsMappedResponses() {
-        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").build();
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.SECURITY).build();
         given(inquiryRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdInOrderByIdAsc(any())).willReturn(List.of());
 
         List<InquiryResponse> responses = inquiryService.getMyInquiries(1L);
 
         assertThat(responses).hasSize(1);
         assertThat(responses.get(0).title()).isEqualTo("제목");
+        assertThat(responses.get(0).category()).isEqualTo(InquiryCategory.SECURITY);
+        assertThat(responses.get(0).imageUrls()).isEmpty();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -1,0 +1,56 @@
+package com.pokade.domain.inquiry.service;
+
+import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.response.InquiryResponse;
+import com.pokade.domain.inquiry.entity.Inquiry;
+import com.pokade.domain.inquiry.repository.InquiryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class InquiryServiceTest {
+
+    @Mock
+    private InquiryRepository inquiryRepository;
+
+    @InjectMocks
+    private InquiryService inquiryService;
+
+    @Test
+    @DisplayName("문의를 작성하면 작성자 id로 저장하고 응답으로 돌려준다")
+    void createInquiry_savesWithUserId() {
+        InquiryCreateRequest request = new InquiryCreateRequest("제목", "내용");
+
+        InquiryResponse response = inquiryService.createInquiry(1L, request);
+
+        ArgumentCaptor<Inquiry> captor = ArgumentCaptor.forClass(Inquiry.class);
+        then(inquiryRepository).should().save(captor.capture());
+        assertThat(captor.getValue().getUserId()).isEqualTo(1L);
+        assertThat(captor.getValue().getTitle()).isEqualTo("제목");
+        assertThat(captor.getValue().getContent()).isEqualTo("내용");
+        assertThat(response.title()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("본인 문의 목록은 최신순으로 내려온 것을 그대로 응답으로 변환한다")
+    void getMyInquiries_returnsMappedResponses() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").build();
+        given(inquiryRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of(inquiry));
+
+        List<InquiryResponse> responses = inquiryService.getMyInquiries(1L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).title()).isEqualTo("제목");
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.notification.service;
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.event.NotificationPushEvent;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -38,6 +40,7 @@ class NotificationServiceTest {
 
     @Mock NotificationRepository notificationRepository;
     @Mock SseEmitterStore sseEmitterStore;
+    @Mock ApplicationEventPublisher eventPublisher;
     @InjectMocks NotificationService notificationService;
 
     private Notification notification(Long userId) {
@@ -192,6 +195,51 @@ class NotificationServiceTest {
         notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
 
         then(emitter).should().completeWithError(any(IOException.class));
+    }
+
+    // ===== 1:1 문의 처리 완료 알림 생성 =====
+    @Test
+    @DisplayName("문의 처리 완료 알림 생성: INQUIRY_HANDLED 타입으로 저장하고, 커밋 이후 푸시를 위한 이벤트를 발행한다")
+    void createInquiryHandledNotification_savesAndPublishesEvent() {
+        notificationService.createInquiryHandledNotification(1L, "결제 문의");
+
+        ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
+        then(notificationRepository).should().save(notificationCaptor.capture());
+        Notification saved = notificationCaptor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(1L);
+        assertThat(saved.getType()).isEqualTo(NotificationType.INQUIRY_HANDLED);
+        assertThat(saved.getMessage()).contains("결제 문의");
+
+        ArgumentCaptor<NotificationPushEvent> eventCaptor = ArgumentCaptor.forClass(NotificationPushEvent.class);
+        then(eventPublisher).should().publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().userId()).isEqualTo(1L);
+        assertThat(eventCaptor.getValue().response().type()).isEqualTo(NotificationType.INQUIRY_HANDLED);
+
+        // 이벤트 발행 시점엔 아직 커밋 전이므로, 이 메서드 자체는 Emitter로 직접 전송하지 않는다.
+        then(sseEmitterStore).should(never()).findByUserId(any());
+    }
+
+    // ===== 커밋 후 알림 푸시 (AFTER_COMMIT 리스너) =====
+    @Test
+    @DisplayName("onNotificationPush: 구독 중인 Emitter가 있으면 notification 이벤트를 전송한다")
+    void onNotificationPush_pushes_to_subscriber() throws Exception {
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", false, null);
+        SseEmitter emitter = mock(SseEmitter.class);
+        given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
+
+        notificationService.onNotificationPush(new NotificationPushEvent(1L, response));
+
+        then(emitter).should().send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    @DisplayName("onNotificationPush: 구독 중인 Emitter가 없으면 예외 없이 조용히 스킵된다")
+    void onNotificationPush_no_subscriber_noop() {
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", false, null);
+        given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
+
+        assertThatCode(() -> notificationService.onNotificationPush(new NotificationPushEvent(1L, response)))
+                .doesNotThrowAnyException();
     }
 
     // ===== SSE 구독 =====

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
@@ -32,7 +32,7 @@ class NotificationSseFlowTest {
     @Test
     @DisplayName("subscribe 후 같은 유저에게 createPriceTargetNotification이 발생하면 연결이 끊기지 않고 유지된다")
     void subscribe_then_notify_keeps_connection_alive() {
-        notificationService = new NotificationService(notificationRepository, sseEmitterStore);
+        notificationService = new NotificationService(notificationRepository, sseEmitterStore, event -> { });
         Long userId = 1L;
         Watchlist watchlist = Watchlist.builder().userId(userId).cardId(10L).targetBuyPrice(100000).build();
 
@@ -51,7 +51,7 @@ class NotificationSseFlowTest {
     @Test
     @DisplayName("다른 유저를 구독 중인 Emitter는 대상 유저에게 온 알림의 영향을 받지 않는다")
     void notification_for_one_user_does_not_touch_another_subscriber() {
-        notificationService = new NotificationService(notificationRepository, sseEmitterStore);
+        notificationService = new NotificationService(notificationRepository, sseEmitterStore, event -> { });
         Long targetUserId = 1L;
         Long otherUserId = 2L;
         Watchlist watchlist = Watchlist.builder().userId(targetUserId).cardId(10L).targetBuyPrice(100000).build();

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -104,7 +104,7 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
         given(priceTradeStatsRepository.findPriceRangesByCardIds(any(), any(), any())).willReturn(List.of(range));
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any())).willReturn(List.of(range));
 
-        NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore());
+        NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore(), event -> { });
         WatchlistService watchlistService = new WatchlistService(watchlistRepository,
                 mock(PriceService.class), cardRepository, priceTradeStatsRepository, mock(CardNameKoResolver.class),
                 notificationService);


### PR DESCRIPTION
## 📌 관련 이슈
- #247

## ✨ 작업 내용
- (#247) 1:1 문의 기능 신규 구현
  - 사용자: 문의 작성(`POST /api/inquiries`, 카테고리 선택 + 사진 최대 3장 첨부), 본인 문의 목록 조회(`GET /api/inquiries/me`)
  - 관리자: 문의 목록 조회(카테고리 필터 + 페이지네이션, `GET /api/admin/inquiries`), 상세 조회, 처리 상태 수동 변경(`PATCH /.../status`)
  - 관리자: 답변 등록/수정(`PATCH /api/admin/inquiries/{id}/answer`) — 답변을 등록하면 상태가 자동으로 `HANDLED`로 전환됨
  - 답변 등록 또는 상태가 `UNHANDLED → HANDLED`로 바뀌는 시점에 작성자에게 알림 발송(`NotificationType.INQUIRY_HANDLED`, 기존 워치리스트 알림과 동일한 SSE 푸시 경로 재사용)
- 첨부 이미지는 `domain.ai`의 `GradeResultImage` 패턴을 재사용해 S3 key만 저장하고 조회 시점에 presigned URL을 발급하도록 구현
- `/api/admin/**`는 이미 `hasRole("ADMIN")`으로 보호돼 있어 `SecurityConfig` 변경 없음

## 📸 스크린샷 / 테스트 결과
- 로컬 서버에 대고 curl로 전 구간 end-to-end 확인:
  - 문의 작성 → 목록 조회 → 관리자 답변 등록(상태 자동 HANDLED 전환) → 재답변(내용 수정) → 유저 알림 생성 확인
  - 관리자 상태 수동 토글: `UNHANDLED→HANDLED` 시에만 알림 발송, `HANDLED→UNHANDLED` 되돌릴 때는 미발송 확인
- `./gradlew test` — 문의/관리자/알림 관련 테스트 전부 통과 (`InquiryServiceTest`, `InquiryControllerTest`, `AdminInquiryServiceTest`, `AdminInquiryControllerTest`, `NotificationServiceTest`)

## 🔍 리뷰 포인트
- `AdminInquiryService.updateStatus()`에서 알림 발송 조건을 "실제로 `UNHANDLED→HANDLED`로 전환되는 순간"으로만 제한했습니다(이미 HANDLED인 걸 다시 HANDLED로 바꾸거나 되돌릴 때는 미발송) — 이 판단 기준이 맞는지 확인 부탁드립니다.
- 답변 등록/수정은 같은 엔드포인트(`PATCH /.../answer`)로 처리해 재답변 시 매번 알림이 다시 발송됩니다 — 의도한 동작인지 검토 부탁드립니다.
- MVP 스코프상 답변에 대한 사용자 회신(양방향 대화)은 포함하지 않았습니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 1:1 문의를 카테고리, 제목, 내용과 함께 등록할 수 있습니다.
  * 문의 등록 시 이미지를 첨부하고, 등록한 문의 목록과 상세 내용을 확인할 수 있습니다.
  * 관리자는 문의를 조회하고 상태를 변경하거나 답변을 등록할 수 있습니다.
  * 문의 처리 완료 및 답변 등록 시 알림을 받을 수 있습니다.

* **유효성 검사**
  * 필수 입력값, 제목 길이, 첨부 이미지 개수·용량을 검증합니다.

* **테스트**
  * 문의 등록, 조회, 처리, 답변 및 권한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->