### PR TITLE
[chore] #258 워치리스트/알림 도메인 모니터링 계측 추가

### DIFF
--- a/Pokade/docker-compose.observability.yml
+++ b/Pokade/docker-compose.observability.yml
@@ -13,6 +13,8 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      # named volume - 컨테이너 재생성에도 TSDB 데이터가 남도록(기존엔 볼륨 미지정으로 익명 볼륨에 저장돼 있었음)
+      - prometheus-data:/prometheus
     ports:
       - "127.0.0.1:9090:9090"
 
@@ -22,7 +24,18 @@ services:
     restart: unless-stopped
     environment:
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD}"
+    volumes:
+      # named volume - 기존엔 볼륨 자체가 없어 컨테이너가 재생성될 때마다 데이터소스/대시보드가 통째로 사라졌음
+      - grafana-data:/var/lib/grafana
+      # 데이터소스/대시보드 provider 설정 - UI 수동 생성 대신 코드로 관리
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      # 실제 대시보드 JSON 파일 - 위 provisioning/dashboards의 provider가 이 경로를 바라본다
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
       - "127.0.0.1:3001:3000"
     depends_on:
       - prometheus
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/Pokade/observability/grafana/dashboards/card-domain.json
+++ b/Pokade/observability/grafana/dashboards/card-domain.json
@@ -1,0 +1,114 @@
+{
+  "title": "카드 도메인 모니터링 (#217)",
+  "uid": "pokade-card-domain",
+  "tags": ["pokade", "card", "temp-217"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "카드 검색 평균 응답시간 (card.search.duration)",
+      "description": "@Timed는 count/sum/max만 노출(히스토그램 버킷 없음) - p50/p95 대신 sum/count 비율(평균)을 사용한다. CardService.search().",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_search_duration_seconds_sum[5m]) / rate(card_search_duration_seconds_count[5m]) * 1000",
+          "legendFormat": "avg duration (ms)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "카드 키워드 검색 평균 응답시간 (card.search.keyword.duration)",
+      "description": "@Timed는 count/sum/max만 노출(히스토그램 버킷 없음) - p50/p95 대신 sum/count 비율(평균)을 사용한다. CardService.searchByKeyword().",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_search_keyword_duration_seconds_sum[5m]) / rate(card_search_keyword_duration_seconds_count[5m]) * 1000",
+          "legendFormat": "avg duration (ms)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "카드 상세 조회 호출 (card.view.increment.calls)",
+      "description": "CardService.getDetail() - 상세 조회 1건당 1씩 증가(incrementViewCount() 직후).",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_view_increment_calls_total[5m])",
+          "legendFormat": "view calls/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "등급 배치조회 호출 - N+1 검증용 (card.grade.batch.calls)",
+      "description": "CardService.fetchGradesByCardIds() - 검색 결과 카드 수와 무관하게 요청 1건당 1씩만 증가해야 N+1이 없다는 뜻이다(2026-08-13 실측: 카드 20개 검색 시 이 카운터가 1만 증가함을 확인).",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_grade_batch_calls_total[5m])",
+          "legendFormat": "batch calls/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "카드 API Rate Limit 허용 (card.ratelimit.allowed)",
+      "description": "CardRateLimitFilter - IP당 분당 60회 제한 내에서 통과된 요청.",
+      "gridPos": { "x": 0, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_ratelimit_allowed_total[5m])",
+          "legendFormat": "allowed/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "카드 API Rate Limit 차단 (card.ratelimit.rejected)",
+      "description": "CardRateLimitFilter - 분당 60회 초과로 429 처리된 요청.",
+      "gridPos": { "x": 12, "y": 16, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(card_ratelimit_rejected_total[5m])",
+          "legendFormat": "rejected/s",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/Pokade/observability/grafana/dashboards/watchlist-notification.json
+++ b/Pokade/observability/grafana/dashboards/watchlist-notification.json
@@ -1,0 +1,114 @@
+{
+  "title": "워치리스트/알림 모니터링 (#258)",
+  "uid": "pokade-watchlist-notification",
+  "tags": ["pokade", "watchlist", "notification", "temp-258"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "워치리스트 등록 평균 응답시간 (watchlist.add.duration)",
+      "description": "@Timed는 count/sum/max만 노출(히스토그램 버킷 없음) - p50/p95 대신 sum/count 비율(평균)을 사용한다.",
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(watchlist_add_duration_seconds_sum[5m]) / rate(watchlist_add_duration_seconds_count[5m]) * 1000",
+          "legendFormat": "avg duration (ms)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "워치리스트 수정 평균 응답시간 (watchlist.update.duration)",
+      "description": "@Timed는 count/sum/max만 노출(히스토그램 버킷 없음) - p50/p95 대신 sum/count 비율(평균)을 사용한다.",
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "ms" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(watchlist_update_duration_seconds_sum[5m]) / rate(watchlist_update_duration_seconds_count[5m]) * 1000",
+          "legendFormat": "avg duration (ms)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "워치리스트 알림 즉시 생성 (watchlist.notify.immediate.calls)",
+      "description": "claimed>0 - 등록/수정 요청 자체가 목표가 도달을 감지해 즉시 알림을 만든 비율.",
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(watchlist_notify_immediate_calls_total[5m])",
+          "legendFormat": "immediate calls/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "워치리스트 알림 - 배치(Batch)가 이미 선점함 (watchlist.notify.already_claimed.calls)",
+      "description": "claimed==0 - 즉시 알림 경로가 markAsNotifiedIfNotYet()을 호출했을 때, 배치(WatchlistTargetPriceNoticeProcessor)가 그 전에 이미 알림을 선점 처리해 스킵한 비율.",
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(watchlist_notify_already_claimed_calls_total[5m])",
+          "legendFormat": "already claimed by batch/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "SSE 활성 연결 수 (notification.sse.active.connections)",
+      "description": "SseEmitterStore에 현재 등록된 Emitter 총 개수(Gauge, 실시간 값).",
+      "gridPos": { "x": 0, "y": 16, "w": 8, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "notification_sse_active_connections",
+          "legendFormat": "active connections",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "SSE 하트비트 전송 실패율 (notification.sse.heartbeat.failure.calls)",
+      "description": "sendHeartbeat()에서만 집계 - 일반 알림 push(pushToSubscribers) 실패는 포함하지 않는다.",
+      "gridPos": { "x": 8, "y": 16, "w": 16, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(notification_sse_heartbeat_failure_calls_total[5m])",
+          "legendFormat": "heartbeat failures/s",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/Pokade/observability/grafana/provisioning/dashboards/dashboard.yml
+++ b/Pokade/observability/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,14 @@
+# Grafana 대시보드 provider provisioning - #258, 팀 논의 전 커밋 대상 아님.
+# 실제 대시보드 JSON은 여기가 아니라 /var/lib/grafana/dashboards(= ../../dashboards 마운트)에 둔다.
+apiVersion: 1
+
+providers:
+  - name: pokade-dashboards
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/Pokade/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/Pokade/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+# Grafana Prometheus 데이터소스 provisioning - #258, 팀 논의 전 커밋 대상 아님.
+# UI에서 수동으로 만들지 않고 코드로 관리한다. url은 compose 네트워크(pokade_default) 기준 컨테이너명.
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://pokade-prometheus:9090
+    isDefault: true
+    editable: false

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -8,8 +8,11 @@ import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +36,11 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final SseEmitterStore sseEmitterStore;
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
+    // required = false: 슬라이스 테스트엔 MeterRegistry 빈이 없어 컨텍스트 로딩이 깨지는 문제(#224 유사)를 막기 위함.
+    @Autowired(required = false)
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     public List<NotificationResponse> getNotifications(Long userId) {
         return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
@@ -101,16 +109,26 @@ public class NotificationService {
     @Scheduled(fixedRate = HEARTBEAT_INTERVAL_MILLIS)
     public void sendHeartbeat() {
         for (SseEmitter emitter : sseEmitterStore.findAll()) {
-            sendEvent(emitter, SseEmitter.event().comment("heartbeat"));
+            // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님. 하트비트 전송 실패율만 별도로 보기 위해
+            // 실패 카운터 지표명을 넘기는 오버로드를 쓴다 - 일반 알림 push(pushToSubscribers)는 대상 아님.
+            sendEvent(emitter, SseEmitter.event().comment("heartbeat"), "notification.sse.heartbeat.failure.calls");
         }
     }
 
     // 하나의 Emitter 전송 실패가 나머지 Emitter 처리를 막지 않도록 예외를 여기서 흡수한다.
     private void sendEvent(SseEmitter emitter, SseEmitter.SseEventBuilder event) {
+        sendEvent(emitter, event, null);
+    }
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님. failureMetricName이 있을 때만 실패 카운터를 증가시킨다.
+    private void sendEvent(SseEmitter emitter, SseEmitter.SseEventBuilder event, String failureMetricName) {
         try {
             emitter.send(event);
         } catch (IOException e) {
             log.info("SSE 전송 실패로 연결을 종료합니다.", e);
+            if (failureMetricName != null) {
+                meterRegistry.counter(failureMetricName).increment();
+            }
             emitter.completeWithError(e);
         }
     }

--- a/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
@@ -1,6 +1,10 @@
 package com.pokade.domain.notification.store;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -17,6 +21,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class SseEmitterStore {
 
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
+    // required = false: 슬라이스 테스트엔 MeterRegistry 빈이 없어 컨텍스트 로딩이 깨지는 문제(#224 유사)를 막기 위함.
+    @Autowired(required = false)
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
+    // emitters 맵 자체를 상태 객체로 등록해, 스크레이프 시점마다 그 시점의 총 연결 수(유저별 리스트 크기 합)를
+    // 즉석에서 계산한다 - 별도 카운터 필드를 직접 증감시키지 않아 save()/remove()의 동시성 로직과 분리된다.
+    @PostConstruct
+    private void registerActiveConnectionsGauge() {
+        meterRegistry.gauge("notification.sse.active.connections", emitters,
+                m -> m.values().stream().mapToInt(List::size).sum());
+    }
 
     public void save(Long userId, SseEmitter emitter) {
         emitters.computeIfAbsent(userId, key -> new CopyOnWriteArrayList<>()).add(emitter);

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -15,7 +15,11 @@ import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,6 +44,16 @@ public class WatchlistService {
     private final CardNameKoResolver cardNameKoResolver;
     private final NotificationService notificationService;
 
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
+    // final이 아니라 Lombok @RequiredArgsConstructor 생성 대상에서 빠져 기존 테스트(@InjectMocks) 영향 없음.
+    // required = false: @DataJpaTest 등 슬라이스 테스트엔 MeterRegistry 빈이 없어 NoSuchBeanDefinitionException으로
+    // 컨텍스트 로딩 자체가 깨졌다(#224). 매칭되는 빈이 없으면 Spring이 필드를 건드리지 않고 그대로 두므로
+    // 아래 기본값(SimpleMeterRegistry)이 계속 살아남아 null이 되지 않는다.
+    @Autowired(required = false)
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+    @Timed(value = "watchlist.add.duration")
     @Transactional
     public WatchlistResponse addWatchlist(Long userId, WatchlistCreateRequest request) {
         validateAtLeastOneTargetPrice(request.targetBuyPrice(), request.targetSellPrice());
@@ -96,8 +110,12 @@ public class WatchlistService {
         }
         int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
         if (claimed == 0) {
+            // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+            meterRegistry.counter("watchlist.notify.already_claimed.calls").increment();
             return;
         }
+        // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+        meterRegistry.counter("watchlist.notify.immediate.calls").increment();
         watchlist.markAsNotified();
         notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
     }
@@ -163,6 +181,8 @@ public class WatchlistService {
         return null;
     }
 
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+    @Timed(value = "watchlist.update.duration")
     @Transactional
     public WatchlistResponse updateWatchlist(Long userId, Long watchlistId, WatchlistUpdateRequest request) {
         boolean resend = Boolean.TRUE.equals(request.resendNotification());


### PR DESCRIPTION
## 📌 관련 이슈
- #258 

## ✨ 작업 내용
- 워치리스트 도메인 지표 2개 추가: watchlist.add.duration, watchlist.update.duration (@Timed)
- 알림 즉시발송/선점 카운터 2개 추가: watchlist.notify.immediate.calls, watchlist.notify.already_claimed.calls
- 알림 도메인 지표 2개 추가: notification.sse.active.connections (Gauge), notification.sse.heartbeat.failure.calls (counter)
- Grafana/Prometheus provisioning 코드화 (데이터소스 + 워치리스트/알림 대시보드)
  - 재시작 시 Grafana 데이터 유실 방지용 named volume 추가
- 카드 도메인(#217) Grafana 대시보드 복원 (동일 원인으로 유실됐던 것 확인 후 재작성)

## 📸 스크린샷 / 테스트 결과
- /actuator/prometheus에서 6개 지표 실측 확인 완료
- Grafana 대시보드 2개(워치리스트/알림, 카드 도메인) 6개 패널씩 정상 렌더링 확인
- 테스트: 783개 중 11개 실패 (기존 auth/trade 도메인 무관 실패, PR #260 신규 테스트 36개는 전부 통과)
- develop 최신화(PR #260 merge) 완료, NotificationService.java import 충돌만 있었고 로직 충돌 없음

## 🔍 리뷰 포인트
- docker-compose.observability.yml에 인프라 설정(볼륨) 포함돼 있어 인프라 담당자 리뷰 요청
- @Timed는 count/sum/max만 노출해 p50/p95는 못 냄 — 평균 응답시간으로 대체 표현함
- develop의 PR #260(SSE ApplicationEventPublisher 리팩터링)과 병행 존재 확인 완료

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?