### PR TITLE
[Refactor]/#295 미사용 컬럼 정리

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/user/dto/response/MyProfileResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/response/MyProfileResponse.java
@@ -3,26 +3,21 @@ package com.pokade.domain.user.dto.response;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.entity.type.Provider;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record MyProfileResponse(
         String email,
-        String phoneNumber,
         Provider provider,
         boolean socialLinked,
         LocalDateTime joinedAt,
-        LocalDate birthDate,
         boolean marketingAgreed
 ) {
     public static MyProfileResponse of(User user, boolean marketingAgreed) {
         return new MyProfileResponse(
                 user.getEmail(),
-                user.getPhoneNumber(),
                 user.getProvider(),
                 !user.isLocalUser(),
                 user.getCreated_At(),
-                user.getBirthDate(),
                 marketingAgreed
         );
     }

--- a/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/entity/User.java
@@ -10,7 +10,6 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -50,12 +49,6 @@ public class User {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
-
-    @Column(name = "birth_date")
-    private LocalDate birthDate;
-
-    @Column(name = "phone_number", length = 20)
-    private String phoneNumber;
 
     @Column(name = "point_balance", nullable = false)
     private Integer pointBalance;
@@ -147,8 +140,6 @@ public class User {
         this.email = "deleted_" + anonToken + "@pokade.invalid";
         this.nickname = "deleted_" + anonToken;
         this.password = null;
-        this.phoneNumber = null;
-        this.birthDate = null;
         String previousKey = this.profileImageUrl;
         this.profileImageUrl = null;
         return previousKey;

--- a/Pokade/src/main/resources/db/migration/V3__drop_unused_user_columns.sql
+++ b/Pokade/src/main/resources/db/migration/V3__drop_unused_user_columns.sql
@@ -1,0 +1,18 @@
+-- 값이 기록된 적이 없고 읽는 곳도 없는 users 컬럼을 정리한다.
+--
+--   phone_number / birth_date
+--     입력 경로가 아예 없어 항상 NULL이었다. SignupRequest에 필드가 없고 수정 요청 DTO도
+--     닉네임용뿐이다. 사용처도 없다(거래는 배송지 주소조차 두지 않고 연락은 채팅으로 한다).
+--     개인정보처리방침 2조의 수집 항목에도 고지된 적이 없다. 응답 DTO에서도 함께 제거한다.
+--
+--   terms_agreed_at / marketing_opt_in
+--     동의 이력이 user_agreements로 이관된 뒤 남은 잔재다. 엔티티가 매핑하지 않는다.
+--     Flyway 도입 전 migrations/V4__drop_user_consent_columns.sql로 작성해 두었으나,
+--     Flyway는 db/migration만 읽으므로 그 파일은 실행된 적이 없다. 여기서 함께 정리한다.
+--
+-- IF EXISTS를 붙여 재실행에도 안전하게 둔다. Flyway 도입 이전에 손으로 스키마를 맞춘
+-- 로컬·운영의 적용 상태가 서로 다를 수 있다(V2가 같은 이유로 IF NOT EXISTS를 남겨 두었다).
+ALTER TABLE users DROP COLUMN IF EXISTS phone_number;
+ALTER TABLE users DROP COLUMN IF EXISTS birth_date;
+ALTER TABLE users DROP COLUMN IF EXISTS terms_agreed_at;
+ALTER TABLE users DROP COLUMN IF EXISTS marketing_opt_in;

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -35,7 +35,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -124,17 +123,15 @@ class UserControllerTest {
     @DisplayName("인증된 사용자가 내 프로필 상세를 조회하면 200과 상세 필드를 반환한다")
     void getMyProfile_success() throws Exception {
         MyProfileResponse res = new MyProfileResponse(
-                "user@pokade.com", "010-1234-5678", Provider.GOOGLE, true,
-                LocalDateTime.of(2026, 1, 2, 3, 4), LocalDate.of(1998, 7, 15), true);
+                "user@pokade.com", Provider.GOOGLE, true,
+                LocalDateTime.of(2026, 1, 2, 3, 4), true);
         given(profileService.getMyProfile(1L)).willReturn(res);
 
         mockMvc.perform(get("/api/users/me/profile").with(userId(1L)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email").value("user@pokade.com"))
-                .andExpect(jsonPath("$.data.phoneNumber").value("010-1234-5678"))
                 .andExpect(jsonPath("$.data.provider").value("GOOGLE"))
                 .andExpect(jsonPath("$.data.socialLinked").value(true))
-                .andExpect(jsonPath("$.data.birthDate").value("1998-07-15"))
                 .andExpect(jsonPath("$.data.marketingAgreed").value(true));
 
         then(profileService).should().getMyProfile(1L);

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -132,7 +132,11 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.data.email").value("user@pokade.com"))
                 .andExpect(jsonPath("$.data.provider").value("GOOGLE"))
                 .andExpect(jsonPath("$.data.socialLinked").value(true))
-                .andExpect(jsonPath("$.data.marketingAgreed").value(true));
+                .andExpect(jsonPath("$.data.marketingAgreed").value(true))
+                // 응답 필드 수를 잠가 둔다 - 고지되지 않은 PII(연락처·생년월일)가 다시 실려 나가는 것을 막는다.
+                // doesNotExist()는 값이 null인 필드를 부재로 판정해 이 회귀를 잡지 못한다.
+                // 필드를 정당하게 추가할 때는 이 숫자도 함께 올린다.
+                .andExpect(jsonPath("$.data.length()").value(5));
 
         then(profileService).should().getMyProfile(1L);
     }


### PR DESCRIPTION
## 📌 관련 이슈

- #295

## ✨ 작업 내용

`users`의 네 컬럼은 값이 기록되는 경로가 없고 읽는 곳도 없다. 그중 둘은 API 응답에까지 실려 항상 `null`을 전달하고 있었다.

| 컬럼 | 응답 노출 | 값을 넣는 코드 |
|---|---|---|
| `phone_number` | `MyProfileResponse.phoneNumber` | 없음 |
| `birth_date` | `MyProfileResponse.birthDate` | 없음 |
| `terms_agreed_at` | 없음 | 없음 |
| `marketing_opt_in` | 없음 | 없음 |

### 연락처·생년월일을 만들지 않고 제거한 이유

명세에는 내 정보 수정이 "닉네임·연락처 등 수정"으로 적혀 있어 수집 기능을 구현하는 방향도 가능했다. 그러나 셋 다 성립하지 않았다.

- **수집 경로가 없다.** `SignupRequest`에 두 필드가 없고 수정 요청 DTO는 `NicknameUpdateRequest`뿐이다. 값이 들어간 적이 없다.
- **사용처가 없다.** `Trade`에 배송지 주소조차 없으며 배송 관련 필드는 `shipped_at`·`delivered_at` 같은 시각뿐이다. 판매자와 구매자의 연락은 채팅으로 이루어진다.
- **개인정보처리방침에 고지되어 있지 않다.** 처리방침 2조의 일반 가입 수집 항목은 이메일 주소·비밀번호·닉네임뿐이다.

고지하지 않은 개인정보를 수집할 수 없고 쓸 곳도 없으므로 필드를 제거했다. 회원가입 화면의 생년월일 입력은 만 14세 검증에만 쓰이고 서버로 전송되지 않으므로 화면 동작에 영향이 없다.

### 동의 컬럼 잔재를 함께 정리한 이유

`terms_agreed_at`·`marketing_opt_in`은 동의 이력이 `user_agreements`로 이관된 뒤 남은 잔재이며 엔티티가 매핑하지 않는다. 이를 제거하는 `migrations/V4__drop_user_consent_columns.sql`을 작성해 두었으나, **Flyway는 `db/migration`만 읽으므로 그 파일은 실행된 적이 없다.** 성격이 같은 정리라 이번 마이그레이션에 합쳤다.

### 변경 파일

| 파일 | 처리 |
|---|---|
| `db/migration/V3__drop_unused_user_columns.sql` | 신규 — 네 컬럼 제거 |
| `User.java` | 두 필드와 탈퇴 익명화 구문 제거 |
| `MyProfileResponse.java` | 레코드 필드와 `of()` 매핑 제거 |
| `UserControllerTest.java` | 프로필 응답 검증 정리 |

기존 V1·V2와 같이 명시적 트랜잭션 구문을 두지 않았다(Flyway가 마이그레이션 단위로 감싼다). 로컬과 운영의 적용 상태가 다를 수 있어 `IF EXISTS`를 붙였다.

## 📸 테스트 결과

| 항목 | 결과 |
|---|---|
| `./gradlew compileJava` | 통과 |
| `UserControllerTest` | 통과 |
| 로컬 dev 기동 | 마이그레이션 적용 후 `ddl-auto=validate` 통과 |
| `GET /api/users/1` | 200 — `users` 테이블 조회 정상 |
| `GET /api/users/me/profile` | `phoneNumber`·`birthDate`가 사라지고 나머지 5개 필드 정상 |
| `/settings` 화면 | 정상 렌더 |

응답 실제 값은 다음과 같다.

```json
{"email":"test1@pokade.com","provider":"LOCAL","socialLinked":false,
 "joinedAt":"2026-08-03T09:25:29.612388","marketingAgreed":false}
```

## 🔍 리뷰 포인트

- **이 배포 이후 구버전 이미지로 롤백할 수 없다.** 구버전 엔티티는 네 컬럼을 매핑하므로 `ddl-auto=validate`가 실패해 부팅되지 않는다. 되돌리려면 컬럼을 되살리는 새 마이그레이션이 필요하다.
- **응답 스키마가 축소된다.** `GET /api/users/me/profile`에서 두 필드가 사라진다. 두 값 모두 항상 `null`이었으므로 화면 표시에는 변화가 없다. FE 타입 정리는 별도 이슈로 진행한다.
- 마이그레이션과 엔티티 변경이 같은 배포에 들어가므로 운영 DB에 psql을 수동 실행할 필요가 없다.
- 명세(`요구사항.md`)와 정책 문서의 연락처·전화번호 표현도 함께 정정했다. 해당 문서는 저장소에 포함되지 않아 이 PR의 변경 파일에는 나타나지 않는다. 요구사항명세서 원본(`.xlsx`) 수정은 별도로 요청이 필요하다.

### 곁가지 (이번 범위 밖)

만 14세 검증이 FE에만 존재한다. 서버는 생년월일을 받지 않으므로 검증할 수단이 없고 브라우저에서 우회하면 통과한다. 별도 이슈로 다룬다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 내 프로필 조회 정보에서 전화번호와 생년월일이 제외됩니다.
  * 프로필에는 이메일, 소셜 로그인 제공자, 연동 여부, 가입일, 마케팅 수신 동의 여부가 표시됩니다.
  * 회원 탈퇴 처리 시 전화번호와 생년월일을 별도로 익명화하지 않습니다.
* **품질 개선**
  * 내 프로필 조회 기능의 검증 기준을 변경된 정보 구성에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->