### PR TITLE
[Feature] 관리자 회원 관리 API — 목록·정지·정지 해제·강제 탈퇴 (FR-ADMIN-04·05·06)

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminUserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminUserController.java
@@ -1,6 +1,6 @@
 package com.pokade.domain.admin.controller;
 
-import com.pokade.domain.admin.metrics.client.dto.response.AdminUserResponse;
+import com.pokade.domain.admin.dto.response.AdminUserResponse;
 import com.pokade.domain.admin.service.AdminUserService;
 import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
@@ -8,6 +8,7 @@ import com.pokade.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,8 @@ public class AdminUserController {
             @RequestParam(required = false) UserStatus status,
             @RequestParam(required = false) Role role,
             @RequestParam(required = false) String keyword,
-            @PageableDefault(size = DEFAULT_PAGE_SIZE) Pageable pageable) {
+            @PageableDefault(size = DEFAULT_PAGE_SIZE, sort = {"created_At", "id"},
+                    direction = Sort.Direction.DESC) Pageable pageable) {
         return ApiResponse.ok(adminUserService.getUsers(status, role, keyword, pageable));
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminUserController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminUserController.java
@@ -1,0 +1,53 @@
+package com.pokade.domain.admin.controller;
+
+import com.pokade.domain.admin.metrics.client.dto.response.AdminUserResponse;
+import com.pokade.domain.admin.service.AdminUserService;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    private final AdminUserService adminUserService;
+
+    @GetMapping
+    public ApiResponse<Page<AdminUserResponse>> getUsers(
+            @RequestParam(required = false) UserStatus status,
+            @RequestParam(required = false) Role role,
+            @RequestParam(required = false) String keyword,
+            @PageableDefault(size = DEFAULT_PAGE_SIZE) Pageable pageable) {
+        return ApiResponse.ok(adminUserService.getUsers(status, role, keyword, pageable));
+    }
+
+    @PatchMapping("/{userId}/suspend")
+    public ApiResponse<Void> suspend(@AuthenticationPrincipal Long adminId,
+                                     @PathVariable Long userId) {
+        adminUserService.suspend(adminId, userId);
+        return ApiResponse.ok("계정을 정지했습니다.");
+    }
+
+    @PatchMapping("/{userId}/unsuspend")
+    public ApiResponse<Void> unsuspend(@AuthenticationPrincipal Long adminId,
+                                       @PathVariable Long userId) {
+        adminUserService.unsuspend(adminId, userId);
+        return ApiResponse.ok("정지를 해제했습니다.");
+    }
+
+    @DeleteMapping("/{userId}")
+    public ApiResponse<Void> forceWithdraw(@AuthenticationPrincipal Long adminId,
+                                           @PathVariable Long userId) {
+        adminUserService.forceWithdraw(adminId, userId);
+        return ApiResponse.ok("계정을 탈퇴 처리했습니다.");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminUserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminUserResponse.java
@@ -1,4 +1,4 @@
-package com.pokade.domain.admin.metrics.client.dto.response;
+package com.pokade.domain.admin.dto.response;
 
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Provider;

--- a/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminUserResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminUserResponse.java
@@ -1,0 +1,30 @@
+package com.pokade.domain.admin.metrics.client.dto.response;
+
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Provider;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+
+import java.time.LocalDateTime;
+
+public record AdminUserResponse(
+        Long userId,
+        String email,
+        String nickname,
+        Role role,
+        UserStatus status,
+        Provider provider,
+        LocalDateTime joinedAt
+) {
+    public static AdminUserResponse from(User user) {
+        return new AdminUserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getRole(),
+                user.getStatus(),
+                user.getProvider(),
+                user.getCreated_At()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminUserService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminUserService.java
@@ -1,0 +1,88 @@
+package com.pokade.domain.admin.service;
+
+import com.pokade.domain.admin.metrics.client.dto.response.AdminUserResponse;
+import com.pokade.domain.auth.store.RefreshTokenStore;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Role;
+import com.pokade.domain.user.entity.type.UserStatus;
+import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.domain.user.service.WithdrawalConfirmer;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenStore refreshTokenStore;
+    private final WithdrawalConfirmer withdrawalConfirmer;
+
+    // 회원 목록 조회 - 선택 필터는 여기서 null이 아닌 값으로 정규화한다.
+    @Transactional(readOnly = true)
+    public Page<AdminUserResponse> getUsers(UserStatus status, Role role, String keyword, Pageable pageable) {
+        List<UserStatus> statuses = status != null ? List.of(status) : Arrays.asList(UserStatus.values());
+        List<Role> roles = role != null ? List.of(role) : Arrays.asList(Role.values());
+        String normalizedKeyword = keyword != null ? keyword.trim() : "";
+
+        return userRepository.findForAdmin(statuses, roles, normalizedKeyword, pageable)
+                .map(AdminUserResponse::from);
+    }
+
+    // 계정 정지 - 로그인,재발급은 이미 상태로 막히지만, 발급된 refresh를 지위 재발급 경로를 즉시 닫는다
+    @Transactional
+    public void suspend(Long adminId, Long targetId) {
+        User target = findTarget(adminId, targetId);
+        if (target.getStatus() == UserStatus.SUSPENDED) {
+            throw new BusinessException(ErrorCode.ALREADY_SUSPENDED);
+        }
+        if (target.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(ErrorCode.ALREADY_WITHDRAWN);
+        }
+        target.suspend();
+        refreshTokenStore.deleteAll(targetId);
+    }
+
+    // 정지 해제
+    @Transactional
+    public void unsuspend(Long adminId, Long targetId) {
+        User target = findTarget(adminId, targetId);
+        if (target.getStatus() != UserStatus.SUSPENDED) {
+            throw new BusinessException(ErrorCode.NOT_SUSPENDED);
+        }
+        target.unsuspend();
+    }
+
+    // 강제 탈퇴 - 유예 없이 즉시 확정한다. 유예 상태로 만든 뒤 같은 트랜잭션에서 확정 로직을 그대로 재사용한다.
+    @Transactional
+    public void forceWithdraw(Long adminId, Long targetId) {
+        User target = findTarget(adminId, targetId);
+        if (target.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(ErrorCode.ALREADY_WITHDRAWN);
+        }
+        target.requestWithdrawal(LocalDateTime.now());
+        userRepository.flush(); // confirm이 다시 조회하므로 상태 전이를 먼저 반영한다.
+        withdrawalConfirmer.confirm(targetId);
+    }
+
+    private User findTarget(Long adminId, Long targetId) {
+        if (adminId.equals(targetId)) {
+            throw new BusinessException(ErrorCode.ADMIN_CANNOT_TARGET_SELF);
+        }
+        User target = userRepository.findById(targetId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        if (target.getRole() == Role.ADMIN) {
+            throw new BusinessException(ErrorCode.ADMIN_CANNOT_TARGET_ADMIN);
+        }
+        return target;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminUserService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminUserService.java
@@ -1,6 +1,6 @@
 package com.pokade.domain.admin.service;
 
-import com.pokade.domain.admin.metrics.client.dto.response.AdminUserResponse;
+import com.pokade.domain.admin.dto.response.AdminUserResponse;
 import com.pokade.domain.auth.store.RefreshTokenStore;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Role;
@@ -47,6 +47,9 @@ public class AdminUserService {
         }
         if (target.getStatus() == UserStatus.DELETED) {
             throw new BusinessException(ErrorCode.ALREADY_WITHDRAWN);
+        }
+        if (target.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.SUSPEND_NOT_ALLOWED);
         }
         target.suspend();
         refreshTokenStore.deleteAll(targetId);

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -175,4 +175,14 @@ public class User {
         this.profileImageUrl = null;
         return previousKey;
     }
+
+    // 계정을 정지한다 (관리자 제재)
+    public void suspend() {
+        this.status = UserStatus.SUSPENDED;
+    }
+
+    // 정지를 해제한다 (활성 상태로 복구)
+    public void unsuspend() {
+        this.status = UserStatus.ACTIVE;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/repository/UserRepository.java
@@ -1,8 +1,13 @@
 package com.pokade.domain.user.repository;
 
 import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.entity.type.Role;
 import com.pokade.domain.user.entity.type.UserStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -17,7 +22,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-
     List<User> findAllByStatusAndWithdrawalRequestedAtBefore(UserStatus status, LocalDateTime cutoff);
 
+    //관리자 회원 목록: 상태,역할 필터 + 이메일,닉네임 검색 + 페지이.
+    // 선택 필터는 서비스에서 null이 아닌 값으로 정규화해 넘긴다 (미지정미연 전체 값 목록, 검색어 미지정이면 빈 문자열)
+    @Query("SELECT u FROM User u "
+            + "WHERE u.status IN :statuses "
+            + "AND u.role IN :roles "
+            + "AND (LOWER(u.email) LIKE LOWER(CONCAT('%', :keyword, '%')) "
+            + "  OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))")
+    Page<User> findForAdmin(@Param("statuses") List<UserStatus> statuses,
+                            @Param("roles") List<Role> roles,
+                            @Param("keyword") String keyword,
+                            Pageable pageable);
 }

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -63,6 +63,11 @@ public enum ErrorCode {
     // ===== 회원 정지 =====
     ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지된 계정입니다. 고객센터에 문의해주세요."),
     ACCOUNT_NOT_ACTIVE(HttpStatus.FORBIDDEN, "현재 계정 상태에서는 이용할 수 없는 기능입니다."),
+    ADMIN_CANNOT_TARGET_SELF(HttpStatus.BAD_REQUEST, "본인 계정에는 수행할 수 없습니다."),
+    ADMIN_CANNOT_TARGET_ADMIN(HttpStatus.BAD_REQUEST, "관리자 계정에는 수행할 수 없습니다."),
+    ALREADY_SUSPENDED(HttpStatus.BAD_REQUEST, "이미 정지된 계정입니다."),
+    NOT_SUSPENDED(HttpStatus.BAD_REQUEST, "정지 상태가 아닌 계정입니다."),
+    ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "이미 탈퇴 처리된 계정입니다."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -68,6 +68,7 @@ public enum ErrorCode {
     ALREADY_SUSPENDED(HttpStatus.BAD_REQUEST, "이미 정지된 계정입니다."),
     NOT_SUSPENDED(HttpStatus.BAD_REQUEST, "정지 상태가 아닌 계정입니다."),
     ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "이미 탈퇴 처리된 계정입니다."),
+    SUSPEND_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "활성 상태의 계정만 정지할 수 있습니다."),
 
     // ===== AI 등급 진단 =====
     AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 등급 진단 서비스에 일시적인 오류가 발생했습니다."),


### PR DESCRIPTION
## 📌 관련 이슈
- #277

## ✨ 작업 내용

명세의 FR-ADMIN-04·05·06이 미착수였다. 관리자 콘솔 사이드바에서 `회원 관리`가 "준비 중"으로 비활성인 그 메뉴다.

**정지의 효력은 이미 구현되어 있었다.** 정지시킬 수단만 없었다. 정지 계정의 로그인 차단(`AuthService:78`)과 토큰 재발급 차단(`AuthService:119`)이 이미 동작하고 있어, 이번 작업은 상태를 바꾸는 경로를 여는 것이 중심이다.

| Method | 경로 | 설명 |
|---|---|---|
| GET | `/api/admin/users` | 목록 — 상태·역할 필터 + 이메일·닉네임 검색 + 페이징 |
| PATCH | `/api/admin/users/{id}/suspend` | 정지 |
| PATCH | `/api/admin/users/{id}/unsuspend` | 정지 해제 |
| DELETE | `/api/admin/users/{id}` | 강제 탈퇴 |

**`unsuspend`는 명세에 없는 추가분이다.** 정지만 있고 해제가 없으면 오조작을 되돌릴 수단이 DB 직접 수정뿐이다.

**강제 탈퇴는 유예 없이 즉시 확정한다.** 자발 탈퇴는 7일 유예 후 배치가 확정하지만, 관리자 제재는 즉시 효력이 나야 하고 본인이 철회할 수 있어서는 안 된다. 엔티티의 `requestWithdrawal()`을 호출한 뒤 같은 트랜잭션에서 `WithdrawalConfirmer.confirm()`을 부른다. 배치와 공유하는 로직이므로 `WithdrawalConfirmer` 자체는 고치지 않았다.

**되돌릴 수 없는 조작이라 가드를 넣었다.** 본인 계정과 `ADMIN` 역할 계정은 대상이 될 수 없고, 상태가 맞지 않으면 400을 반환한다.

**정지 시 `refreshTokenStore.deleteAll(userId)`를 호출한다.** 로그인과 재발급은 상태로 이미 막히지만 발급된 access 토큰은 만료까지 살아 있어, 재발급 경로를 즉시 닫는다.

**선택 필터는 `:param IS NULL`을 쓰지 않는다.** 서비스에서 널이 아닌 값으로 정규화해 `IN` 절로 넘긴다(미지정이면 전체 enum 목록, 검색어 미지정이면 빈 문자열). `TradeRepository.findMyTrades`와 같은 방식이다.

## 📸 스크린샷 / 테스트 결과

로컬 dev 프로파일 + 실제 DB로 확인했다. CI는 테스트를 건너뛰므로 API를 직접 호출해 검증했다.

| 항목 | 결과 |
|---|---|
| 목록 조회·페이징 | 200 |
| 상태·역할 필터 | 정상 |
| 이메일·닉네임 검색 (대소문자 무시) | 정상 |
| 잘못된 enum 값 | 400 |
| 본인 대상 (정지·탈퇴) | 400 `ADMIN_CANNOT_TARGET_SELF` |
| 관리자 대상 (정지·해제·탈퇴) | 400 `ADMIN_CANNOT_TARGET_ADMIN` |
| 없는 유저 | 404 `USER_NOT_FOUND` |
| 정지 → 재정지 | 200 → 400 `ALREADY_SUSPENDED` |
| 해제 → 재해제 | 200 → 400 `NOT_SUSPENDED` |
| 정지 상태에서 로그인 | 차단됨 (`ACCOUNT_SUSPENDED`) |
| 강제 탈퇴 | `DELETED` + 이메일·닉네임 익명화 + 비밀번호·연락처·생년월일 제거 + `deleted_at` 기록 |
| 재탈퇴 | 400 `ALREADY_WITHDRAWN` |
| 탈퇴 계정 정지·해제 | 400 |

검증용 계정은 DB에 직접 넣고 확인 후 삭제했다.

## 🔍 리뷰 포인트

- `forceWithdraw`의 `@Transactional`이 이 기능의 전제다. 없으면 `findTarget`이 돌려준 엔티티가 준영속 상태가 되어 `requestWithdrawal()`이 반영되지 않고, `confirm()`이 새 트랜잭션에서 `ACTIVE`를 보고 멱등 skip한다. **API는 200을 반환하는데 아무것도 저장되지 않는다.** 구현 중 실제로 겪었고 DB를 직접 확인해서야 드러났다
- `userRepository.flush()`는 `confirm()`이 `findById`로 다시 조회하기 때문에 상태 전이를 먼저 반영하려는 것이다
- 정지에 `DELETED` 검사를 따로 둔 이유는, 익명화된 계정의 상태를 되돌리면 데이터가 꼬이기 때문이다
- 검색어의 `%`·`_`는 와일드카드로 동작한다. 이메일에 `_`가 흔해 `a_b` 검색이 `axb`도 잡는다. 현재 규모에서 문제가 없다고 보고 이스케이프는 넣지 않았다
- 스키마에 `user_sanctions` 테이블이 이미 있으나 이번 구현은 쓰지 않는다. 제재 사유·이력 저장은 범위 밖으로 뒀다. 원래 의도를 아는 분이 있으면 알려주면 좋겠다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (문서 변경 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 회원 목록 조회 기능을 추가했습니다.
  * 상태, 역할, 이메일·닉네임 키워드로 회원을 검색하고 페이지 단위로 확인할 수 있습니다.
  * 관리자가 회원 계정을 정지하거나 정지 해제할 수 있습니다.
  * 관리자가 회원을 강제 탈퇴 처리할 수 있습니다.
  * 본인 또는 다른 관리자 계정에 대한 제한된 작업을 안내하는 오류 처리를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->