### PR TITLE
[Feature] #275 워치리스트 목표가 재계산 로직 개선 및 알림 카드명 한글화

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
@@ -4,6 +4,10 @@ import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,8 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/notifications")
 @RequiredArgsConstructor
@@ -23,8 +25,10 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping
-    public ApiResponse<List<NotificationResponse>> getNotifications(@AuthenticationPrincipal Long userId) {
-        return ApiResponse.ok(notificationService.getNotifications(userId));
+    public ApiResponse<Page<NotificationResponse>> getNotifications(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ApiResponse.ok(notificationService.getNotifications(userId, pageable));
     }
 
     @PatchMapping("/{id}/read")

--- a/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/controller/NotificationController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,6 +39,15 @@ public class NotificationController {
     ) {
         notificationService.markAsRead(userId, id);
         return ApiResponse.ok("알림을 읽음 처리했습니다.");
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteNotification(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        notificationService.deleteNotification(userId, id);
+        return ApiResponse.ok("알림을 삭제했습니다.");
     }
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)

--- a/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,4 +36,15 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Notification n WHERE n.id = :id AND n.userId = :userId")
     int deleteByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
+
+    // #162: 자동 정리(하이브리드 TTL) - 읽은 알림은 readCutoff보다 오래되면 삭제, 안 읽은 알림도
+    // unreadCutoff(더 긴 유예기간)보다 오래되면 삭제한다 - 안 읽은 알림이 영원히 안 지워지는 것을 방지한다.
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            DELETE FROM Notification n
+            WHERE (n.isRead = true AND n.createdAt < :readCutoff)
+               OR (n.isRead = false AND n.createdAt < :unreadCutoff)
+            """)
+    int deleteExpiredNotifications(@Param("readCutoff") LocalDateTime readCutoff,
+                                    @Param("unreadCutoff") LocalDateTime unreadCutoff);
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,8 @@
 package com.pokade.domain.notification.repository;
 
 import com.pokade.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -12,6 +14,10 @@ import java.util.Optional;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     List<Notification> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    // #162: 목록 조회 페이지네이션용. 위 findByUserIdOrderByCreatedAtDesc()는 워치리스트 알림 테스트
+    // (WatchlistTargetPriceNoticeConcurrencyTest 등)가 검증/정리 용도로 그대로 쓰고 있어 건드리지 않는다.
+    Page<Notification> findByUserId(Long userId, Pageable pageable);
 
     Optional<Notification> findByIdAndUserId(Long id, Long userId);
 

--- a/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/repository/NotificationRepository.java
@@ -26,4 +26,13 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true WHERE n.id = :id AND n.userId = :userId AND n.isRead = false")
     int markAsReadIfUnread(@Param("id") Long id, @Param("userId") Long userId);
+
+    // #162: 개별 삭제도 markAsReadIfUnread와 같은 이유로 조회-후-삭제 대신 조건부 원자적 DELETE로 처리한다.
+    // 삭제된 행 수가 0이면(존재하지 않거나 본인 소유가 아님) 호출부가 NOTIFICATION_NOT_FOUND로 처리한다 -
+    // 본인 소유가 아닌 알림의 존재 여부를 별도로 노출하지 않는다.
+    // clearAutomatically: 벌크 DELETE는 영속성 컨텍스트를 거치지 않아, 이미 로드되어 관리 중인 엔티티가
+    // 있으면 DB에서 지워진 뒤에도 1차 캐시 때문에 findById 등에서 계속 조회되는 문제가 있어 자동으로 비운다.
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.id = :id AND n.userId = :userId")
+    int deleteByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationCleanupService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationCleanupService.java
@@ -21,7 +21,7 @@ public class NotificationCleanupService {
 
     private final NotificationRepository notificationRepository;
 
-    @Scheduled(cron = "0 0 5 * * *")
+    @Scheduled(cron = "0 0 5 * * MON")
     @Transactional
     public void deleteExpiredNotifications() {
         LocalDateTime readCutoff = LocalDateTime.now().minusDays(READ_RETENTION_DAYS);

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationCleanupService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationCleanupService.java
@@ -1,0 +1,33 @@
+package com.pokade.domain.notification.service;
+
+import com.pokade.domain.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+// 알림 자동 정리 배치(#162, 하이브리드 TTL). 읽은 알림은 READ_RETENTION_DAYS, 안 읽은 알림도
+// UNREAD_RETENTION_DAYS가 지나면 삭제해 notifications 테이블이 무한 누적되지 않게 한다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationCleanupService {
+
+    private static final int READ_RETENTION_DAYS = 30;
+    private static final int UNREAD_RETENTION_DAYS = 180;
+
+    private final NotificationRepository notificationRepository;
+
+    @Scheduled(cron = "0 0 5 * * *")
+    @Transactional
+    public void deleteExpiredNotifications() {
+        LocalDateTime readCutoff = LocalDateTime.now().minusDays(READ_RETENTION_DAYS);
+        LocalDateTime unreadCutoff = LocalDateTime.now().minusDays(UNREAD_RETENTION_DAYS);
+
+        int deleted = notificationRepository.deleteExpiredNotifications(readCutoff, unreadCutoff);
+        log.info("만료된 알림 {}건을 정리했습니다.", deleted);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -48,11 +50,8 @@ public class NotificationService {
     @Autowired(required = false)
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
-    public List<NotificationResponse> getNotifications(Long userId) {
-        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userId)
-                .stream()
-                .map(NotificationResponse::of)
-                .toList();
+    public Page<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
+        return notificationRepository.findByUserId(userId, pageable).map(NotificationResponse::of);
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -68,6 +68,16 @@ public class NotificationService {
         throw new BusinessException(ErrorCode.NOTIFICATION_ALREADY_READ);
     }
 
+    // #162: 본인 소유 알림만 삭제 가능 - 조건부 원자적 DELETE(WHERE id=:id AND userId=:userId)가 0건이면
+    // 존재하지 않거나 본인 소유가 아닌 것이므로 구분 없이 NOTIFICATION_NOT_FOUND로 처리한다.
+    @Transactional
+    public void deleteNotification(Long userId, Long notificationId) {
+        int deleted = notificationRepository.deleteByIdAndUserId(notificationId, userId);
+        if (deleted == 0) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+    }
+
     // 워치리스트 목표가 도달 알림 생성 (reachedTargetPrice: 도달한 것으로 판정된 목표가 - 구매/판매 목표가 중 실제로 도달한 쪽)
     @Transactional
     public void createPriceTargetNotification(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -9,6 +9,7 @@ import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.web.PageableValidator;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,9 @@ public class NotificationService {
     // 보내 연결이 유휴 상태로 조기 종료되지 않도록 한다.
     private static final long HEARTBEAT_INTERVAL_MILLIS = 15_000L;
 
+    // #162: 다른 페이징 API(AiGradeService/CardQueryService/ChatService)와 동일한 상한
+    private static final int MAX_PAGE_SIZE = 100;
+
     private final NotificationRepository notificationRepository;
     private final SseEmitterStore sseEmitterStore;
     private final ApplicationEventPublisher eventPublisher;
@@ -51,6 +55,7 @@ public class NotificationService {
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     public Page<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
+        PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
         return notificationRepository.findByUserId(userId, pageable).map(NotificationResponse::of);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -100,4 +100,39 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
                                                             @Param("grade") ListingGrade grade,
                                                             @Param("status") TradeStatus status,
                                                             @Param("from") LocalDateTime from);
+
+    /**
+     * 워치리스트 "목표가 도달" 판정용(#275): 여러 워치리스트를 배치로 조회할 때, 카드마다 서로 다른
+     * 등록(createdAt) 시점을 각각 적용해서 최저/최고가를 구한다. cardIds[i]와 sinceList[i]가 짝을
+     * 이룬다(같은 인덱스끼리 매칭) - 길이가 다르면 안 된다.
+     *
+     * 네이티브 쿼리에서 enum 파라미터를 그대로 바인딩하면 Hibernate가 ordinal(숫자)로 보내
+     * "character varying = smallint" 타입 오류가 난다(#275 스파이크로 실측 확인) - 그래서 이 default
+     * 메서드가 enum을 문자열로 변환해 실제 네이티브 쿼리 메서드에 넘긴다. 호출부는 기존 메서드들과
+     * 동일하게 enum을 그대로 넘기면 된다.
+     */
+    default List<CardPriceRangeView> findPriceRangesByCardIdsSincePerCard(List<Long> cardIds,
+                                                                           List<LocalDateTime> sinceList,
+                                                                           ListingGrade grade,
+                                                                           TradeStatus status) {
+        return findPriceRangesByCardIdsSincePerCardNative(
+                cardIds.toArray(Long[]::new),
+                sinceList.toArray(LocalDateTime[]::new),
+                grade == null ? null : grade.name(),
+                status.name());
+    }
+
+    @Query(value = """
+            SELECT pairs.card_id AS cardId, MIN(t.price) AS minPrice, MAX(t.price) AS maxPrice
+            FROM unnest(:cardIds, :sinceList) AS pairs(card_id, since)
+            JOIN listings l ON l.card_id = pairs.card_id
+            JOIN trades t ON t.listing_id = l.id
+            WHERE t.status = :status AND t.confirmed_at >= pairs.since
+              AND (:grade IS NULL OR l.grade = :grade)
+            GROUP BY pairs.card_id
+            """, nativeQuery = true)
+    List<CardPriceRangeView> findPriceRangesByCardIdsSincePerCardNative(@Param("cardIds") Long[] cardIds,
+                                                                         @Param("sinceList") LocalDateTime[] sinceList,
+                                                                         @Param("grade") String grade,
+                                                                         @Param("status") String status);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -25,8 +25,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -82,6 +84,9 @@ public class WatchlistService {
         try {
             Watchlist saved = watchlistRepository.save(watchlist);
 
+            // TODO(#275): updateWatchlist()/getWatchlist()와 같은 원인(전체 기간 range 사용)을 공유하지만,
+            // "등록 시점에 이미 도달이면 배치를 기다리지 않고 즉시 알림"이라는 의도된 최적화(아래 주석)와
+            // 상충할 수 있어 이번엔 범위에서 제외함 - 등록 이후 스코프로 바꿀지는 별도 논의 필요.
             PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
                     .findPriceRangesByCardIds(List.of(saved.getCardId()), null, TradeStatus.COMPLETED)
                     .stream()
@@ -122,7 +127,15 @@ public class WatchlistService {
 
     private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
         cardRepository.findById(watchlist.getCardId())
-                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice));
+                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, resolveCardDisplayName(card), reachedTargetPrice));
+    }
+
+    // 알림 문구에 쓸 카드 표시명(#275) - 한글명이 있으면 한글명, 없으면(도감번호 없음/매핑 실패 등) 영문 원본으로
+    // 폴백한다. getWatchlist()가 이미 같은 리졸버를 쓰고 있어 그 패턴을 재사용 가능한 형태로 뽑았다 -
+    // WatchlistTargetPriceNoticeProcessor(배치 알림 경로)도 이 메서드로 위임해서 즉시/배치 두 경로가
+    // 항상 같은 표시명을 쓰도록 한다.
+    String resolveCardDisplayName(Card card) {
+        return Objects.requireNonNullElse(cardNameKoResolver.resolve(card), card.getName());
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {
@@ -139,8 +152,15 @@ public class WatchlistService {
                 .stream()
                 .collect(Collectors.toMap(Card::getId, Function.identity()));
 
+        // #275: 카드마다 "이 워치리스트가 등록된 시점(createdAt) 이후" 체결분만으로 도달을 판정해야 한다
+        // (전체 기간으로 보면 과거 어느 시점에 목표가 범위를 스쳤다는 이유만으로 잘못 판정될 수 있음 - 배치
+        // 판정 경로(WatchlistTargetPriceNoticeProcessor)와 동일한 스코프로 통일). 한 유저는 같은 카드를
+        // 중복 등록할 수 없어(cardId 유니크) cardIds와 sinceList를 같은 순서로 안전하게 페어링할 수 있다.
+        Map<Long, LocalDateTime> createdAtByCardId = watchlists.stream()
+                .collect(Collectors.toMap(Watchlist::getCardId, this::resolveWatchScopeStart, (a, b) -> a));
+        List<LocalDateTime> sinceList = cardIds.stream().map(createdAtByCardId::get).toList();
         Map<Long, PriceTradeStatsRepository.CardPriceRangeView> rangeByCardId =
-                priceTradeStatsRepository.findPriceRangesByCardIds(cardIds, null, TradeStatus.COMPLETED)
+                priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(cardIds, sinceList, null, TradeStatus.COMPLETED)
                         .stream()
                         .collect(Collectors.toMap(PriceTradeStatsRepository.CardPriceRangeView::getCardId, Function.identity()));
         // "등락" 배지용 - 최근 7일 vs 이전 7일 S등급 평균 체결가 비교(%). getStats()/getRanking()과 같은 기준.
@@ -162,6 +182,13 @@ public class WatchlistService {
 
     private boolean isTargetReached(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
         return resolveReachedTargetPrice(watchlist, range) != null;
+    }
+
+    // createdAt은 @CreationTimestamp라 DB에 영속화된 행이면 항상 채워지지만(방금 조회한 워치리스트가
+    // null일 일은 실제로는 없음), 순수 빌더로 만든 인스턴스(단위 테스트 등)나 예상 못한 레거시 데이터에
+    // 대비해 방어적으로 LocalDateTime.MIN(사실상 전체 기간)으로 폴백한다.
+    private LocalDateTime resolveWatchScopeStart(Watchlist watchlist) {
+        return Objects.requireNonNullElse(watchlist.getCreatedAt(), LocalDateTime.MIN);
     }
 
     // 목표가(구매/판매) 도달 판정 - 도달한 목표가 값을 반환(없으면 null).
@@ -199,8 +226,12 @@ public class WatchlistService {
             watchlist.requestNotificationAgain();
         }
 
+        // #275: 전체 기간이 아니라 "이 워치리스트 등록 시점 이후" 체결분만으로 재판정한다 - 목표가를
+        // 수정해도 과거(등록 훨씬 전) 한때 그 가격대였다는 이유만으로 즉시 "도달"로 오판정되던 버그 수정.
+        // getWatchlist()/배치(WatchlistTargetPriceNoticeProcessor)와 동일한 스코프로 통일.
         PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
-                .findPriceRangesByCardIds(List.of(watchlist.getCardId()), null, TradeStatus.COMPLETED)
+                .findPriceRangesByCardIdsSincePerCard(
+                        List.of(watchlist.getCardId()), List.of(resolveWatchScopeStart(watchlist)), null, TradeStatus.COMPLETED)
                 .stream()
                 .findFirst()
                 .orElse(null);

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
@@ -60,6 +60,8 @@ public class WatchlistTargetPriceNoticeProcessor {
             return;
         }
 
-        notificationService.createPriceTargetNotification(watchlist, card.getName(), reachedTargetPrice);
+        // #275: 카드명 한글화 - watchlistService가 이미 가진 CardNameKoResolver 폴백 로직을 재사용한다
+        // (즉시 알림 경로인 WatchlistService.notifyIfTargetAlreadyReached()와 항상 같은 표시명을 쓰도록).
+        notificationService.createPriceTargetNotification(watchlist, watchlistService.resolveCardDisplayName(card), reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -291,6 +291,8 @@ CREATE TABLE IF NOT EXISTS notifications (
     is_read      BOOLEAN NOT NULL DEFAULT FALSE,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+-- 유저별 알림 목록(최신순 페이지네이션) 조회 최적화
+CREATE INDEX IF NOT EXISTS idx_notifications_user_created ON notifications(user_id, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS chat_messages (
     id           BIGSERIAL PRIMARY KEY,

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -140,6 +140,16 @@ class NotificationControllerTest {
     }
 
     @Test
+    void size가_상한을_초과하면_서비스의_INVALID_INPUT_예외가_400으로_응답된다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "size는 최대 100까지 요청할 수 있습니다."))
+                .given(notificationService).getNotifications(any(), any());
+
+        mockMvc.perform(get("/api/notifications?size=101").with(userId(100L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
     void 읽음_처리에_성공하면_200을_반환한다() throws Exception {
         willDoNothing().given(notificationService).markAsRead(anyLong(), anyLong());
 

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -16,10 +16,16 @@ import com.pokade.global.security.oauth.OAuth2LoginSuccessHandler;
 import com.pokade.global.security.oauth.RedisAuthorizationRequestRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -31,14 +37,17 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -88,16 +97,45 @@ class NotificationControllerTest {
     }
 
     @Test
-    void 목록_조회에_성공하면_200과_목록을_반환한다() throws Exception {
+    void 목록_조회에_성공하면_200과_페이지를_반환한다() throws Exception {
         NotificationResponse response = new NotificationResponse(
                 1L, NotificationType.PRICE_TARGET, "메시지", false, LocalDateTime.now());
 
-        given(notificationService.getNotifications(100L)).willReturn(List.of(response));
+        given(notificationService.getNotifications(eq(100L), any(Pageable.class)))
+                .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));
 
         mockMvc.perform(get("/api/notifications").with(userId(100L)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].id").value(1L));
+                .andExpect(jsonPath("$.data.content.length()").value(1))
+                .andExpect(jsonPath("$.data.content[0].id").value(1L))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    void 알림이_없으면_빈_페이지와_200을_반환한다() throws Exception {
+        given(notificationService.getNotifications(eq(100L), any(Pageable.class)))
+                .willReturn(Page.empty(PageRequest.of(0, 20)));
+
+        mockMvc.perform(get("/api/notifications").with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").isEmpty())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+
+    @Test
+    void 페이징_파라미터가_없으면_20건_createdAt_DESC가_기본값이다() throws Exception {
+        given(notificationService.getNotifications(any(), any())).willReturn(Page.empty());
+
+        mockMvc.perform(get("/api/notifications").with(userId(100L)))
+                .andExpect(status().isOk());
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(notificationService).getNotifications(eq(100L), captor.capture());
+
+        Pageable pageable = captor.getValue();
+        assertThat(pageable.getPageSize()).isEqualTo(20);
+        assertThat(pageable.getSort().getOrderFor("createdAt").getDirection())
+                .isEqualTo(Sort.Direction.DESC);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -49,6 +49,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -166,6 +167,26 @@ class NotificationControllerTest {
         mockMvc.perform(patch("/api/notifications/1/read").with(userId(100L)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("NOTIFICATION_ALREADY_READ"));
+    }
+
+    @Test
+    void 삭제에_성공하면_200을_반환한다() throws Exception {
+        willDoNothing().given(notificationService).deleteNotification(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/notifications/1").with(userId(100L)))
+                .andExpect(status().isOk());
+
+        then(notificationService).should().deleteNotification(100L, 1L);
+    }
+
+    @Test
+    void 존재하지_않거나_본인_소유가_아닌_알림_삭제시_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND))
+                .given(notificationService).deleteNotification(anyLong(), anyLong());
+
+        mockMvc.perform(delete("/api/notifications/999").with(userId(100L)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("NOTIFICATION_NOT_FOUND"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -170,6 +171,51 @@ class NotificationRepositoryTest {
         int result = notificationRepository.deleteByIdAndUserId(999_999L, userId);
 
         assertThat(result).isEqualTo(0);
+    }
+
+    @Test
+    void deleteExpiredNotifications_읽은_알림은_기준일이_지나면_삭제되고_그_전이면_유지된다() {
+        Long userId = insertUser("cleanup-read@test.com");
+        Notification oldRead = saveNotification(userId, NotificationType.PRICE_TARGET, "old-read");
+        Notification recentRead = saveNotification(userId, NotificationType.PRICE_TARGET, "recent-read");
+        notificationRepository.markAsReadIfUnread(oldRead.getId(), userId);
+        notificationRepository.markAsReadIfUnread(recentRead.getId(), userId);
+        entityManager.clear();
+        backdateCreatedAt(oldRead.getId(), LocalDateTime.now().minusDays(31));
+        backdateCreatedAt(recentRead.getId(), LocalDateTime.now().minusDays(29));
+
+        int deleted = notificationRepository.deleteExpiredNotifications(
+                LocalDateTime.now().minusDays(30), LocalDateTime.now().minusDays(180));
+
+        assertThat(deleted).isEqualTo(1);
+        assertThat(notificationRepository.findById(oldRead.getId())).isEmpty();
+        assertThat(notificationRepository.findById(recentRead.getId())).isPresent();
+    }
+
+    @Test
+    void deleteExpiredNotifications_안읽은_알림은_읽은_기준일이_지나도_유지되고_더_긴_기준일이_지나야_삭제된다() {
+        Long userId = insertUser("cleanup-unread@test.com");
+        Notification oldUnread = saveNotification(userId, NotificationType.PRICE_TARGET, "old-unread");
+        // 30일(읽은 알림 기준)은 지났지만 180일(안 읽은 알림 기준)은 안 지난 케이스 - 하이브리드 정책의 핵심.
+        Notification recentUnread = saveNotification(userId, NotificationType.PRICE_TARGET, "recent-unread");
+        backdateCreatedAt(oldUnread.getId(), LocalDateTime.now().minusDays(181));
+        backdateCreatedAt(recentUnread.getId(), LocalDateTime.now().minusDays(60));
+
+        int deleted = notificationRepository.deleteExpiredNotifications(
+                LocalDateTime.now().minusDays(30), LocalDateTime.now().minusDays(180));
+
+        assertThat(deleted).isEqualTo(1);
+        assertThat(notificationRepository.findById(oldUnread.getId())).isEmpty();
+        assertThat(notificationRepository.findById(recentUnread.getId())).isPresent();
+    }
+
+    private void backdateCreatedAt(Long notificationId, LocalDateTime createdAt) {
+        entityManager.createNativeQuery("UPDATE notifications SET created_at = :createdAt WHERE id = :id")
+                .setParameter("createdAt", createdAt)
+                .setParameter("id", notificationId)
+                .executeUpdate();
+        entityManager.flush();
+        entityManager.clear();
     }
 
     private Notification saveNotification(Long userId, NotificationType type, String message) {

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -140,6 +140,38 @@ class NotificationRepositoryTest {
         assertThat(notificationRepository.findById(saved.getId()).orElseThrow().isRead()).isFalse();
     }
 
+    @Test
+    void deleteByIdAndUserId는_본인_소유_알림을_1건_삭제한다() {
+        Long userId = insertUser("delete-owner@test.com");
+        Notification saved = saveNotification(userId, NotificationType.PRICE_TARGET, "to-delete");
+
+        int result = notificationRepository.deleteByIdAndUserId(saved.getId(), userId);
+
+        assertThat(result).isEqualTo(1);
+        assertThat(notificationRepository.findById(saved.getId())).isEmpty();
+    }
+
+    @Test
+    void deleteByIdAndUserId는_본인_소유가_아니면_삭제하지_않는다() {
+        Long ownerId = insertUser("delete-owner2@test.com");
+        Long otherUserId = insertUser("delete-other@test.com");
+        Notification saved = saveNotification(ownerId, NotificationType.PRICE_TARGET, "owned");
+
+        int result = notificationRepository.deleteByIdAndUserId(saved.getId(), otherUserId);
+
+        assertThat(result).isEqualTo(0);
+        assertThat(notificationRepository.findById(saved.getId())).isPresent();
+    }
+
+    @Test
+    void deleteByIdAndUserId는_존재하지_않는_알림이면_0건이다() {
+        Long userId = insertUser("delete-none@test.com");
+
+        int result = notificationRepository.deleteByIdAndUserId(999_999L, userId);
+
+        assertThat(result).isEqualTo(0);
+    }
+
     private Notification saveNotification(Long userId, NotificationType type, String message) {
         Notification saved = notificationRepository.save(
                 Notification.builder()

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +51,51 @@ class NotificationRepositoryTest {
 
         assertThat(found).hasSize(1);
         assertThat(found.get(0).getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void findByUserId_페이징은_같은_유저의_알림을_요청한_정렬로_페이지_단위로_조회한다() {
+        Long userId = insertUser("paging@test.com");
+        Notification first = saveNotification(userId, NotificationType.PRICE_TARGET, "first");
+        Notification second = saveNotification(userId, NotificationType.TRADE_CONFIRMED, "second");
+        Notification third = saveNotification(userId, NotificationType.LISTING_STALE, "third");
+
+        Page<Notification> firstPage = notificationRepository.findByUserId(
+                userId, PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+        assertThat(firstPage.getContent()).extracting(Notification::getId)
+                .containsExactly(third.getId(), second.getId());
+        assertThat(firstPage.getTotalElements()).isEqualTo(3);
+        assertThat(firstPage.getTotalPages()).isEqualTo(2);
+
+        Page<Notification> secondPage = notificationRepository.findByUserId(
+                userId, PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+        assertThat(secondPage.getContent()).extracting(Notification::getId)
+                .containsExactly(first.getId());
+    }
+
+    @Test
+    void findByUserId_페이징은_다른_유저의_알림과_섞이지_않는다() {
+        Long userId = insertUser("paging-mine@test.com");
+        Long otherUserId = insertUser("paging-other@test.com");
+        saveNotification(userId, NotificationType.PRICE_TARGET, "mine");
+        saveNotification(otherUserId, NotificationType.PRICE_TARGET, "other");
+
+        Page<Notification> found = notificationRepository.findByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(found.getContent()).hasSize(1);
+        assertThat(found.getContent().get(0).getUserId()).isEqualTo(userId);
+    }
+
+    @Test
+    void findByUserId_페이징은_알림이_없으면_빈_페이지를_반환한다() {
+        Long userId = insertUser("paging-empty@test.com");
+
+        Page<Notification> found = notificationRepository.findByUserId(userId, PageRequest.of(0, 20));
+
+        assertThat(found.getContent()).isEmpty();
+        assertThat(found.getTotalElements()).isZero();
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationCleanupServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationCleanupServiceTest.java
@@ -1,0 +1,45 @@
+package com.pokade.domain.notification.service;
+
+import com.pokade.domain.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationCleanupServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationCleanupService notificationCleanupService;
+
+    @Test
+    void 읽은_알림은_30일_안읽은_알림은_180일_cutoff로_정리를_요청한다() {
+        given(notificationRepository.deleteExpiredNotifications(any(), any())).willReturn(0);
+
+        notificationCleanupService.deleteExpiredNotifications();
+
+        ArgumentCaptor<LocalDateTime> readCutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> unreadCutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(notificationRepository)
+                .deleteExpiredNotifications(readCutoffCaptor.capture(), unreadCutoffCaptor.capture());
+
+        assertThat(readCutoffCaptor.getValue())
+                .isCloseTo(LocalDateTime.now().minusDays(30), within(1, ChronoUnit.MINUTES));
+        assertThat(unreadCutoffCaptor.getValue())
+                .isCloseTo(LocalDateTime.now().minusDays(180), within(1, ChronoUnit.MINUTES));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -115,6 +115,29 @@ class NotificationServiceTest {
                 .extracting("errorCode").isEqualTo(ErrorCode.NOTIFICATION_ALREADY_READ);
     }
 
+    // ===== 삭제 =====
+    // deleteByIdAndUserId()도 markAsReadIfUnread()와 같은 이유로 조건부 원자적 DELETE라, 존재하지 않는
+    // 알림과 본인 소유가 아닌 알림을 구분하지 않고 0건이면 그대로 NOTIFICATION_NOT_FOUND로 처리한다.
+    @Test
+    @DisplayName("삭제: 원자적 삭제가 1건이면 정상 처리된다")
+    void deleteNotification_success() {
+        given(notificationRepository.deleteByIdAndUserId(1L, 1L)).willReturn(1);
+
+        notificationService.deleteNotification(1L, 1L);
+
+        then(notificationRepository).should(Mockito.times(1)).deleteByIdAndUserId(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("삭제: 삭제 0건이면(존재하지 않거나 본인 소유가 아님) NOTIFICATION_NOT_FOUND")
+    void deleteNotification_notFound() {
+        given(notificationRepository.deleteByIdAndUserId(1L, 1L)).willReturn(0);
+
+        assertThatThrownBy(() -> notificationService.deleteNotification(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+    }
+
     // ===== 목표가 도달 알림 생성 =====
     @Test
     @DisplayName("목표가 도달 알림 생성: notificationRepository.save가 호출된다")

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -79,6 +79,18 @@ class NotificationServiceTest {
         assertThat(result.getTotalElements()).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("목록 조회: 페이지 크기가 상한(100)을 초과하면 BusinessException(INVALID_INPUT)을 던진다")
+    void getNotifications_throwsWhenPageSizeExceedsLimit() {
+        Pageable pageable = PageRequest.of(0, 101);
+
+        assertThatThrownBy(() -> notificationService.getNotifications(1L, pageable))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+
+        then(notificationRepository).should(Mockito.never()).findByUserId(Mockito.any(), Mockito.any());
+    }
+
     // ===== 읽음 처리 =====
     // markAsReadIfUnread()는 "조회 후 갱신"이 아니라 조건부 원자적 UPDATE라, 존재하지 않는 알림과
     // 이미 읽은 알림을 구분하려면 0건 갱신 시에만 findByIdAndUserId로 원인을 판별한다.

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -18,6 +18,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -51,24 +55,28 @@ class NotificationServiceTest {
 
     // ===== 목록 조회 =====
     @Test
-    @DisplayName("목록 조회: 알림이 없으면 빈 리스트 반환")
+    @DisplayName("목록 조회: 알림이 없으면 빈 페이지 반환")
     void getNotifications_empty() {
-        given(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L)).willReturn(List.of());
+        Pageable pageable = PageRequest.of(0, 20);
+        given(notificationRepository.findByUserId(1L, pageable)).willReturn(Page.empty(pageable));
 
-        List<NotificationResponse> result = notificationService.getNotifications(1L);
+        Page<NotificationResponse> result = notificationService.getNotifications(1L, pageable);
 
-        assertThat(result).isEmpty();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
     }
 
     @Test
-    @DisplayName("목록 조회: 알림 개수만큼 NotificationResponse 리스트 반환")
+    @DisplayName("목록 조회: 알림 개수만큼 NotificationResponse 페이지 반환")
     void getNotifications_success() {
-        given(notificationRepository.findByUserIdOrderByCreatedAtDesc(1L))
-                .willReturn(List.of(notification(1L), notification(1L)));
+        Pageable pageable = PageRequest.of(0, 20);
+        given(notificationRepository.findByUserId(1L, pageable))
+                .willReturn(new PageImpl<>(List.of(notification(1L), notification(1L)), pageable, 2));
 
-        List<NotificationResponse> result = notificationService.getNotifications(1L);
+        Page<NotificationResponse> result = notificationService.getNotifications(1L, pageable);
 
-        assertThat(result).hasSize(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getTotalElements()).isEqualTo(2);
     }
 
     // ===== 읽음 처리 =====

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
@@ -207,4 +207,64 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
                 .extracting(PriceTradeStatsRepository.CardPriceRangeView::getMinPrice)
                 .containsExactly(5000000);
     }
+
+    @Test
+    @DisplayName("t8 findPriceRangesByCardIdsSincePerCard()는 카드별로 서로 다른 등록 시점(since)을 정확히 페어링해서 적용한다(#275)")
+    void t8() {
+        Card secondCard = Card.builder().name("Blastoise").build();
+        entityManager.persist(secondCard);
+        Long secondCardId = secondCard.getId();
+
+        // 카드1: registeredAt1 이전/이후 체결 섞임 - registeredAt1 이후만 잡혀야 함(2000000 제외, 3000000만)
+        LocalDateTime registeredAt1 = LocalDateTime.now().minusDays(5);
+        Listing card1Before = persistListing(2000000, ListingGrade.S);
+        Listing card1After = persistListing(3000000, ListingGrade.S);
+        persistCompletedTrade(card1Before, registeredAt1.minusDays(1));
+        persistCompletedTrade(card1After, registeredAt1.plusDays(1));
+
+        // 카드2: registeredAt2(카드1과 다른 시점) 기준 - registeredAt2 이전 체결(4000000)은 제외, 이후(5000000)만 포함
+        LocalDateTime registeredAt2 = LocalDateTime.now().minusDays(20);
+        Listing card2Before = Listing.builder().cardId(secondCardId).sellerId(sellerId).price(4000000).grade(ListingGrade.S).build();
+        Listing card2After = Listing.builder().cardId(secondCardId).sellerId(sellerId).price(5000000).grade(ListingGrade.S).build();
+        listingRepository.save(card2Before);
+        listingRepository.save(card2After);
+        persistCompletedTrade(card2Before, registeredAt2.minusDays(1));
+        persistCompletedTrade(card2After, registeredAt2.plusDays(1));
+
+        var ranges = priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(
+                List.of(cardId, secondCardId),
+                List.of(registeredAt1, registeredAt2),
+                null,
+                TradeStatus.COMPLETED);
+
+        assertThat(ranges).hasSize(2);
+        assertThat(ranges).filteredOn(r -> r.getCardId().equals(cardId))
+                .extracting(PriceTradeStatsRepository.CardPriceRangeView::getMinPrice,
+                        PriceTradeStatsRepository.CardPriceRangeView::getMaxPrice)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(3000000, 3000000));
+        assertThat(ranges).filteredOn(r -> r.getCardId().equals(secondCardId))
+                .extracting(PriceTradeStatsRepository.CardPriceRangeView::getMinPrice,
+                        PriceTradeStatsRepository.CardPriceRangeView::getMaxPrice)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(5000000, 5000000));
+    }
+
+    @Test
+    @DisplayName("t9 findPriceRangesByCardIdsSincePerCard()는 grade를 지정하면 해당 등급 체결만 반영한다(#275)")
+    void t9() {
+        LocalDateTime registeredAt = LocalDateTime.now().minusDays(5);
+        Listing sGrade = persistListing(3000000, ListingGrade.S);
+        Listing otherGrade = persistListing(9000000, ListingGrade.PSA10);
+        persistCompletedTrade(sGrade, registeredAt.plusDays(1));
+        persistCompletedTrade(otherGrade, registeredAt.plusDays(1));
+
+        var ranges = priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(
+                List.of(cardId),
+                List.of(registeredAt),
+                ListingGrade.S,
+                TradeStatus.COMPLETED);
+
+        assertThat(ranges).hasSize(1);
+        assertThat(ranges.get(0).getMinPrice()).isEqualTo(3000000);
+        assertThat(ranges.get(0).getMaxPrice()).isEqualTo(3000000);
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -22,7 +22,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -225,7 +227,7 @@ class WatchlistServiceTest {
         assertThat(result).isEmpty();
         then(priceService).should(never()).getSummaries(any(), any(), anyBoolean());
         then(cardRepository).should(never()).findAllById(any());
-        then(priceTradeStatsRepository).should(never()).findPriceRangesByCardIds(any(), any(), any());
+        then(priceTradeStatsRepository).should(never()).findPriceRangesByCardIdsSincePerCard(any(), any(), any(), any());
         then(priceService).should(never()).getChangeRates(any());
     }
 
@@ -290,7 +292,7 @@ class WatchlistServiceTest {
         Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(eq(List.of(10L)), eq(List.of(LocalDateTime.MIN)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of(new PriceRange(10L, 800, 1200)));
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
@@ -306,7 +308,7 @@ class WatchlistServiceTest {
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true)))
                 .willReturn(List.of(new CardPriceSummaryResponse(10L, 500, null, null, "KRW", null, null)));
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(eq(List.of(10L)), eq(List.of(LocalDateTime.MIN)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of(new PriceRange(10L, 300, 9500))); // 과거 한때 9500까지 거래된 적 있음
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
@@ -320,7 +322,7 @@ class WatchlistServiceTest {
         Watchlist watchlist = watchlist(1L, 10L); // targetBuyPrice = 1000
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(eq(List.of(10L)), eq(List.of(LocalDateTime.MIN)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of(new PriceRange(10L, 1500, 2000)));
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
@@ -334,12 +336,37 @@ class WatchlistServiceTest {
         Watchlist watchlist = watchlist(1L, 10L);
         given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlist));
         given(priceService.getSummaries(eq(List.of(10L)), isNull(), eq(true))).willReturn(List.of());
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED)))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(eq(List.of(10L)), eq(List.of(LocalDateTime.MIN)), isNull(), eq(TradeStatus.COMPLETED)))
                 .willReturn(List.of());
 
         List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
 
         assertThat(result.get(0).targetReached()).isFalse();
+    }
+
+    // #275: 워치리스트마다 서로 다른 등록(createdAt) 시점이 카드ID와 정확히 같은 순서로 페어링되어
+    // 리포지토리에 전달되는지 검증한다(배치 페어링 파라미터라 순서가 어긋나면 다른 카드의 since를
+    // 잘못 적용하게 됨).
+    @Test
+    @DisplayName("목록 조회: 워치리스트마다 다른 등록 시점(createdAt)이 카드ID와 정확히 페어링되어 전달된다(#275)")
+    void getWatchlist_pairsEachCardWithItsOwnCreatedAt() {
+        Watchlist watchlistA = watchlist(1L, 10L);
+        Watchlist watchlistB = watchlist(1L, 20L);
+        LocalDateTime createdAtA = LocalDateTime.now().minusDays(10);
+        LocalDateTime createdAtB = LocalDateTime.now().minusDays(1);
+        ReflectionTestUtils.setField(watchlistA, "createdAt", createdAtA);
+        ReflectionTestUtils.setField(watchlistB, "createdAt", createdAtB);
+        given(watchlistRepository.findByUserId(1L)).willReturn(List.of(watchlistA, watchlistB));
+        given(priceService.getSummaries(eq(List.of(10L, 20L)), isNull(), eq(true))).willReturn(List.of());
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(
+                eq(List.of(10L, 20L)), eq(List.of(createdAtA, createdAtB)), isNull(), eq(TradeStatus.COMPLETED)))
+                .willReturn(List.of(new PriceRange(10L, 800, 1200)));
+
+        List<WatchlistResponse> result = watchlistService.getWatchlist(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).targetReached()).isTrue();
+        assertThat(result.get(1).targetReached()).isFalse();
     }
 
     @Test
@@ -448,7 +475,7 @@ class WatchlistServiceTest {
     void updateWatchlist_targetReached_reflectsActualPriceRange() {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
 
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
@@ -462,7 +489,7 @@ class WatchlistServiceTest {
     void updateWatchlist_targetReached_falseWhenOutOfRange() {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
 
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(9000, null, null));
@@ -477,7 +504,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false(메모리 스냅샷 - 배치가 이미 선점한 상황을 재현)
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
         given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(0);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
 
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
@@ -493,7 +520,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
         given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
         given(cardRepository.findById(10L)).willReturn(Optional.of(card));
@@ -511,7 +538,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
         target.markAsNotified();
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 800, 1200)));
 
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null, null));
@@ -528,7 +555,7 @@ class WatchlistServiceTest {
         target.markAsNotified();
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
         given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 800, 1200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
         given(cardRepository.findById(10L)).willReturn(Optional.of(card));
@@ -545,7 +572,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
         given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         Card card = Card.builder().id(10L).name("리자몽").build();
         given(cardRepository.findById(10L)).willReturn(Optional.of(card));
@@ -562,7 +589,7 @@ class WatchlistServiceTest {
         Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, isNotified = false
         given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
         given(watchlistRepository.markAsNotifiedIfNotYet(any())).willReturn(1);
-        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(10L), null, TradeStatus.COMPLETED))
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
                 .willReturn(List.of(new PriceRange(10L, 1800, 2200)));
         given(cardRepository.findById(10L)).willReturn(Optional.empty());
 
@@ -571,6 +598,43 @@ class WatchlistServiceTest {
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
         then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+    }
+
+    // #275 버그 재현 테스트: 워치리스트 등록(createdAt) 훨씬 이전에 목표가 범위였다가 지금은 벗어난
+    // 카드에 대해, 등록 시점 이후 범위만 봤을 때는 미도달이어야 한다는 걸 실제 createdAt 값으로 검증한다.
+    // (수정 전 버그: 전체 기간 range를 써서 등록 이전 이력만으로도 "도달"로 잘못 판정됐음)
+    @Test
+    @DisplayName("수정: 등록(createdAt) 시점 이후 범위만 판정에 반영되고, 그 정확한 시점이 리포지토리에 전달된다(#275)")
+    void updateWatchlist_usesActualCreatedAtAsRangeScope() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000
+        LocalDateTime registeredAt = LocalDateTime.now().minusDays(3);
+        ReflectionTestUtils.setField(target, "createdAt", registeredAt);
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        // 등록 이후 범위로 좁히면 목표가(2000)가 그 구간(2500~2700) 밖이라 미도달이어야 한다 -
+        // 등록 이전 전체 기간을 봤다면(버그 재현 시나리오) 과거 저가 이력 때문에 도달로 잘못 나왔을 수 있다.
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(
+                List.of(10L), List.of(registeredAt), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 2500, 2700)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, null));
+
+        assertThat(response.targetReached()).isFalse();
+        // 옛 방식(전체 기간 findPriceRangesByCardIds)은 더 이상 호출되지 않아야 한다.
+        then(priceTradeStatsRepository).should(never()).findPriceRangesByCardIds(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("수정: createdAt이 null(방어적 케이스)이어도 NPE 없이 LocalDateTime.MIN으로 폴백해서 정상 동작한다(#275)")
+    void updateWatchlist_nullCreatedAt_fallsBackToMinSafely() {
+        Watchlist target = watchlist(1L, 10L); // targetBuyPrice = 1000, createdAt = null(빌더 기본값)
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+        given(priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(
+                List.of(10L), List.of(LocalDateTime.MIN), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(10L, 800, 1200)));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(1000, null, null));
+
+        assertThat(response.targetReached()).isTrue();
     }
 
     // ===== 삭제 =====

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
@@ -66,6 +66,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
                 .willReturn(List.of(sinceRegistration));
         given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
         given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(1);
+        given(watchlistService.resolveCardDisplayName(card)).willReturn("리자몽");
 
         processor.process(1L, card, allTimeRange);
 


### PR DESCRIPTION
## 📌 관련 이슈
- #275 

## ✨ 작업 내용
- 워치리스트 목표가 재계산(targetReached) 시 전체 기간 체결가를 기준으로 삼아 오판정되던 버그 수정 
   — 등록 이후 체결가만 스코핑
- 알림 문구의 카드명을 영문에서 한글로 표시
- `GET /api/notifications` 페이지네이션(`Page<>`) 도입
- notifications 테이블 (user_id, created_at) 복합 인덱스 추가
- 개별 알림 삭제 API (`DELETE /api/notifications/{id}`) 추가
- 읽은/오래된 알림 자동 정리 배치 추가 (하이브리드 TTL: 읽은 알림 30일 / 안 읽은 알림 180일, 매주 월요일 새벽 5시)

## 📸 스크린샷 / 테스트 결과
- targetReached 8단계 시나리오 검증 완료 (과거 체결가 시드 → 수정 전이라면 오판정됐을 조건에서 정확히 `false` 반환, 새로고침해도 안정적, 거짓 알림 미생성 확인). 그 외 전 항목 단위 테스트로 검증, `com.pokade.domain.notification.*` 전체 재실행 통과.

## 🔍 리뷰 포인트
- `PriceTradeStatsRepository.java`(price 도메인)에 신규 메서드 추가함. 기존 메서드는 미수정, 순수 추가만 
- 이 PR은 #275(버그 수정)와 #162(알림 UX/관리 개선) 작업을 함께 포함합니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?