### PR TITLE
[Feature] #280 알림-카드 연동 데이터 보강 및 도메인 리팩터링

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardService.java
@@ -7,11 +7,9 @@ import org.springframework.stereotype.Service;
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
-import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,10 +34,6 @@ public class CardService {
     private final CardQueryService cardQueryService;
     private final CardFacetService cardFacetService;
 
-    public Page<CardResponse> search(List<String> types, List<String> rarities, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
-        return cardQueryService.search(types, rarities, expansionId, minPrice, maxPrice, sort, pageable);
-    }
-
     public Page<CardResponse> search(List<String> types, List<String> rarities, List<String> languages, String expansionId, Integer minPrice, Integer maxPrice, String sort, Pageable pageable) {
         return cardQueryService.search(types, rarities, languages, expansionId, minPrice, maxPrice, sort, pageable);
     }
@@ -58,13 +52,5 @@ public class CardService {
 
     public CardFacetsResponse getFacets() {
         return cardFacetService.getFacets();
-    }
-
-    /**
-     * Scrydex external_id로 내부 카드 엔티티를 조회한다. AI 등급진단 등 다른 도메인이
-     * vision/외부 식별 결과를 내부 card_id에 매핑할 때 사용할 수 있도록 제공하는 조회 전용 메서드.
-     */
-    public Optional<Card> findByExternalId(String externalId) {
-        return cardQueryService.findByExternalId(externalId);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.notification.dto;
 
+import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
 
@@ -10,18 +11,30 @@ public record NotificationResponse(
         NotificationType type,
         String message,
         Long cardId,
+        String cardImageUrl,
         boolean isRead,
         LocalDateTime createdAt
 ) {
 
-    public static NotificationResponse of(Notification notification) {
+    // card는 알림 생성/조회 시점에 cardId로 조회한 카드(없으면 null) - 알림 자체엔 이미지를 스냅샷으로
+    // 저장하지 않고 항상 그 시점의 최신 카드 이미지를 반영한다(카드가 무관한 알림은 card=null로 넘긴다).
+    public static NotificationResponse of(Notification notification, Card card) {
         return new NotificationResponse(
                 notification.getId(),
                 notification.getType(),
                 notification.getMessage(),
                 notification.getCardId(),
+                resolveImageUrl(card),
                 notification.isRead(),
                 notification.getCreatedAt()
         );
+    }
+
+    // WatchlistResponse.resolveImageUrl()과 동일한 컨벤션 - imageMedium 우선, 없으면 imageSmall로 폴백.
+    private static String resolveImageUrl(Card card) {
+        if (card == null) {
+            return null;
+        }
+        return card.getImageMedium() != null ? card.getImageMedium() : card.getImageSmall();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
@@ -9,6 +9,7 @@ public record NotificationResponse(
         Long id,
         NotificationType type,
         String message,
+        Long cardId,
         boolean isRead,
         LocalDateTime createdAt
 ) {
@@ -18,6 +19,7 @@ public record NotificationResponse(
                 notification.getId(),
                 notification.getType(),
                 notification.getMessage(),
+                notification.getCardId(),
                 notification.isRead(),
                 notification.getCreatedAt()
         );

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
@@ -38,6 +38,9 @@ public class Notification {
     @Column(length = 255)
     private String message;
 
+    @Column(name = "card_id")
+    private Long cardId;
+
     @Column(name = "is_read", nullable = false)
     private boolean isRead;
 
@@ -46,10 +49,11 @@ public class Notification {
     private LocalDateTime createdAt;
 
     @Builder
-    public Notification(Long userId, NotificationType type, String message) {
+    public Notification(Long userId, NotificationType type, String message, Long cardId) {
         this.userId = userId;
         this.type = type;
         this.message = message;
+        this.cardId = cardId;
         this.isRead = false;
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -90,6 +90,7 @@ public class NotificationService {
                 .userId(watchlist.getUserId())
                 .type(NotificationType.PRICE_TARGET)
                 .message(buildPriceTargetMessage(watchlist, cardName, reachedTargetPrice))
+                .cardId(watchlist.getCardId())
                 .build();
 
         notificationRepository.save(notification);

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.notification.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
@@ -27,7 +29,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -46,6 +53,7 @@ public class NotificationService {
     private static final int MAX_PAGE_SIZE = 100;
 
     private final NotificationRepository notificationRepository;
+    private final CardRepository cardRepository;
     private final SseEmitterStore sseEmitterStore;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -56,7 +64,24 @@ public class NotificationService {
 
     public Page<NotificationResponse> getNotifications(Long userId, Pageable pageable) {
         PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
-        return notificationRepository.findByUserId(userId, pageable).map(NotificationResponse::of);
+        Page<Notification> notifications = notificationRepository.findByUserId(userId, pageable);
+
+        // cardId별로 각각 조회하면 페이지당(최대 MAX_PAGE_SIZE건) N+1이 되므로, distinct cardId로 한 번에
+        // 배치 조회한다(WatchlistService.getWatchlist()와 동일한 패턴). cardId가 없는 알림(INQUIRY_HANDLED 등)은
+        // 애초에 이 목록에서 제외되므로 cardById.get(null)이 자연스럽게 null을 반환한다.
+        List<Long> cardIds = notifications.stream()
+                .map(Notification::getCardId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        // Map.of()는 null 키 조회 시 NPE를 던지므로(cardId가 없는 알림에서 cardById.get(null) 호출 시 문제),
+        // 빈 맵 폴백도 null 키 조회가 안전한 Collections.emptyMap()을 쓴다.
+        Map<Long, Card> cardById = cardIds.isEmpty()
+                ? Collections.emptyMap()
+                : cardRepository.findAllById(cardIds).stream()
+                        .collect(Collectors.toMap(Card::getId, Function.identity()));
+
+        return notifications.map(notification -> NotificationResponse.of(notification, cardById.get(notification.getCardId())));
     }
 
     @Transactional
@@ -84,8 +109,10 @@ public class NotificationService {
     }
 
     // 워치리스트 목표가 도달 알림 생성 (reachedTargetPrice: 도달한 것으로 판정된 목표가 - 구매/판매 목표가 중 실제로 도달한 쪽)
+    // card: 호출자(WatchlistTargetPriceEvaluator/WatchlistTargetPriceNoticeProcessor)가 목표가 판정을 위해
+    // 이미 조회해 둔 카드 - 여기서 다시 조회하지 않고 그대로 재사용해 SSE 즉시 푸시에도 카드 이미지를 채운다.
     @Transactional
-    public void createPriceTargetNotification(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {
+    public void createPriceTargetNotification(Watchlist watchlist, String cardName, Card card, Integer reachedTargetPrice) {
         Notification notification = Notification.builder()
                 .userId(watchlist.getUserId())
                 .type(NotificationType.PRICE_TARGET)
@@ -94,7 +121,7 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
-        pushToSubscribers(watchlist.getUserId(), NotificationResponse.of(notification));
+        pushToSubscribers(watchlist.getUserId(), NotificationResponse.of(notification, card));
     }
 
     private String buildPriceTargetMessage(Watchlist watchlist, String cardName, Integer reachedTargetPrice) {
@@ -115,7 +142,7 @@ public class NotificationService {
                 .build();
 
         notificationRepository.save(notification);
-        eventPublisher.publishEvent(new NotificationPushEvent(userId, NotificationResponse.of(notification)));
+        eventPublisher.publishEvent(new NotificationPushEvent(userId, NotificationResponse.of(notification, null)));
     }
 
     // 트랜잭션이 없는 컨텍스트(단위 테스트 등)에서도 그대로 실행되도록 fallbackExecution=true.

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -3,7 +3,6 @@ package com.pokade.domain.watchlist.service;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
-import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
@@ -16,10 +15,7 @@ import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import io.micrometer.core.annotation.Timed;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +24,6 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -44,15 +39,7 @@ public class WatchlistService {
     private final CardRepository cardRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
     private final CardNameKoResolver cardNameKoResolver;
-    private final NotificationService notificationService;
-
-    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
-    // final이 아니라 Lombok @RequiredArgsConstructor 생성 대상에서 빠져 기존 테스트(@InjectMocks) 영향 없음.
-    // required = false: @DataJpaTest 등 슬라이스 테스트엔 MeterRegistry 빈이 없어 NoSuchBeanDefinitionException으로
-    // 컨텍스트 로딩 자체가 깨졌다(#224). 매칭되는 빈이 없으면 Spring이 필드를 건드리지 않고 그대로 두므로
-    // 아래 기본값(SimpleMeterRegistry)이 계속 살아남아 null이 되지 않는다.
-    @Autowired(required = false)
-    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator;
 
     // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
     @Timed(value = "watchlist.add.duration")
@@ -92,50 +79,15 @@ public class WatchlistService {
                     .stream()
                     .findFirst()
                     .orElse(null);
-            Integer reachedTargetPrice = resolveReachedTargetPrice(saved, range);
+            Integer reachedTargetPrice = watchlistTargetPriceEvaluator.resolveReachedTargetPrice(saved, range);
             boolean targetReached = reachedTargetPrice != null;
             // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
             // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
-            notifyIfNewlyReached(saved, reachedTargetPrice);
+            watchlistTargetPriceEvaluator.notifyIfNewlyReached(saved, reachedTargetPrice);
             return WatchlistResponse.of(saved, targetReached);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
-    }
-
-    // 목표가에 새로 도달한 경우(아직 알림 안 간 상태에서 도달)에만 markAsNotified + 실제 알림 생성을 한다.
-    // "이미 알림 갔는지"는 메모리 값이 아니라 markAsNotifiedIfNotYet()의 원자적 조건부 UPDATE(DB 기준)로
-    // 판정한다 - 배치(WatchlistTargetPriceNoticeProcessor)가 그 사이 먼저 선점했을 수 있어서, 메모리에 로드된
-    // isNotified만 믿으면 중복 알림이 생길 수 있다. claimed>0일 때만 엔티티도 true로 맞춰서, 이 메서드가
-    // 반환하는 WatchlistResponse의 isNotified가 실제 DB 상태와 일치하게 한다(배치는 응답 DTO가 없어서 이
-    // 동기화가 필요 없었던 것과 다른 점).
-    private void notifyIfNewlyReached(Watchlist watchlist, Integer reachedTargetPrice) {
-        if (reachedTargetPrice == null) {
-            return;
-        }
-        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
-        if (claimed == 0) {
-            // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
-            meterRegistry.counter("watchlist.notify.already_claimed.calls").increment();
-            return;
-        }
-        // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
-        meterRegistry.counter("watchlist.notify.immediate.calls").increment();
-        watchlist.markAsNotified();
-        notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
-    }
-
-    private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
-        cardRepository.findById(watchlist.getCardId())
-                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, resolveCardDisplayName(card), reachedTargetPrice));
-    }
-
-    // 알림 문구에 쓸 카드 표시명(#275) - 한글명이 있으면 한글명, 없으면(도감번호 없음/매핑 실패 등) 영문 원본으로
-    // 폴백한다. getWatchlist()가 이미 같은 리졸버를 쓰고 있어 그 패턴을 재사용 가능한 형태로 뽑았다 -
-    // WatchlistTargetPriceNoticeProcessor(배치 알림 경로)도 이 메서드로 위임해서 즉시/배치 두 경로가
-    // 항상 같은 표시명을 쓰도록 한다.
-    String resolveCardDisplayName(Card card) {
-        return Objects.requireNonNullElse(cardNameKoResolver.resolve(card), card.getName());
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {
@@ -157,7 +109,7 @@ public class WatchlistService {
         // 판정 경로(WatchlistTargetPriceNoticeProcessor)와 동일한 스코프로 통일). 한 유저는 같은 카드를
         // 중복 등록할 수 없어(cardId 유니크) cardIds와 sinceList를 같은 순서로 안전하게 페어링할 수 있다.
         Map<Long, LocalDateTime> createdAtByCardId = watchlists.stream()
-                .collect(Collectors.toMap(Watchlist::getCardId, this::resolveWatchScopeStart, (a, b) -> a));
+                .collect(Collectors.toMap(Watchlist::getCardId, watchlistTargetPriceEvaluator::resolveWatchScopeStart, (a, b) -> a));
         List<LocalDateTime> sinceList = cardIds.stream().map(createdAtByCardId::get).toList();
         Map<Long, PriceTradeStatsRepository.CardPriceRangeView> rangeByCardId =
                 priceTradeStatsRepository.findPriceRangesByCardIdsSincePerCard(cardIds, sinceList, null, TradeStatus.COMPLETED)
@@ -181,31 +133,7 @@ public class WatchlistService {
     }
 
     private boolean isTargetReached(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
-        return resolveReachedTargetPrice(watchlist, range) != null;
-    }
-
-    // createdAt은 @CreationTimestamp라 DB에 영속화된 행이면 항상 채워지지만(방금 조회한 워치리스트가
-    // null일 일은 실제로는 없음), 순수 빌더로 만든 인스턴스(단위 테스트 등)나 예상 못한 레거시 데이터에
-    // 대비해 방어적으로 LocalDateTime.MIN(사실상 전체 기간)으로 폴백한다.
-    private LocalDateTime resolveWatchScopeStart(Watchlist watchlist) {
-        return Objects.requireNonNullElse(watchlist.getCreatedAt(), LocalDateTime.MIN);
-    }
-
-    // 목표가(구매/판매) 도달 판정 - 도달한 목표가 값을 반환(없으면 null).
-    // isTargetReached()와 동일한 판정 로직을 재사용 가능한 형태로 추출한 것 (WatchlistTargetPriceNoticeService에서 재사용).
-    Integer resolveReachedTargetPrice(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
-        if (range == null || range.getMinPrice() == null || range.getMaxPrice() == null) {
-            return null;
-        }
-        Integer targetBuyPrice = watchlist.getTargetBuyPrice();
-        if (targetBuyPrice != null && range.getMinPrice() <= targetBuyPrice && targetBuyPrice <= range.getMaxPrice()) {
-            return targetBuyPrice;
-        }
-        Integer targetSellPrice = watchlist.getTargetSellPrice();
-        if (targetSellPrice != null && range.getMinPrice() <= targetSellPrice && targetSellPrice <= range.getMaxPrice()) {
-            return targetSellPrice;
-        }
-        return null;
+        return watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, range) != null;
     }
 
     // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
@@ -231,13 +159,13 @@ public class WatchlistService {
         // getWatchlist()/배치(WatchlistTargetPriceNoticeProcessor)와 동일한 스코프로 통일.
         PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
                 .findPriceRangesByCardIdsSincePerCard(
-                        List.of(watchlist.getCardId()), List.of(resolveWatchScopeStart(watchlist)), null, TradeStatus.COMPLETED)
+                        List.of(watchlist.getCardId()), List.of(watchlistTargetPriceEvaluator.resolveWatchScopeStart(watchlist)), null, TradeStatus.COMPLETED)
                 .stream()
                 .findFirst()
                 .orElse(null);
-        Integer reachedTargetPrice = resolveReachedTargetPrice(watchlist, range);
+        Integer reachedTargetPrice = watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, range);
         boolean targetReached = reachedTargetPrice != null;
-        notifyIfNewlyReached(watchlist, reachedTargetPrice);
+        watchlistTargetPriceEvaluator.notifyIfNewlyReached(watchlist, reachedTargetPrice);
         return WatchlistResponse.of(watchlist, targetReached);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceEvaluator.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceEvaluator.java
@@ -1,0 +1,93 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+// 워치리스트 목표가(구매/판매) 도달 판정 로직의 단일 소유자. 즉시 판정 경로(WatchlistService의
+// 등록/수정)와 배치 판정 경로(WatchlistTargetPriceNoticeProcessor)가 이 클래스에 공통으로 의존해,
+// 두 경로가 항상 같은 기준(범위 판정, 카드 표시명)으로 알림을 생성하도록 한다.
+@Service
+@RequiredArgsConstructor
+public class WatchlistTargetPriceEvaluator {
+
+    private final WatchlistRepository watchlistRepository;
+    private final CardRepository cardRepository;
+    private final NotificationService notificationService;
+    private final CardNameKoResolver cardNameKoResolver;
+
+    // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님.
+    // required = false: 슬라이스 테스트엔 MeterRegistry 빈이 없어 컨텍스트 로딩이 깨지는 문제(#224 유사)를 막기 위함.
+    @Autowired(required = false)
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    // 목표가에 새로 도달한 경우(아직 알림 안 간 상태에서 도달)에만 markAsNotified + 실제 알림 생성을 한다.
+    // "이미 알림 갔는지"는 메모리 값이 아니라 markAsNotifiedIfNotYet()의 원자적 조건부 UPDATE(DB 기준)로
+    // 판정한다 - 배치(WatchlistTargetPriceNoticeProcessor)가 그 사이 먼저 선점했을 수 있어서, 메모리에 로드된
+    // isNotified만 믿으면 중복 알림이 생길 수 있다. claimed>0일 때만 엔티티도 true로 맞춰서, 호출자가 만드는
+    // WatchlistResponse의 isNotified가 실제 DB 상태와 일치하게 한다(배치는 응답 DTO가 없어서 이
+    // 동기화가 필요 없었던 것과 다른 점).
+    public void notifyIfNewlyReached(Watchlist watchlist, Integer reachedTargetPrice) {
+        if (reachedTargetPrice == null) {
+            return;
+        }
+        int claimed = watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId());
+        if (claimed == 0) {
+            // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+            meterRegistry.counter("watchlist.notify.already_claimed.calls").increment();
+            return;
+        }
+        // 임시 계측 - #258, 팀 논의 전 커밋 대상 아님
+        meterRegistry.counter("watchlist.notify.immediate.calls").increment();
+        watchlist.markAsNotified();
+        notifyIfTargetAlreadyReached(watchlist, reachedTargetPrice);
+    }
+
+    private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
+        cardRepository.findById(watchlist.getCardId())
+                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, resolveCardDisplayName(card), reachedTargetPrice));
+    }
+
+    // 알림 문구에 쓸 카드 표시명(#275) - 한글명이 있으면 한글명, 없으면(도감번호 없음/매핑 실패 등) 영문 원본으로
+    // 폴백한다. 즉시 알림 경로(notifyIfTargetAlreadyReached)와 배치 알림 경로
+    // (WatchlistTargetPriceNoticeProcessor)가 항상 같은 표시명을 쓰도록 이 클래스에 단일화했다.
+    public String resolveCardDisplayName(Card card) {
+        return Objects.requireNonNullElse(cardNameKoResolver.resolve(card), card.getName());
+    }
+
+    // createdAt은 @CreationTimestamp라 DB에 영속화된 행이면 항상 채워지지만(방금 조회한 워치리스트가
+    // null일 일은 실제로는 없음), 순수 빌더로 만든 인스턴스(단위 테스트 등)나 예상 못한 레거시 데이터에
+    // 대비해 방어적으로 LocalDateTime.MIN(사실상 전체 기간)으로 폴백한다.
+    public LocalDateTime resolveWatchScopeStart(Watchlist watchlist) {
+        return Objects.requireNonNullElse(watchlist.getCreatedAt(), LocalDateTime.MIN);
+    }
+
+    // 목표가(구매/판매) 도달 판정 - 도달한 목표가 값을 반환(없으면 null).
+    // 즉시 판정 경로(WatchlistService)와 배치 판정 경로(WatchlistTargetPriceNoticeProcessor)가 공유한다.
+    public Integer resolveReachedTargetPrice(Watchlist watchlist, PriceTradeStatsRepository.CardPriceRangeView range) {
+        if (range == null || range.getMinPrice() == null || range.getMaxPrice() == null) {
+            return null;
+        }
+        Integer targetBuyPrice = watchlist.getTargetBuyPrice();
+        if (targetBuyPrice != null && range.getMinPrice() <= targetBuyPrice && targetBuyPrice <= range.getMaxPrice()) {
+            return targetBuyPrice;
+        }
+        Integer targetSellPrice = watchlist.getTargetSellPrice();
+        if (targetSellPrice != null && range.getMinPrice() <= targetSellPrice && targetSellPrice <= range.getMaxPrice()) {
+            return targetSellPrice;
+        }
+        return null;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceEvaluator.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceEvaluator.java
@@ -57,7 +57,7 @@ public class WatchlistTargetPriceEvaluator {
 
     private void notifyIfTargetAlreadyReached(Watchlist watchlist, Integer reachedTargetPrice) {
         cardRepository.findById(watchlist.getCardId())
-                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, resolveCardDisplayName(card), reachedTargetPrice));
+                .ifPresent(card -> notificationService.createPriceTargetNotification(watchlist, resolveCardDisplayName(card), card, reachedTargetPrice));
     }
 
     // 알림 문구에 쓸 카드 표시명(#275) - 한글명이 있으면 한글명, 없으면(도감번호 없음/매핑 실패 등) 영문 원본으로

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
@@ -28,14 +28,14 @@ public class WatchlistTargetPriceNoticeProcessor {
     private final WatchlistRepository watchlistRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
     private final NotificationService notificationService;
-    private final WatchlistService watchlistService;
+    private final WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void process(Long watchlistId, Card card, PriceTradeStatsRepository.CardPriceRangeView allTimeRange) {
         // 새 트랜잭션에서 워치리스트를 재조회한다 - 스케줄러가 후보를 읽은 시점과 이 트랜잭션이 실제로
         // 열리는 시점 사이에 삭제/변경됐을 수 있어, 이전 트랜잭션에서 로드된 인스턴스를 그대로 쓰지 않는다.
         Watchlist watchlist = watchlistRepository.findById(watchlistId).orElse(null);
-        if (watchlist == null || card == null || watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange) == null) {
+        if (watchlist == null || card == null || watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, allTimeRange) == null) {
             return;
         }
 
@@ -46,7 +46,7 @@ public class WatchlistTargetPriceNoticeProcessor {
         PriceTradeStatsRepository.CardPriceRangeView rangeSinceRegistration =
                 sinceRegistration.isEmpty() ? null : sinceRegistration.get(0);
 
-        Integer reachedTargetPrice = watchlistService.resolveReachedTargetPrice(watchlist, rangeSinceRegistration);
+        Integer reachedTargetPrice = watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, rangeSinceRegistration);
         if (reachedTargetPrice == null) {
             return;
         }
@@ -60,8 +60,8 @@ public class WatchlistTargetPriceNoticeProcessor {
             return;
         }
 
-        // #275: 카드명 한글화 - watchlistService가 이미 가진 CardNameKoResolver 폴백 로직을 재사용한다
-        // (즉시 알림 경로인 WatchlistService.notifyIfTargetAlreadyReached()와 항상 같은 표시명을 쓰도록).
-        notificationService.createPriceTargetNotification(watchlist, watchlistService.resolveCardDisplayName(card), reachedTargetPrice);
+        // #275: 카드명 한글화 - WatchlistTargetPriceEvaluator가 가진 CardNameKoResolver 폴백 로직을 재사용한다
+        // (즉시 알림 경로인 WatchlistTargetPriceEvaluator.notifyIfTargetAlreadyReached()와 항상 같은 표시명을 쓰도록).
+        notificationService.createPriceTargetNotification(watchlist, watchlistTargetPriceEvaluator.resolveCardDisplayName(card), reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessor.java
@@ -62,6 +62,6 @@ public class WatchlistTargetPriceNoticeProcessor {
 
         // #275: 카드명 한글화 - WatchlistTargetPriceEvaluator가 가진 CardNameKoResolver 폴백 로직을 재사용한다
         // (즉시 알림 경로인 WatchlistTargetPriceEvaluator.notifyIfTargetAlreadyReached()와 항상 같은 표시명을 쓰도록).
-        notificationService.createPriceTargetNotification(watchlist, watchlistTargetPriceEvaluator.resolveCardDisplayName(card), reachedTargetPrice);
+        notificationService.createPriceTargetNotification(watchlist, watchlistTargetPriceEvaluator.resolveCardDisplayName(card), card, reachedTargetPrice);
     }
 }

--- a/Pokade/src/main/resources/schema.sql
+++ b/Pokade/src/main/resources/schema.sql
@@ -288,6 +288,7 @@ CREATE TABLE IF NOT EXISTS notifications (
     user_id      BIGINT NOT NULL REFERENCES users(id),
     type         VARCHAR(30) NOT NULL,                          -- PRICE_TARGET / TRADE_CONFIRMED / LISTING_STALE / INQUIRY_HANDLED 등
     message      VARCHAR(255),
+    card_id      BIGINT REFERENCES cards(id),                   -- 알림 클릭 시 카드 상세 이동용; 카드와 무관한 알림(문의 처리 등)은 NULL
     is_read      BOOLEAN NOT NULL DEFAULT FALSE,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,6 @@ import org.springframework.data.domain.Pageable;
 import com.pokade.domain.card.dto.CardDetailResponse;
 import com.pokade.domain.card.dto.CardFacetsResponse;
 import com.pokade.domain.card.dto.CardResponse;
-import com.pokade.domain.card.entity.Card;
 
 /**
  * CardService는 CardQueryService/CardFacetService로 위임만 하는 파사드다(카드 도메인
@@ -39,19 +37,6 @@ class CardServiceTest {
 
     @InjectMocks
     private CardService cardService;
-
-    @Test
-    @DisplayName("search(7-인자)는 CardQueryService.search(7-인자)로 위임한다")
-    void searchDelegatesToQueryService() {
-        Pageable pageable = PageRequest.of(0, 20);
-        Page<CardResponse> page = new PageImpl<>(List.of(), pageable, 0);
-        given(cardQueryService.search(List.of("Fire"), List.of("Rare Holo"), "base1", 1000, 2000, "name", pageable))
-                .willReturn(page);
-
-        Page<CardResponse> result = cardService.search(List.of("Fire"), List.of("Rare Holo"), "base1", 1000, 2000, "name", pageable);
-
-        assertThat(result).isSameAs(page);
-    }
 
     @Test
     @DisplayName("search(8-인자, languages 포함)는 CardQueryService.search(8-인자)로 위임한다")
@@ -112,17 +97,6 @@ class CardServiceTest {
 
         assertThat(result).isSameAs(facets);
         verifyNoQueryServiceInteraction();
-    }
-
-    @Test
-    @DisplayName("findByExternalId는 CardQueryService.findByExternalId로 위임한다")
-    void findByExternalIdDelegatesToQueryService() {
-        Card card = Card.builder().id(1L).name("Mew ex").externalId("sv3pt5-151").build();
-        given(cardQueryService.findByExternalId("sv3pt5-151")).willReturn(Optional.of(card));
-
-        Optional<Card> result = cardService.findByExternalId("sv3pt5-151");
-
-        assertThat(result).contains(card);
     }
 
     private void verifyNoQueryServiceInteraction() {

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -100,7 +100,7 @@ class NotificationControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_페이지를_반환한다() throws Exception {
         NotificationResponse response = new NotificationResponse(
-                1L, NotificationType.PRICE_TARGET, "메시지", false, LocalDateTime.now());
+                1L, NotificationType.PRICE_TARGET, "메시지", 10L, false, LocalDateTime.now());
 
         given(notificationService.getNotifications(eq(100L), any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -100,7 +100,7 @@ class NotificationControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_페이지를_반환한다() throws Exception {
         NotificationResponse response = new NotificationResponse(
-                1L, NotificationType.PRICE_TARGET, "메시지", 10L, false, LocalDateTime.now());
+                1L, NotificationType.PRICE_TARGET, "메시지", 10L, "medium.png", false, LocalDateTime.now());
 
         given(notificationService.getNotifications(eq(100L), any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));

--- a/Pokade/src/test/java/com/pokade/domain/notification/dto/NotificationResponseTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/dto/NotificationResponseTest.java
@@ -1,0 +1,46 @@
+package com.pokade.domain.notification.dto;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationResponseTest {
+
+    private Notification notification() {
+        return Notification.builder()
+                .userId(1L).type(NotificationType.PRICE_TARGET).message("메시지").cardId(10L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("of: card가 null이면(카드와 무관한 알림) cardImageUrl도 null이다")
+    void of_nullCard_cardImageUrlNull() {
+        NotificationResponse response = NotificationResponse.of(notification(), null);
+
+        assertThat(response.cardImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("of: imageMedium이 있으면 imageMedium을 cardImageUrl로 쓴다")
+    void of_prefersImageMedium() {
+        Card card = Card.builder().id(10L).name("리자몽").imageSmall("small.png").imageMedium("medium.png").build();
+
+        NotificationResponse response = NotificationResponse.of(notification(), card);
+
+        assertThat(response.cardImageUrl()).isEqualTo("medium.png");
+    }
+
+    @Test
+    @DisplayName("of: imageMedium이 없으면 imageSmall로 폴백한다")
+    void of_fallsBackToImageSmall() {
+        Card card = Card.builder().id(10L).name("리자몽").imageSmall("small.png").build();
+
+        NotificationResponse response = NotificationResponse.of(notification(), card);
+
+        assertThat(response.cardImageUrl()).isEqualTo("small.png");
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -162,7 +162,7 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("목표가 도달 알림 생성: PRICE_TARGET 타입과 워치리스트의 userId로 저장된다")
+    @DisplayName("목표가 도달 알림 생성: PRICE_TARGET 타입과 워치리스트의 userId/cardId로 저장된다")
     void createPriceTargetNotification_type() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
 
@@ -173,6 +173,7 @@ class NotificationServiceTest {
         Notification saved = captor.getValue();
         assertThat(saved.getUserId()).isEqualTo(1L);
         assertThat(saved.getType()).isEqualTo(NotificationType.PRICE_TARGET);
+        assertThat(saved.getCardId()).isEqualTo(10L);
     }
 
     @Test
@@ -252,6 +253,7 @@ class NotificationServiceTest {
         assertThat(saved.getUserId()).isEqualTo(1L);
         assertThat(saved.getType()).isEqualTo(NotificationType.INQUIRY_HANDLED);
         assertThat(saved.getMessage()).contains("결제 문의");
+        assertThat(saved.getCardId()).isNull();
 
         ArgumentCaptor<NotificationPushEvent> eventCaptor = ArgumentCaptor.forClass(NotificationPushEvent.class);
         then(eventPublisher).should().publishEvent(eventCaptor.capture());
@@ -266,7 +268,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 있으면 notification 이벤트를 전송한다")
     void onNotificationPush_pushes_to_subscriber() throws Exception {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, false, null);
         SseEmitter emitter = mock(SseEmitter.class);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
 
@@ -278,7 +280,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 없으면 예외 없이 조용히 스킵된다")
     void onNotificationPush_no_subscriber_noop() {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, false, null);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
 
         assertThatCode(() -> notificationService.onNotificationPush(new NotificationPushEvent(1L, response)))

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.notification.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.notification.dto.NotificationResponse;
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
@@ -43,6 +45,7 @@ import static org.mockito.Mockito.never;
 class NotificationServiceTest {
 
     @Mock NotificationRepository notificationRepository;
+    @Mock CardRepository cardRepository;
     @Mock SseEmitterStore sseEmitterStore;
     @Mock ApplicationEventPublisher eventPublisher;
     @InjectMocks NotificationService notificationService;
@@ -51,6 +54,10 @@ class NotificationServiceTest {
         return Notification.builder()
                 .userId(userId).type(NotificationType.PRICE_TARGET).message("메시지")
                 .build();
+    }
+
+    private Card card() {
+        return Card.builder().id(10L).name("리자몽").imageMedium("medium.png").build();
     }
 
     // ===== 목록 조회 =====
@@ -77,6 +84,48 @@ class NotificationServiceTest {
 
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("목록 조회: cardId가 없는 알림만 있으면 카드를 배치 조회하지 않고 cardImageUrl은 null이다")
+    void getNotifications_noCardId_skipsCardBatchFetch() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Notification inquiryHandled = Notification.builder()
+                .userId(1L).type(NotificationType.INQUIRY_HANDLED).message("메시지").build();
+        given(notificationRepository.findByUserId(1L, pageable))
+                .willReturn(new PageImpl<>(List.of(inquiryHandled), pageable, 1));
+
+        Page<NotificationResponse> result = notificationService.getNotifications(1L, pageable);
+
+        assertThat(result.getContent().get(0).cardImageUrl()).isNull();
+        then(cardRepository).should(never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("목록 조회: 같은 페이지 안 여러 알림의 카드를 distinct cardId로 한 번만 배치 조회한다(N+1 방지)")
+    void getNotifications_batchFetchesCardsOnce() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Notification n1 = Notification.builder()
+                .userId(1L).type(NotificationType.PRICE_TARGET).message("메시지1").cardId(10L).build();
+        Notification n2 = Notification.builder()
+                .userId(1L).type(NotificationType.PRICE_TARGET).message("메시지2").cardId(10L).build();
+        Notification n3 = Notification.builder()
+                .userId(1L).type(NotificationType.PRICE_TARGET).message("메시지3").cardId(20L).build();
+        given(notificationRepository.findByUserId(1L, pageable))
+                .willReturn(new PageImpl<>(List.of(n1, n2, n3), pageable, 3));
+        Card card10 = Card.builder().id(10L).name("리자몽").imageMedium("medium-10.png").build();
+        Card card20 = Card.builder().id(20L).name("피카츄").imageSmall("small-20.png").build();
+        given(cardRepository.findAllById(List.of(10L, 20L))).willReturn(List.of(card10, card20));
+
+        Page<NotificationResponse> result = notificationService.getNotifications(1L, pageable);
+
+        assertThat(result.getContent().get(0).cardImageUrl()).isEqualTo("medium-10.png");
+        assertThat(result.getContent().get(1).cardImageUrl()).isEqualTo("medium-10.png");
+        // card20은 imageMedium이 없어 imageSmall로 폴백한다.
+        assertThat(result.getContent().get(2).cardImageUrl()).isEqualTo("small-20.png");
+        // cardId 3건(distinct 시 2건)에 대해 findAllById가 정확히 1번만 호출됐는지 - 개별 findById 호출이 없었는지 검증.
+        then(cardRepository).should(Mockito.times(1)).findAllById(any());
+        then(cardRepository).should(never()).findById(any());
     }
 
     @Test
@@ -156,7 +205,7 @@ class NotificationServiceTest {
     void createPriceTargetNotification_saves() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         then(notificationRepository).should().save(Mockito.any(Notification.class));
     }
@@ -166,7 +215,7 @@ class NotificationServiceTest {
     void createPriceTargetNotification_type() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         then(notificationRepository).should().save(captor.capture());
@@ -181,7 +230,7 @@ class NotificationServiceTest {
     void createPriceTargetNotification_message_sell() {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetSellPrice(150000).build();
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 150000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 150000);
 
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         then(notificationRepository).should().save(captor.capture());
@@ -197,7 +246,7 @@ class NotificationServiceTest {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L)
                 .targetBuyPrice(100000).targetSellPrice(150000).build();
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
         then(notificationRepository).should().save(captor.capture());
@@ -213,7 +262,7 @@ class NotificationServiceTest {
         SseEmitter emitter = mock(SseEmitter.class);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         then(emitter).should().send(any(SseEmitter.SseEventBuilder.class));
     }
@@ -224,7 +273,7 @@ class NotificationServiceTest {
         Watchlist watchlist = Watchlist.builder().userId(1L).cardId(10L).targetBuyPrice(100000).build();
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
 
-        assertThatCode(() -> notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000))
+        assertThatCode(() -> notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000))
                 .doesNotThrowAnyException();
     }
 
@@ -236,7 +285,7 @@ class NotificationServiceTest {
         doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         then(emitter).should().completeWithError(any(IOException.class));
     }
@@ -268,7 +317,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 있으면 notification 이벤트를 전송한다")
     void onNotificationPush_pushes_to_subscriber() throws Exception {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, false, null);
         SseEmitter emitter = mock(SseEmitter.class);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
 
@@ -280,7 +329,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 없으면 예외 없이 조용히 스킵된다")
     void onNotificationPush_no_subscriber_noop() {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, false, null);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
 
         assertThatCode(() -> notificationService.onNotificationPush(new NotificationPushEvent(1L, response)))

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationSseFlowTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.notification.service;
 
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.watchlist.entity.Watchlist;
@@ -26,13 +28,20 @@ class NotificationSseFlowTest {
     @Mock
     private NotificationRepository notificationRepository;
 
+    @Mock
+    private CardRepository cardRepository;
+
     private final SseEmitterStore sseEmitterStore = new SseEmitterStore();
     private NotificationService notificationService;
+
+    private Card card() {
+        return Card.builder().id(10L).name("리자몽").build();
+    }
 
     @Test
     @DisplayName("subscribe 후 같은 유저에게 createPriceTargetNotification이 발생하면 연결이 끊기지 않고 유지된다")
     void subscribe_then_notify_keeps_connection_alive() {
-        notificationService = new NotificationService(notificationRepository, sseEmitterStore, event -> { });
+        notificationService = new NotificationService(notificationRepository, cardRepository, sseEmitterStore, event -> { });
         Long userId = 1L;
         Watchlist watchlist = Watchlist.builder().userId(userId).cardId(10L).targetBuyPrice(100000).build();
 
@@ -40,7 +49,7 @@ class NotificationSseFlowTest {
         assertThat(sseEmitterStore.findByUserId(userId)).containsExactly(emitter);
 
         assertThatCode(() ->
-                notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000))
+                notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000))
                 .doesNotThrowAnyException();
 
         // 전송이 실패했다면 sendEvent()의 completeWithError -> onError 콜백으로 store에서 제거됐을 것이다.
@@ -51,7 +60,7 @@ class NotificationSseFlowTest {
     @Test
     @DisplayName("다른 유저를 구독 중인 Emitter는 대상 유저에게 온 알림의 영향을 받지 않는다")
     void notification_for_one_user_does_not_touch_another_subscriber() {
-        notificationService = new NotificationService(notificationRepository, sseEmitterStore, event -> { });
+        notificationService = new NotificationService(notificationRepository, cardRepository, sseEmitterStore, event -> { });
         Long targetUserId = 1L;
         Long otherUserId = 2L;
         Watchlist watchlist = Watchlist.builder().userId(targetUserId).cardId(10L).targetBuyPrice(100000).build();
@@ -59,7 +68,7 @@ class NotificationSseFlowTest {
         SseEmitter otherEmitter = notificationService.subscribe(otherUserId);
         notificationService.subscribe(targetUserId);
 
-        notificationService.createPriceTargetNotification(watchlist, "리자몽", 100000);
+        notificationService.createPriceTargetNotification(watchlist, "리자몽", card(), 100000);
 
         assertThat(sseEmitterStore.findByUserId(otherUserId)).containsExactly(otherEmitter);
     }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -51,9 +51,13 @@ class WatchlistConcurrencyTest {
     private EntityManager entityManager;
 
     private WatchlistService newWatchlistService() {
+        CardRepository cardRepository = mock(CardRepository.class);
+        CardNameKoResolver cardNameKoResolver = mock(CardNameKoResolver.class);
+        NotificationService notificationService = mock(NotificationService.class);
+        WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator =
+                new WatchlistTargetPriceEvaluator(watchlistRepository, cardRepository, notificationService, cardNameKoResolver);
         return new WatchlistService(watchlistRepository, mock(PriceService.class),
-                mock(CardRepository.class), mock(PriceTradeStatsRepository.class), mock(CardNameKoResolver.class),
-                mock(NotificationService.class));
+                cardRepository, mock(PriceTradeStatsRepository.class), cardNameKoResolver, watchlistTargetPriceEvaluator);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -146,7 +146,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), any(Card.class), eq(2000));
     }
 
     @Test
@@ -163,7 +163,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isFalse();
         assertThat(response.isNotified()).isFalse();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -182,7 +182,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -506,7 +506,7 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(9000, null, null));
 
         assertThat(response.targetReached()).isFalse();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -522,7 +522,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isFalse();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -540,7 +540,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), any(Card.class), eq(2000));
     }
 
     @Test
@@ -556,7 +556,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -574,7 +574,7 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(null, null, true));
 
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(1000));
+        then(notificationService).should().createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), any(Card.class), eq(1000));
     }
 
     @Test
@@ -591,7 +591,7 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(2000, null, true));
 
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should(times(1)).createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), eq(2000));
+        then(notificationService).should(times(1)).createPriceTargetNotification(any(Watchlist.class), eq("리자몽"), any(Card.class), eq(2000));
     }
 
     @Test
@@ -608,7 +608,7 @@ class WatchlistServiceTest {
 
         assertThat(response.targetReached()).isTrue();
         assertThat(response.isNotified()).isTrue();
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     // #275 버그 재현 테스트: 워치리스트 등록(createdAt) 훨씬 이전에 목표가 범위였다가 지금은 벗어난

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -16,10 +16,10 @@ import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -48,7 +48,18 @@ class WatchlistServiceTest {
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
     @Mock CardNameKoResolver cardNameKoResolver;
     @Mock NotificationService notificationService;
-    @InjectMocks WatchlistService watchlistService;
+    WatchlistService watchlistService;
+
+    // 목표가 판정/알림 로직은 WatchlistTargetPriceEvaluator로 분리돼 있지만, 그 판정 결과가 WatchlistService의
+    // 응답(targetReached/isNotified)에 실제로 반영되는지는 이 테스트가 여전히 검증해야 하므로 mock이 아니라
+    // 같은 mock 협력자로 구성한 실제 인스턴스를 주입한다.
+    @BeforeEach
+    void setUp() {
+        WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator =
+                new WatchlistTargetPriceEvaluator(watchlistRepository, cardRepository, notificationService, cardNameKoResolver);
+        watchlistService = new WatchlistService(
+                watchlistRepository, priceService, cardRepository, priceTradeStatsRepository, cardNameKoResolver, watchlistTargetPriceEvaluator);
+    }
 
     private Watchlist watchlist(Long userId, Long cardId) {
         return Watchlist.builder()

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -103,7 +103,7 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
         given(priceTradeStatsRepository.findPriceRangesByCardIds(any(), any(), any())).willReturn(List.of(range));
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any())).willReturn(List.of(range));
 
-        NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore(), event -> { });
+        NotificationService notificationService = new NotificationService(notificationRepository, cardRepository, new SseEmitterStore(), event -> { });
         WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator = new WatchlistTargetPriceEvaluator(
                 watchlistRepository, cardRepository, notificationService, mock(CardNameKoResolver.class));
         WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -8,7 +8,6 @@ import com.pokade.domain.notification.repository.NotificationRepository;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
-import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
 import jakarta.persistence.EntityManager;
@@ -105,11 +104,10 @@ class WatchlistTargetPriceNoticeConcurrencyTest {
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(any(), any(), any(), any())).willReturn(List.of(range));
 
         NotificationService notificationService = new NotificationService(notificationRepository, new SseEmitterStore(), event -> { });
-        WatchlistService watchlistService = new WatchlistService(watchlistRepository,
-                mock(PriceService.class), cardRepository, priceTradeStatsRepository, mock(CardNameKoResolver.class),
-                notificationService);
+        WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator = new WatchlistTargetPriceEvaluator(
+                watchlistRepository, cardRepository, notificationService, mock(CardNameKoResolver.class));
         WatchlistTargetPriceNoticeProcessor processor = new WatchlistTargetPriceNoticeProcessor(
-                watchlistRepository, priceTradeStatsRepository, notificationService, watchlistService);
+                watchlistRepository, priceTradeStatsRepository, notificationService, watchlistTargetPriceEvaluator);
 
         return new WatchlistTargetPriceNoticeService(watchlistRepository, cardRepository,
                 priceTradeStatsRepository, processor);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
@@ -29,7 +29,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
     @Mock WatchlistRepository watchlistRepository;
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
     @Mock NotificationService notificationService;
-    @Mock WatchlistService watchlistService;
+    @Mock WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator;
     @InjectMocks WatchlistTargetPriceNoticeProcessor processor;
 
     private record PriceRange(Long cardId, Integer minPrice, Integer maxPrice)
@@ -58,15 +58,15 @@ class WatchlistTargetPriceNoticeProcessorTest {
         Card card = Card.builder().id(10L).name("리자몽").build();
 
         PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
 
         PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(sinceRegistration));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
         given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(1);
-        given(watchlistService.resolveCardDisplayName(card)).willReturn("리자몽");
+        given(watchlistTargetPriceEvaluator.resolveCardDisplayName(card)).willReturn("리자몽");
 
         processor.process(1L, card, allTimeRange);
 
@@ -82,13 +82,13 @@ class WatchlistTargetPriceNoticeProcessorTest {
         Card card = Card.builder().id(10L).name("리자몽").build();
 
         PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
 
         PriceRange sinceRegistration = new PriceRange(10L, 900, 1100);
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of(sinceRegistration));
-        given(watchlistService.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, sinceRegistration)).willReturn(1000);
         given(watchlistRepository.markAsNotifiedIfNotYet(watchlist.getId())).willReturn(0);
 
         processor.process(1L, card, allTimeRange);
@@ -105,13 +105,13 @@ class WatchlistTargetPriceNoticeProcessorTest {
 
         // 전체 기간 기준으로는 후보로 걸러짐(1차 통과)
         PriceRange allTimeRange = new PriceRange(10L, 800, 1200);
-        given(watchlistService.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, allTimeRange)).willReturn(1000);
 
         // 등록 이후로 좁히면 체결 이력 없음 -> 2차 확인에서 탈락
         given(priceTradeStatsRepository.findPriceRangesByCardIdsSince(
                 eq(List.of(10L)), isNull(), eq(TradeStatus.COMPLETED), any()))
                 .willReturn(List.of());
-        given(watchlistService.resolveReachedTargetPrice(watchlist, null)).willReturn(null);
+        given(watchlistTargetPriceEvaluator.resolveReachedTargetPrice(watchlist, null)).willReturn(null);
 
         processor.process(1L, card, allTimeRange);
 

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeProcessorTest.java
@@ -46,7 +46,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
 
         processor.process(1L, Card.builder().id(10L).name("리자몽").build(), new PriceRange(10L, 800, 1200));
 
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
         then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
     }
 
@@ -71,7 +71,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
         processor.process(1L, card, allTimeRange);
 
         then(watchlistRepository).should().markAsNotifiedIfNotYet(watchlist.getId());
-        then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", 1000);
+        then(notificationService).should().createPriceTargetNotification(watchlist, "리자몽", card, 1000);
     }
 
     @Test
@@ -93,7 +93,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
 
         processor.process(1L, card, allTimeRange);
 
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
     }
 
     @Test
@@ -115,7 +115,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
 
         processor.process(1L, card, allTimeRange);
 
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
         then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
     }
 
@@ -127,7 +127,7 @@ class WatchlistTargetPriceNoticeProcessorTest {
 
         processor.process(1L, null, new PriceRange(10L, 800, 1200));
 
-        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any());
+        then(notificationService).should(never()).createPriceTargetNotification(any(), any(), any(), any());
         then(watchlistRepository).should(never()).markAsNotifiedIfNotYet(any());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
@@ -38,7 +38,7 @@ import static org.mockito.BDDMockito.given;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({WatchlistTargetPriceNoticeService.class, WatchlistTargetPriceNoticeProcessor.class,
-        WatchlistService.class, com.pokade.domain.notification.service.NotificationService.class,
+        WatchlistService.class, WatchlistTargetPriceEvaluator.class, com.pokade.domain.notification.service.NotificationService.class,
         com.pokade.domain.notification.store.SseEmitterStore.class})
 class WatchlistTargetPriceNoticeTransactionIsolationTest {
 


### PR DESCRIPTION
## 📌 관련 이슈
- #280 

## ✨ 작업 내용
- `WatchlistService`(257줄) 목표가 판정/즉시알림 로직을 `WatchlistTargetPriceEvaluator`로 분리 (186줄로 축소)
- 알림에 참조 카드 정보 추가: `notifications.card_id` 컬럼 + `cardImageUrl` 응답 필드 (알림 클릭 시 카드 상세 이동, 썸네일 표시용)
- `CardService`의 미사용 메서드(7-인자 `search()` 오버로드, `findByExternalId()`) 삭제

## 📸 스크린샷 / 테스트 결과
- `WatchlistTargetPriceEvaluator` 분리 후 watchlist 도메인 테스트 68건 전부 통과
- 카드 이미지 URL은 조회 시점 배치 조회(`findAllById` + Map 그룹핑)로 N+1 회피, notification 도메인 테스트 132건 통과
- 실제 알림 발생시켜 `/api/notifications` 응답에 `cardId`/`cardImageUrl` 정상 반환 확인 (FE 연동까지 스모크 테스트 완료)

## 🔍 리뷰 포인트
- 스키마 변경 포함 
  - 배포 시 프로덕션 DB에 `ALTER TABLE notifications ADD COLUMN card_id BIGINT REFERENCES cards(id);` 실행 필요 
      (로컬은 이미 반영 완료)
- `findByExternalId()` 삭제는 grep 확인 결과 프로덕션 미사용이지만, 
   Javadoc상 "AI 등급진단 등에서 사용 가능하도록 제공"이라 적혀 있었음. 코드 확인 결과 현재 미사용이라 삭제했고, 필요 시 재구현 예정
- 알림 카드 이미지는 `WatchlistResponse.resolveImageUrl()`과 동일한 컨벤션(`imageMedium` 우선, 없으면 `imageSmall`) 재사용

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?