### PR TITLE
[Feature] 거래 검수/배송 관리자 API 구현 #252

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminListingController.java
@@ -3,6 +3,9 @@ package com.pokade.domain.admin.controller;
 import com.pokade.domain.admin.service.AdminListingService;
 import com.pokade.domain.report.dto.ReportResponse;
 import com.pokade.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "관리자 - 매물", description = "매물 신고 조회 및 숨김 처리 API (ADMIN 권한 필요)")
 @RestController
 @RequestMapping("/api/admin")
 @RequiredArgsConstructor
@@ -19,13 +23,18 @@ public class AdminListingController {
 
     private final AdminListingService adminListingService;
 
+    @Operation(summary = "매물 신고 목록 조회", description = "접수된 매물 신고 목록을 조회합니다. 신고가 없으면 빈 배열을 반환합니다.")
     @GetMapping("/reports")
     public ApiResponse<List<ReportResponse>> getListingReports() {
         return ApiResponse.ok(adminListingService.getListingReports());
     }
 
+    @Operation(
+            summary = "매물 숨김 처리",
+            description = "신고 검토 후 매물을 숨김(HIDDEN) 처리합니다. 대상 매물이 없으면 404, 이미 숨김 처리된 매물이면 400을 반환합니다."
+    )
     @PatchMapping("/listings/{id}/hide")
-    public ApiResponse<Void> hideListing(@PathVariable Long id) {
+    public ApiResponse<Void> hideListing(@Parameter(description = "매물 ID") @PathVariable Long id) {
         adminListingService.hideListing(id);
         return ApiResponse.ok("매물이 숨김 처리되었습니다.");
     }

--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminTradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminTradeController.java
@@ -1,0 +1,46 @@
+package com.pokade.domain.admin.controller;
+
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "관리자 - 거래", description = "거래 검수/배송 처리 API (ADMIN 권한 필요)")
+@RestController
+@RequestMapping("/api/admin/trades")
+@RequiredArgsConstructor
+public class AdminTradeController {
+
+    private final TradeService tradeService;
+
+    @Operation(
+            summary = "검수/배송 대기 거래 목록 조회",
+            description = "발송됨(SHIPPED_TO_PLATFORM, 검수 대기)·검수됨(INSPECTED, 배송 대기) 거래를 접수순으로 조회합니다."
+    )
+    @GetMapping
+    public ApiResponse<List<TradeResponse>> getPendingTrades() {
+        return ApiResponse.ok(tradeService.getPendingTrades());
+    }
+
+    @Operation(summary = "검수 완료 처리", description = "발송된 거래를 검수 완료 처리합니다 (SHIPPED_TO_PLATFORM → INSPECTED).")
+    @PatchMapping("/{id}/inspect")
+    public ApiResponse<TradeResponse> inspectTrade(@Parameter(description = "거래 ID") @PathVariable Long id) {
+        return ApiResponse.ok("검수 완료 처리되었습니다.", tradeService.markInspected(id));
+    }
+
+    @Operation(summary = "배송 완료 처리", description = "검수된 거래를 배송 완료 처리합니다 (INSPECTED → DELIVERED).")
+    @PatchMapping("/{id}/deliver")
+    public ApiResponse<TradeResponse> deliverTrade(@Parameter(description = "거래 ID") @PathVariable Long id) {
+        return ApiResponse.ok("배송 완료 처리되었습니다.", tradeService.markDelivered(id));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
@@ -9,6 +9,9 @@ import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.service.ListingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "매물", description = "카드 매물 등록/조회/수정/삭제 API")
 @RestController
 @RequestMapping("/api/listings")
 @RequiredArgsConstructor
@@ -31,6 +35,7 @@ public class ListingController {
 
     private final ListingService listingService;
 
+    @Operation(summary = "매물 등록", description = "판매할 카드 매물을 등록합니다.")
     @PostMapping
     public ApiResponse<ListingResponse> createListing(
             @AuthenticationPrincipal Long sellerId,
@@ -39,41 +44,48 @@ public class ListingController {
         return ApiResponse.ok("매물이 등록되었습니다.", listingService.createListing(sellerId, request));
     }
 
+    @Operation(summary = "판매 중인 매물 목록 조회", description = "특정 카드의 판매 중(ACTIVE)인 매물 목록을 가격 오름차순으로 조회합니다.")
     @GetMapping
-    public ApiResponse<List<ListingSummaryResponse>> getActiveListings(@RequestParam Long cardId) {
+    public ApiResponse<List<ListingSummaryResponse>> getActiveListings(
+            @Parameter(description = "카드 ID") @RequestParam Long cardId
+    ) {
         return ApiResponse.ok(listingService.getActiveListings(cardId));
     }
 
+    @Operation(summary = "호가창 조회", description = "특정 카드의 매물을 등급/변형별로 필터링하여 호가창 형태로 조회합니다.")
     @GetMapping("/{cardId}/orderbook")
     public ApiResponse<List<OrderbookEntryResponse>> getOrderbook(
-            @PathVariable Long cardId,
-            @RequestParam(required = false) Long variantId,
-            @RequestParam(required = false) ListingGrade grade
+            @Parameter(description = "카드 ID") @PathVariable Long cardId,
+            @Parameter(description = "카드 변형 ID (선택)") @RequestParam(required = false) Long variantId,
+            @Parameter(description = "매물 등급 필터 (선택)") @RequestParam(required = false) ListingGrade grade
     ) {
         return ApiResponse.ok(listingService.getOrderbook(cardId, variantId, grade));
     }
 
+    @Operation(summary = "내 매물 목록 조회", description = "로그인한 사용자가 판매자로 등록한 매물 목록을 상태별로 조회합니다.")
     @GetMapping("/me")
     public ApiResponse<List<ListingSummaryResponse>> getMyListings(
             @AuthenticationPrincipal Long sellerId,
-            @RequestParam(required = false) ListingStatus status
+            @Parameter(description = "매물 상태 필터 (선택)") @RequestParam(required = false) ListingStatus status
     ) {
         return ApiResponse.ok(listingService.getMyListings(sellerId, status));
     }
 
+    @Operation(summary = "매물 가격 수정", description = "판매자 본인의 매물 가격을 수정합니다. 판매 중(ACTIVE) 상태가 아니면 실패합니다.")
     @PutMapping("/{id}")
     public ApiResponse<ListingResponse> updateListing(
             @AuthenticationPrincipal Long sellerId,
-            @PathVariable Long id,
+            @Parameter(description = "매물 ID") @PathVariable Long id,
             @Valid @RequestBody ListingUpdateRequest request
     ) {
         return ApiResponse.ok("매물 가격이 수정되었습니다.", listingService.updatePrice(sellerId, id, request));
     }
 
+    @Operation(summary = "매물 삭제", description = "판매자 본인의 매물을 삭제(취소)합니다.")
     @DeleteMapping("/{id}")
     public ApiResponse<Void> deleteListing(
             @AuthenticationPrincipal Long sellerId,
-            @PathVariable Long id
+            @Parameter(description = "매물 ID") @PathVariable Long id
     ) {
         listingService.deleteListing(sellerId, id);
         return ApiResponse.ok("매물이 삭제되었습니다.");

--- a/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/controller/TradeController.java
@@ -4,6 +4,9 @@ import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.service.TradeService;
 import com.pokade.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "거래", description = "즉시구매 및 거래 상태(발송/검수/배송/확정/취소) 관리 API")
 @RestController
 @RequestMapping("/api/trades")
 @RequiredArgsConstructor
@@ -22,6 +26,11 @@ public class TradeController {
 
     private final TradeService tradeService;
 
+    @Operation(
+            summary = "즉시구매 요청",
+            description = "매물을 즉시구매하여 거래를 생성합니다. 본인이 등록한 매물은 구매할 수 없고, "
+                    + "이미 거래 중이거나 판매 중이 아닌 매물이면 실패합니다."
+    )
     @PostMapping
     public ApiResponse<TradeResponse> createTrade(
             @AuthenticationPrincipal Long buyerId,
@@ -30,34 +39,45 @@ public class TradeController {
         return ApiResponse.ok("구매 요청이 접수되었습니다.", tradeService.createTrade(buyerId, request));
     }
 
+    @Operation(summary = "거래 상세 조회", description = "거래 참여자(구매자 또는 판매자)만 조회할 수 있습니다.")
     @GetMapping("/{id}")
     public ApiResponse<TradeResponse> getTrade(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long id
+            @Parameter(description = "거래 ID") @PathVariable Long id
     ) {
         return ApiResponse.ok(tradeService.getTrade(userId, id));
     }
 
+    @Operation(
+            summary = "판매자 발송 처리",
+            description = "판매자가 매물을 플랫폼으로 발송했음을 기록합니다 (PENDING → SHIPPED_TO_PLATFORM). 판매자 본인만 호출할 수 있습니다."
+    )
     @PatchMapping("/{id}/ship")
     public ApiResponse<TradeResponse> shipTrade(
             @AuthenticationPrincipal Long sellerId,
-            @PathVariable Long id
+            @Parameter(description = "거래 ID") @PathVariable Long id
     ) {
         return ApiResponse.ok("발송 처리되었습니다.", tradeService.shipTrade(sellerId, id));
     }
 
+    @Operation(
+            summary = "구매 확정",
+            description = "구매자가 수령한 물품을 확인하고 거래를 최종 확정합니다 (DELIVERED → COMPLETED). "
+                    + "배송 완료(DELIVERED) 상태가 아니면 실패합니다."
+    )
     @PatchMapping("/{id}/confirm")
     public ApiResponse<TradeResponse> confirmTrade(
             @AuthenticationPrincipal Long buyerId,
-            @PathVariable Long id
+            @Parameter(description = "거래 ID") @PathVariable Long id
     ) {
         return ApiResponse.ok("구매가 확정되었습니다.", tradeService.confirmTrade(buyerId, id));
     }
 
+    @Operation(summary = "거래 취소", description = "최종 상태(COMPLETED/CANCELLED)가 아닌 거래를 취소합니다.")
     @PatchMapping("/{id}/cancel")
     public ApiResponse<TradeResponse> cancelTrade(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long id
+            @Parameter(description = "거래 ID") @PathVariable Long id
     ) {
         return ApiResponse.ok("거래가 취소되었습니다.", tradeService.cancelTrade(userId, id));
     }

--- a/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/repository/TradeRepository.java
@@ -37,4 +37,9 @@ public interface TradeRepository extends JpaRepository<Trade, Long> {
             + "WHERE (t.buyerId = :userId OR l.sellerId = :userId) AND t.status = :status")
     long countByParticipantIdAndStatus(@Param("userId") Long userId,
                                        @Param("status") TradeStatus status);
+
+    // 관리자 검수/배송 처리 대기 목록: SHIPPED_TO_PLATFORM(검수 대기), INSPECTED(배송 대기) 거래
+    @Query("SELECT t FROM Trade t JOIN FETCH t.listing l "
+            + "WHERE t.status IN :statuses ORDER BY t.createdAt ASC")
+    List<Trade> findByStatusInOrderByCreatedAtAsc(@Param("statuses") List<TradeStatus> statuses);
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -9,6 +9,7 @@ import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Payment;
 import com.pokade.domain.trade.entity.PaymentMethod;
 import com.pokade.domain.trade.entity.Trade;
+import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.trade.repository.PaymentRepository;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.global.exception.BusinessException;
@@ -17,6 +18,8 @@ import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -118,6 +121,15 @@ public class TradeService {
         trade.shipToPlatform();
 
         return toResponse(trade);
+    }
+
+    // 관리자 검수/배송 처리 대기 목록: 발송됨(검수 대기), 검수됨(배송 대기) 거래
+    public List<TradeResponse> getPendingTrades() {
+        return tradeRepository.findByStatusInOrderByCreatedAtAsc(
+                        List.of(TradeStatus.SHIPPED_TO_PLATFORM, TradeStatus.INSPECTED))
+                .stream()
+                .map(this::toResponse)
+                .toList();
     }
 
     // 관리자 페이지에서 호출 — 인가(관리자 권한 확인)는 호출하는 쪽(관리자 도메인)의 책임.

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
@@ -1,0 +1,155 @@
+package com.pokade.domain.admin.controller;
+
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.config.SecurityConfig;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.security.JwtAuthenticationEntryPoint;
+import com.pokade.global.security.JwtTokenProvider;
+import com.pokade.global.security.TokenBlacklistStore;
+import com.pokade.global.security.oauth.CustomOAuth2UserService;
+import com.pokade.global.security.oauth.OAuth2LoginFailureHandler;
+import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
+import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminTradeController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+class AdminTradeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TradeService tradeService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private TokenBlacklistStore tokenBlacklistStore;
+
+    @MockitoBean
+    private RedisAuthorizationRequestRepository redisAuthorizationRequestRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    @MockitoBean
+    private OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
+
+    @MockitoBean
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    private RequestPostProcessor admin() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                1L, null, List.of(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        return authentication(auth);
+    }
+
+    private RequestPostProcessor user() {
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                1L, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return authentication(auth);
+    }
+
+    private TradeResponse tradeResponseOf(Long id, TradeStatus status) {
+        return new TradeResponse(
+                id, 10L, 200L, 100L, 1L, "리자몽 ex", 10000, status,
+                LocalDateTime.now(), null, null, null, null, LocalDateTime.now());
+    }
+
+    @Test
+    void 검수_배송_대기_목록_조회에_성공하면_200을_반환한다() throws Exception {
+        given(tradeService.getPendingTrades())
+                .willReturn(List.of(tradeResponseOf(1L, TradeStatus.SHIPPED_TO_PLATFORM)));
+
+        mockMvc.perform(get("/api/admin/trades").with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].status").value("SHIPPED_TO_PLATFORM"));
+    }
+
+    @Test
+    void 관리자가_아니면_대기_목록_조회시_403을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/admin/trades").with(user()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 검수_완료_처리에_성공하면_200을_반환한다() throws Exception {
+        given(tradeService.markInspected(1L)).willReturn(tradeResponseOf(1L, TradeStatus.INSPECTED));
+
+        mockMvc.perform(patch("/api/admin/trades/{id}/inspect", 1L).with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("INSPECTED"));
+    }
+
+    @Test
+    void 관리자가_아니면_검수_완료_처리시_403을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/admin/trades/{id}/inspect", 1L).with(user()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 존재하지_않는_거래를_검수처리하면_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.TRADE_NOT_FOUND))
+                .given(tradeService).markInspected(999L);
+
+        mockMvc.perform(patch("/api/admin/trades/{id}/inspect", 999L).with(admin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
+    }
+
+    @Test
+    void 배송_완료_처리에_성공하면_200을_반환한다() throws Exception {
+        given(tradeService.markDelivered(1L)).willReturn(tradeResponseOf(1L, TradeStatus.DELIVERED));
+
+        mockMvc.perform(patch("/api/admin/trades/{id}/deliver", 1L).with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("DELIVERED"));
+    }
+
+    @Test
+    void 관리자가_아니면_배송_완료_처리시_403을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/admin/trades/{id}/deliver", 1L).with(user()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 존재하지_않는_거래를_배송처리하면_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.TRADE_NOT_FOUND))
+                .given(tradeService).markDelivered(999L);
+
+        mockMvc.perform(patch("/api/admin/trades/{id}/deliver", 999L).with(admin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -308,6 +309,35 @@ class TradeServiceTest {
         assertThatThrownBy(() -> tradeService.shipTrade(100L, 1L))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_TRADE_STATUS);
+    }
+
+    @Test
+    void 검수_배송_대기_거래가_없으면_빈_목록을_반환한다() {
+        given(tradeRepository.findByStatusInOrderByCreatedAtAsc(
+                List.of(TradeStatus.SHIPPED_TO_PLATFORM, TradeStatus.INSPECTED)))
+                .willReturn(List.of());
+
+        List<TradeResponse> responses = tradeService.getPendingTrades();
+
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    void 검수_배송_대기_거래_목록을_반환한다() {
+        Trade shipped = tradeOf(100L, 200L);
+        shipped.shipToPlatform();
+        Trade inspected = tradeOf(100L, 200L);
+        inspected.shipToPlatform();
+        inspected.markInspected();
+        given(tradeRepository.findByStatusInOrderByCreatedAtAsc(
+                List.of(TradeStatus.SHIPPED_TO_PLATFORM, TradeStatus.INSPECTED)))
+                .willReturn(List.of(shipped, inspected));
+
+        List<TradeResponse> responses = tradeService.getPendingTrades();
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses.get(0).status()).isEqualTo(TradeStatus.SHIPPED_TO_PLATFORM);
+        assertThat(responses.get(1).status()).isEqualTo(TradeStatus.INSPECTED);
     }
 
     @Test


### PR DESCRIPTION
## 📌 관련 이슈
- #252

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
- `TradeRepository`: 검수/배송 대기 거래 조회 쿼리(`findByStatusInOrderByCreatedAtAsc`) 추가                                                        
  - `TradeService.getPendingTrades()`: `SHIPPED_TO_PLATFORM`(검수 대기) + `INSPECTED`(배송 대기) 거래를 접수순으로 조회                               
  - `AdminTradeController` 신규 생성                                                                                                                  
    - `GET /api/admin/trades` — 검수/배송 대기 목록 조회                                                                                              
    - `PATCH /api/admin/trades/{id}/inspect` — 검수 완료 처리 (`SHIPPED_TO_PLATFORM` → `INSPECTED`)                                                   
    - `PATCH /api/admin/trades/{id}/deliver` — 배송 완료 처리 (`INSPECTED` → `DELIVERED`)                                                             
  - `ListingController`/`TradeController`/`AdminListingController`/`AdminTradeController Swagger(`@Tag`/`@Operation`/`@Parameter`) 어노테이션 추가 
                                        

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?