### PR TITLE
[Chore] GHCR pokade-backend 이미지 버전 정리 자동화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,21 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
 
+  cleanup-old-images:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # :latest 태그 하나만 쓰다 보니 push할 때마다 새 다이제스트가 쌓이고 이전 것은
+      # 태그 없이(untagged) 남아 GHCR 저장 용량을 계속 먹는다. 최신 4개만 남기고 정리.
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: pokade-backend
+          package-type: container
+          min-versions-to-keep: 4
+          token: ${{ secrets.GHCR_PAT }}
+
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📌 관련 이슈
- #283

## ✨ 작업 내용
- 지금은 `latest` 태그 하나만 써서 push할 때마다 이전 다이제스트가 태그 없이(untagged) GHCR에 그대로 쌓여 저장 용량이 계속 증가한다.
- `build-and-push` 완료 후 병렬로 도는 `cleanup-old-images` 잡을 추가해, `actions/delete-package-versions@v5`로 최신 4개 버전만 남기고 나머지를 자동 삭제한다.
- `deploy` 잡은 이 정리 작업을 기다리지 않도록 `needs`를 `build-and-push`로만 유지했다(배포 지연 없음).

## 📸 스크린샷 / 테스트 결과
- 이 PR이 머지되어 실제 push가 발생해야 워크플로가 동작한다. 머지 후 Actions 탭에서 `cleanup-old-images` 잡 성공 여부를 확인해야 한다.
- 패키지 버전 **삭제**에는 `delete:packages` 스코프가 필요해, 기존 `GHCR_PAT`(현재 docker login에서 재사용 중인 PAT)에 스코프를 추가해두었다.

## 🔍 리뷰 포인트
- `min-versions-to-keep: 4`로 잡았다 — 롤백 여유분을 감안한 숫자라 늘리거나 줄일지는 상의 필요.
- 지금 `docker/build-push-action`이 `latest` 태그 하나만 붙이고 있어서, 버전(다이제스트) 구분은 되지만 태그로 특정 커밋을 지목해 롤백하는 수단은 없다(별도 이슈: [deploy-image-tag-latest-race 트러블슈팅](../../docs/troubleshooting/deploy-image-tag-latest-race.md) 참고, 아직 워크플로에 반영 전).

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가? (워크플로 파일 변경만 있어 해당 없음)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (문서 변경 없음)