### PR TITLE
[Feature] 내 거래 내역 조회 (FR-PROFILE-05)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/MyTradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/MyTradeController.java
@@ -1,0 +1,44 @@
+package com.pokade.domain.trade.controller;
+
+import com.pokade.domain.trade.dto.MyTradeResponse;
+import com.pokade.domain.trade.dto.MyTradeSearchCondition;
+import com.pokade.domain.trade.dto.TradeRole;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users/me/trades")
+@RequiredArgsConstructor
+public class MyTradeController {
+
+    private final TradeService tradeService;
+
+    @GetMapping
+    public ApiResponse<Page<MyTradeResponse>> getMyTrades(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) TradeRole role,
+            @RequestParam(required = false) List<TradeStatus> status,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ApiResponse.ok(tradeService.getMyTrades(
+                userId, new MyTradeSearchCondition(role, status, from, to), pageable));
+    }
+}
+

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeResponse.java
@@ -1,0 +1,39 @@
+package com.pokade.domain.trade.dto;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+
+import java.time.LocalDateTime;
+
+public record MyTradeResponse(
+        Long tradeId,
+        Long listingId,
+        Long cardId,
+        String cardName,
+        String cardImageUrl,
+        Integer price,
+        TradeStatus status,
+        TradeRole role,
+        Long counterpartyId,
+        LocalDateTime createdAt,
+        LocalDateTime completedAt
+) {
+
+    public static MyTradeResponse of(Trade trade, Long userId, Card card) {
+        boolean isBuyer = trade.getBuyerId().equals(userId);
+        return new MyTradeResponse(
+                trade.getId(),
+                trade.getListing().getId(),
+                trade.getListing().getCardId(),
+                card == null ? null : card.getName(),
+                card == null ? null : card.getImageSmall(),
+                trade.getPrice(),
+                trade.getStatus(),
+                isBuyer ? TradeRole.BUY : TradeRole.SELL,
+                isBuyer ? trade.getListing().getSellerId() : trade.getBuyerId(),
+                trade.getCreatedAt(),
+                trade.getConfirmedAt()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeSearchCondition.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeSearchCondition.java
@@ -22,6 +22,9 @@ public record MyTradeSearchCondition(
         if (from != null && to != null && from.isAfter(to)) {
             throw new BusinessException(ErrorCode.INVALID_PERIOD);
         }
+        if (to != null && to.isAfter(MAX_DATE)) {
+            throw new BusinessException(ErrorCode.INVALID_PERIOD);
+        }
     }
 
     public boolean includeBuy() {

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeSearchCondition.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeSearchCondition.java
@@ -1,0 +1,49 @@
+package com.pokade.domain.trade.dto;
+
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyTradeSearchCondition(
+        TradeRole role,
+        List<TradeStatus> statuses,
+        LocalDate from,
+        LocalDate to
+) {
+
+    private static final LocalDate MIN_DATE = LocalDate.of(1970, 1, 1);
+    private static final LocalDate MAX_DATE = LocalDate.of(9999, 12, 31);
+
+    public MyTradeSearchCondition {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BusinessException(ErrorCode.INVALID_PERIOD);
+        }
+    }
+
+    public boolean includeBuy() {
+        return role != TradeRole.SELL;
+    }
+
+    public boolean includeSell() {
+        return role != TradeRole.BUY;
+    }
+
+    // IN 절에는 null을 넘길 수 없어 미지정이면 전체 상태로 채운다
+    public List<TradeStatus> statusesOrAll() {
+        return (statuses == null || statuses.isEmpty()) ? List.of(TradeStatus.values()) : statuses;
+    }
+
+    // 날짜 미지정 시 null을 넘기면 Postgres가 파라미터 타입을 추론하지 못해 센티널 값으로 채운다
+    public LocalDateTime fromDateTime() {
+        return (from == null ? MIN_DATE : from).atStartOfDay();
+    }
+
+    // to 당일 거래까지 포함되도록 다음 날 0시 미만으로 비교한다
+    public LocalDateTime toDateTimeExclusive() {
+        return (to == null ? MAX_DATE : to).plusDays(1).atStartOfDay();
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeRole.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeRole.java
@@ -1,0 +1,6 @@
+package com.pokade.domain.trade.dto;
+
+public enum TradeRole {
+    BUY,
+    SELL
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
@@ -2,6 +2,7 @@ package com.pokade.domain.trade.repository;
 
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,25 +17,46 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             + "WHERE l.cardId = :cardId AND t.status = :status "
             + "ORDER BY t.confirmedAt DESC")
     List<Trade> findRecentCompletedTrades(@Param("cardId") Long cardId,
-                                           @Param("status") TradeStatus status,
-                                           Pageable pageable);
+                                          @Param("status") TradeStatus status,
+                                          Pageable pageable);
 
     @Query("SELECT t FROM Trade t JOIN FETCH t.listing l "
             + "WHERE l.cardId = :cardId AND t.status = :status AND t.confirmedAt >= :from "
             + "ORDER BY t.confirmedAt ASC")
     List<Trade> findCompletedTradesSince(@Param("cardId") Long cardId,
-                                          @Param("status") TradeStatus status,
-                                          @Param("from") LocalDateTime from);
+                                         @Param("status") TradeStatus status,
+                                         @Param("from") LocalDateTime from);
 
     // 회원탈퇴 확정 정리용: 탈퇴한 유저가 구매자 또는 판매자(매물 소유자)로 참여 중인 미종결 거래 조회
     @Query("SELECT t FROM Trade t JOIN FETCH t.listing l "
             + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status IN :statuses")
     List<Trade> findByParticipantIdAndStatusIn(@Param("userId") Long userId,
-                                                @Param("statuses") List<TradeStatus> statuses);
+                                               @Param("statuses") List<TradeStatus> statuses);
 
     // 공개 프로필용: 확정된 거래 수 ( 구매자, 판매자 양쪽 합산)
     @Query("SELECT COUNT(t) FROM Trade t JOIN t.listing l "
             + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status = :status")
     long countByParticipantIdAndStatus(@Param("userId") Long userId,
                                        @Param("status") TradeStatus status);
+
+    // 마이페이지 거래 내역: 구매/판매 역할,상태,기간 필터 + 페이징
+    @Query(value = "SELECT t FROM Trade t JOIN FETCH t.listing l "
+            + "WHERE ((:includeBuy = true AND t.buyerId = :userId) "
+            + "    OR (:includeSell = true AND l.sellerId = :userId)) "
+            + "AND t.status IN :statuses "
+            + "AND t.createdAt >= :from "
+            + "AND t.createdAt < :to",
+            countQuery = "SELECT COUNT(t) FROM Trade t JOIN t.listing l "
+                    + "WHERE ((:includeBuy = true AND t.buyerId = :userId) "
+                    + "    OR (:includeSell = true AND l.sellerId = :userId)) "
+                    + "AND t.status IN :statuses "
+                    + "AND t.createdAt >= :from "
+                    + "AND t.createdAt < :to")
+    Page<Trade> findMyTrades(@Param("userId") Long userId,
+                             @Param("includeBuy") boolean includeBuy,
+                             @Param("includeSell") boolean includeSell,
+                             @Param("statuses") List<TradeStatus> statuses,
+                             @Param("from") LocalDateTime from,
+                             @Param("to") LocalDateTime to,
+                             Pageable pageable);
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -1,9 +1,11 @@
 package com.pokade.domain.trade.service;
 
-import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.dto.MyTradeResponse;
+import com.pokade.domain.trade.dto.MyTradeSearchCondition;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Payment;
@@ -15,8 +17,15 @@ import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -85,6 +94,28 @@ public class TradeService {
         }
 
         return toResponse(trade);
+    }
+
+    public Page<MyTradeResponse> getMyTrades(Long userId, MyTradeSearchCondition condition, Pageable pageable) {
+        Page<Trade> trades = tradeRepository.findMyTrades(
+                userId,
+                condition.includeBuy(),
+                condition.includeSell(),
+                condition.statusesOrAll(),
+                condition.fromDateTime(),
+                condition.toDateTimeExclusive(),
+                pageable);
+
+        Set<Long> cardIds = trades.getContent().stream()
+                .map(trade -> trade.getListing().getCardId())
+                .collect(Collectors.toSet());
+
+        // toResponse()처럼 건건이 조회하면 목록 크기만큼 쿼리가 나가므로 한 번에 모아 온다
+        Map<Long, Card> cards = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, Function.identity()));
+
+        return trades.map(trade ->
+                MyTradeResponse.of(trade, userId, cards.get(trade.getListing().getCardId())));
     }
 
     @Transactional

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
@@ -112,6 +112,15 @@ class MyTradeControllerTest {
     }
 
     @Test
+    void to가_조회_상한을_넘으면_400_INVALID_PERIOD를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/users/me/trades")
+                        .param("to", "+999999999-12-31")
+                        .with(userId(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PERIOD"));
+    }
+
+    @Test
     void 요청_파라미터가_조회_조건으로_그대로_전달된다() throws Exception {
         given(tradeService.getMyTrades(any(), any(), any())).willReturn(Page.empty());
 

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
@@ -1,0 +1,164 @@
+package com.pokade.domain.trade.controller;
+
+import com.pokade.domain.trade.dto.MyTradeResponse;
+import com.pokade.domain.trade.dto.MyTradeSearchCondition;
+import com.pokade.domain.trade.dto.TradeRole;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MyTradeController.class)
+@AutoConfigureMockMvc
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class}) // 인가 계약을 검증하려면 실물 시큐리티 설정이 필요
+class MyTradeControllerTest {
+
+    private static final Long USER_ID = 3L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TradeService tradeService;                                // MyTradeController가 요구
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;                        // 실제 JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;                  // JwtAuthenticationFilter가 요구
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;      // SecurityConfig가 요구
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;          // SecurityConfig가 요구
+    @MockitoBean
+    private RedisAuthorizationRequestRepository authorizationRequestRepository; // SecurityConfig가 요구
+
+    private RequestPostProcessor userId(Long userId) {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    private MyTradeResponse sampleResponse() {
+        return new MyTradeResponse(
+                10L, 20L, 30L, "리자몽", "https://img/small.png",
+                50000, TradeStatus.COMPLETED, TradeRole.BUY, 99L,
+                LocalDateTime.of(2026, 5, 10, 12, 0),
+                LocalDateTime.of(2026, 5, 12, 9, 0));
+    }
+
+    @Test
+    void 무토큰으로_호출하면_401을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/users/me/trades"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 조건에_맞는_거래가_없으면_빈목록과_200을_반환한다() throws Exception {
+        given(tradeService.getMyTrades(eq(USER_ID), any(MyTradeSearchCondition.class), any(Pageable.class)))
+                .willReturn(Page.empty(PageRequest.of(0, 20)));
+
+        mockMvc.perform(get("/api/users/me/trades").with(userId(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isEmpty())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+
+    @Test
+    void from이_to보다_늦으면_400_INVALID_PERIOD를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/users/me/trades")
+                        .param("from", "2026-05-20")
+                        .param("to", "2026-05-10")
+                        .with(userId(USER_ID)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PERIOD"));
+    }
+
+    @Test
+    void 요청_파라미터가_조회_조건으로_그대로_전달된다() throws Exception {
+        given(tradeService.getMyTrades(any(), any(), any())).willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/users/me/trades")
+                        .param("role", "SELL")
+                        .param("status", "PENDING,COMPLETED")
+                        .param("from", "2026-05-01")
+                        .param("to", "2026-05-31")
+                        .with(userId(USER_ID)))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<MyTradeSearchCondition> captor = ArgumentCaptor.forClass(MyTradeSearchCondition.class);
+        verify(tradeService).getMyTrades(eq(USER_ID), captor.capture(), any(Pageable.class));
+
+        MyTradeSearchCondition condition = captor.getValue();
+        assertThat(condition.role()).isEqualTo(TradeRole.SELL);
+        assertThat(condition.statuses()).containsExactly(TradeStatus.PENDING, TradeStatus.COMPLETED);
+        assertThat(condition.from()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(condition.to()).isEqualTo(LocalDate.of(2026, 5, 31));
+    }
+
+    @Test
+    void 페이징_파라미터가_없으면_20건_createdAt_DESC가_기본값이다() throws Exception {
+        given(tradeService.getMyTrades(any(), any(), any())).willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/users/me/trades").with(userId(USER_ID)))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(tradeService).getMyTrades(eq(USER_ID), any(MyTradeSearchCondition.class), captor.capture());
+
+        Pageable pageable = captor.getValue();
+        assertThat(pageable.getPageSize()).isEqualTo(20);
+        assertThat(pageable.getSort().getOrderFor("createdAt").getDirection())
+                .isEqualTo(Sort.Direction.DESC);
+    }
+
+    @Test
+    void 응답에_역할과_상대방_id가_담긴다() throws Exception {
+        given(tradeService.getMyTrades(any(), any(), any()))
+                .willReturn(new PageImpl<>(List.of(sampleResponse()), PageRequest.of(0, 20), 1));
+
+        mockMvc.perform(get("/api/users/me/trades").with(userId(USER_ID)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].tradeId").value(10))
+                .andExpect(jsonPath("$.data.content[0].role").value("BUY"))
+                .andExpect(jsonPath("$.data.content[0].counterpartyId").value(99))
+                .andExpect(jsonPath("$.data.content[0].cardName").value("리자몽"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/trade/repository/TradeRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/repository/TradeRepositoryTest.java
@@ -1,27 +1,30 @@
 package com.pokade.domain.trade.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.trade.dto.MyTradeSearchCondition;
+import com.pokade.domain.trade.dto.TradeRole;
+import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.user.entity.User;
+import com.pokade.support.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
-import com.pokade.domain.card.entity.Card;
-import com.pokade.domain.listing.entity.Listing;
-import com.pokade.domain.listing.entity.ListingGrade;
-import com.pokade.domain.listing.repository.ListingRepository;
-import com.pokade.domain.trade.entity.Trade;
-import com.pokade.domain.trade.entity.TradeStatus;
-import com.pokade.domain.user.entity.User;
-import com.pokade.support.AbstractIntegrationTest;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
-import jakarta.persistence.EntityManager;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 class TradeRepositoryTest extends AbstractIntegrationTest {
@@ -79,6 +82,42 @@ class TradeRepositoryTest extends AbstractIntegrationTest {
                 .executeUpdate();
         entityManager.clear();
         return trade;
+    }
+
+    private Long sellerId() {
+        return ((Number) entityManager.createNativeQuery(
+                "SELECT id FROM users WHERE email = 'trade-seller@test.com'").getSingleResult()).longValue();
+    }
+
+    private Trade persistTrade(Listing listing, Long tradeBuyerId) {
+        return tradeRepository.save(
+                Trade.builder()
+                        .listing(listing)
+                        .buyerId(tradeBuyerId)
+                        .price(listing.getPrice())
+                        .build()
+        );
+    }
+
+    // created_at은 @CreationTimestamp라 지정할 수 없어, 기간 경계 검증을 위해 직접 덮어씀
+    private void overrideCreatedAt(Long tradeId, LocalDateTime createdAt) {
+        entityManager.flush();
+        entityManager.createNativeQuery("UPDATE trades SET created_at = :createdAt WHERE id = :id")
+                .setParameter("createdAt", createdAt)
+                .setParameter("id", tradeId)
+                .executeUpdate();
+        entityManager.clear();
+    }
+
+    private Page<Trade> findMine(Long userId, MyTradeSearchCondition condition, int size) {
+        return tradeRepository.findMyTrades(
+                userId,
+                condition.includeBuy(),
+                condition.includeSell(),
+                condition.statusesOrAll(),
+                condition.fromDateTime(),
+                condition.toDateTimeExclusive(),
+                PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt")));
     }
 
     @Test
@@ -201,5 +240,115 @@ class TradeRepositoryTest extends AbstractIntegrationTest {
                 cardId, TradeStatus.COMPLETED, LocalDateTime.now().minusDays(30));
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t8 role 미지정이면 구매·판매 거래가 모두 조회된다")
+    void t8() {
+        Long otherId = sellerId();
+        persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);   // 내가 구매자
+        persistTrade(persistListing(buyerId, 2000, ListingGrade.B), otherId);   // 내가 판매자
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(null, null, null, null), 20);
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("t9 role=BUY면 내가 구매자인 거래만 조회된다")
+    void t9() {
+        Long otherId = sellerId();
+        persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);
+        persistTrade(persistListing(buyerId, 2000, ListingGrade.B), otherId);
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(TradeRole.BUY, null, null, null), 20);
+
+        assertThat(result.getContent())
+                .singleElement()
+                .satisfies(t -> assertThat(t.getBuyerId()).isEqualTo(buyerId));
+    }
+
+    @Test
+    @DisplayName("t10 role=SELL이면 내가 판매자인 거래만 조회된다")
+    void t10() {
+        Long otherId = sellerId();
+        persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);
+        persistTrade(persistListing(buyerId, 2000, ListingGrade.B), otherId);
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(TradeRole.SELL, null, null, null), 20);
+
+        assertThat(result.getContent())
+                .singleElement()
+                .satisfies(t -> assertThat(t.getListing().getSellerId()).isEqualTo(buyerId));
+    }
+
+    @Test
+    @DisplayName("t11 status를 지정하면 해당 상태의 거래만 조회된다")
+    void t11() {
+        Long otherId = sellerId();
+        persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);   // PENDING
+        Trade cancelled = persistTrade(persistListing(otherId, 2000, ListingGrade.B), buyerId);
+        cancelled.cancel();
+        entityManager.flush();
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(null, List.of(TradeStatus.CANCELLED), null, null), 20);
+
+        assertThat(result.getContent())
+                .extracting(Trade::getStatus)
+                .containsExactly(TradeStatus.CANCELLED);
+    }
+
+    @Test
+    @DisplayName("t12 to에 지정한 날의 거래는 그날 늦은 시각이어도 포함되고, 다음 날은 제외된다")
+    void t12() {
+        Long otherId = sellerId();
+        LocalDate targetDay = LocalDate.of(2026, 5, 10);
+
+        Trade lastMinute = persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);
+        overrideCreatedAt(lastMinute.getId(), targetDay.atTime(23, 30));
+
+        Trade nextDay = persistTrade(persistListing(otherId, 2000, ListingGrade.B), buyerId);
+        overrideCreatedAt(nextDay.getId(), targetDay.plusDays(1).atTime(0, 30));
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(null, null, targetDay, targetDay), 20);
+
+        assertThat(result.getContent())
+                .extracting(Trade::getId)
+                .containsExactly(lastMinute.getId());
+    }
+
+    @Test
+    @DisplayName("t13 내가 참여하지 않은 거래는 조회되지 않는다")
+    void t13() {
+        User outsider = User.createLocalUser("trade-outsider@test.com", "hashed", "outsider");
+        entityManager.persist(outsider);
+        entityManager.flush();
+
+        persistTrade(persistListing(sellerId(), 1000, ListingGrade.A), outsider.getId());
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(null, null, null, null), 20);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("t14 페이지 크기를 넘겨도 totalElements는 전체 건수를 센다")
+    void t14() {
+        Long otherId = sellerId();
+        persistTrade(persistListing(otherId, 1000, ListingGrade.A), buyerId);
+        persistTrade(persistListing(otherId, 2000, ListingGrade.B), buyerId);
+        persistTrade(persistListing(otherId, 3000, ListingGrade.S), buyerId);
+
+        Page<Trade> result = findMine(buyerId,
+                new MyTradeSearchCondition(null, null, null, null), 2);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #259

## ✨ 작업 내용
- `GET /api/users/me/trades` 추가. 본인이 구매자 또는 판매자로 참여한 거래를 역할·상태·기간 필터와 페이징으로 조회
- **컨트롤러는 `MyTradeController`로 신규 생성.** 경로는 명세를 따르되 코드는 trade 도메인에 뒀다. `TradeController`(`/api/trades`)에 두 번째 `@RequestMapping`을 붙이는 것보다 소유권이 분명하다
- **`status`는 의미 그룹이 아니라 원시 상태 다중값으로 받는다.** '진행중'이 어떤 상태들인지는 화면 사정이라, 서버에 묶어두면 화면이 바뀔 때마다 서버를 고쳐야 한다
- **동적 조건은 단일 JPQL.** 서비스에서 기본값을 채워 넣고 `role` 3분기는 `includeBuy`/`includeSell` boolean 두 개로 풀었다. QueryDSL·Specification은 프로젝트에 전례가 없어 이 API 하나 때문에 도입하지 않았다
- **N+1 차단.** 기존 `TradeService.toResponse()`는 카드 이름을 건건이 `findById`로 가져온다(단건 조회라 지금은 무해). 목록에서는 `Listing`을 `JOIN FETCH`하고 `Card`는 `findAllById`로 한 번에 모은다
- 목록 전용 `MyTradeResponse` 신규. `role`·`counterpartyId`는 서버가 계산하고, 썸네일은 `Card.imageSmall`
- `from > to`는 400 `INVALID_PERIOD`. 조건은 맞는데 결과가 없는 경우만 빈 목록 200
- DB 마이그레이션 없음. FE 화면 연동은 별도 이슈

## 📸 스크린샷 / 테스트 결과

**단위·슬라이스 테스트** — `MyTradeControllerTest` 6/6, `TradeRepositoryTest` 신규 7건(t8~t14) 통과

**dev 프로파일 e2e** (`test1@pokade.com`, userId 3)

| 요청 | 결과 |
|---|---|
| 무토큰 | 401 |
| 전체(role 미지정) | total=3, createdAt DESC |
| `role=BUY` / `role=SELL` | 2건 / 1건으로 정확히 분리 |
| `status=COMPLETED` | 1건 |
| `status=PENDING,COMPLETED` | 3건 (콤마 다중값 바인딩 정상) |
| `from=to=2026-03-15` | 1건 — 당일 경계 포함 |
| `to=2026-03-14` | 0건 — 하루 전은 제외 |
| `size=2` | content 2건, totalElements 3 (countQuery 정상) |
| `from > to` | 400 `INVALID_PERIOD` |
| `role=BUYER`(오타) | 400 `INVALID_INPUT` |

**N+1 실측** — `show-sql`로 확인. 거래 3건 / 서로 다른 카드 2종 요청에서 카드 조회는 `where c1_0.id in (?, ?)` **한 방**. 결과가 한 페이지에 들어가면 count 쿼리가 생략돼 총 2방, 페이지를 넘기면 3방, 0건이면 1방이다.

## 🔍 리뷰 포인트
- **`countQuery`를 명시한 이유** — `JOIN FETCH`가 있으면 Spring Data가 count 쿼리를 자동 유도하지 못한다. 본문과 `WHERE` 절이 완전히 같아야 하고, 어긋나면 목록은 멀쩡한데 `totalElements`만 틀리는 형태로 숨는다. t14가 이걸 잡는다
- **날짜 미지정 시 null 대신 센티널 값을 넘긴다** — Postgres가 `(:to IS NULL OR ...)`의 파라미터 타입을 추론하지 못해 `could not determine data type of parameter`로 실패한다. 코드베이스에 `:param IS NULL` 선례가 11곳 있지만 전부 enum·Integer를 컬럼과 직접 비교하는 자리라 타입이 실린다. `LocalDateTime`을 `IS NULL`로만 검사하는 이 자리와는 상황이 다르다
- **상대방 닉네임은 의도적으로 뺐다** — user 도메인 cross-domain이라 `global/port`에 조회 포트를 새로 만들어야 하고 또 다른 N+1이 붙는다. `counterpartyId`만 주면 FE가 프로필 링크는 걸 수 있고, 닉네임이 실제로 필요해지면 그때 포트와 함께 추가하는 게 낫다고 봤다
- **이슈 본문의 `counterpartId`는 오타다. 실제 응답 필드는 `counterpartyId`** — 거래 상대방을 뜻하는 정식 용어가 counterparty라 이쪽으로 갔다. FE 연동 시 주의
- **`TradeRepositoryTest`의 기존 t1·t3·t5·t6은 여전히 실패한다.** 이 PR이 만든 문제가 아니라, `persistCompletedTrade`가 PENDING 거래에 바로 `complete()`를 부르는데 지금은 DELIVERED만 허용해서 생긴 기존 실패다(검수·배송 단계가 들어오면서 테스트가 안 따라간 것). CI가 `-x test`라 드러나지 않았다. 범위를 넘어 이번엔 손대지 않았는데, 같이 고치는 게 낫다고 보시면 알려주세요
- `Page`를 그대로 응답에 실어 `PageImpl` 직렬화 경고가 뜬다. `CardController` 등 기존 코드와 동일한 방식이라 이 PR에서 바꾸지 않았다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (신규 테스트 전부 통과. 위에 적은 기존 실패 4건은 별개)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가? (명세 경로와 동일해 정정 불필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 로그인한 사용자가 자신의 거래 내역을 조회할 수 있습니다.
  * 구매·판매 역할, 거래 상태, 시작일·종료일로 거래 내역을 필터링할 수 있습니다.
  * 거래별 매물, 카드, 가격, 상태, 상대방 및 거래 일시를 확인할 수 있습니다.
  * 거래 내역은 최신 생성순으로 페이지 단위 조회됩니다.

* **버그 수정**
  * 유효하지 않은 기간을 입력하면 오류를 안내합니다.
  * 카드 정보가 없는 거래도 정상적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->