### PR TITLE
[Feature] #298 워치리스트 관심수 배치 조회 API 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/controller/WatchlistController.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.watchlist.controller;
 
+import com.pokade.domain.watchlist.dto.WatchlistCountResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -37,6 +39,11 @@ public class WatchlistController {
     @GetMapping
     public ApiResponse<List<WatchlistResponse>> getWatchlist(@AuthenticationPrincipal Long userId) {
         return ApiResponse.ok(watchlistService.getWatchlist(userId));
+    }
+
+    @GetMapping("/counts")
+    public ApiResponse<List<WatchlistCountResponse>> getWatchlistCounts(@RequestParam List<Long> cardIds) {
+        return ApiResponse.ok(watchlistService.getWatchlistCounts(cardIds));
     }
 
     @PatchMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCountResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCountResponse.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.watchlist.dto;
+
+public record WatchlistCountResponse(
+        Long cardId,
+        long count
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -36,4 +36,14 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     @Modifying(flushAutomatically = true)
     @Query("UPDATE Watchlist w SET w.isNotified = true WHERE w.id = :id AND w.isNotified = false")
     int markAsNotifiedIfNotYet(@Param("id") Long id);
+
+    // 카드별 관심수(워치리스트 등록 수) 배치 조회 - 카드 수와 무관하게 쿼리 1회로 처리한다(CardRepository.findGradesByCardIds와 동일한 패턴).
+    // 등록이 하나도 없는 카드는 결과 행 자체가 없으므로, 호출부에서 요청한 cardId 전체에 대해 0으로 채워야 한다.
+    @Query("SELECT w.cardId AS cardId, COUNT(w) AS count FROM Watchlist w WHERE w.cardId IN :cardIds GROUP BY w.cardId")
+    List<WatchlistCardCountView> countGroupedByCardIdIn(@Param("cardIds") List<Long> cardIds);
+
+    interface WatchlistCardCountView {
+        Long getCardId();
+        Long getCount();
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -7,6 +7,7 @@ import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.dto.WatchlistCountResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
@@ -33,6 +34,8 @@ import java.util.stream.Collectors;
 public class WatchlistService {
 
     private static final long WATCHLIST_LIMIT = 20;
+    // CardQueryService.MAX_FILTER_VALUES와 같은 취지 - 한 번에 조회 가능한 카드 수 상한을 둬서 과도한 IN절을 막는다.
+    private static final int MAX_COUNT_CARD_IDS = 100;
 
     private final WatchlistRepository watchlistRepository;
     private final PriceService priceService;
@@ -173,6 +176,28 @@ public class WatchlistService {
         if (targetBuyPrice == null && targetSellPrice == null) {
             throw new BusinessException(ErrorCode.TARGET_PRICE_REQUIRED);
         }
+    }
+
+    // 카드별 관심수(워치리스트 등록 수) 배치 조회 - 카드 수와 무관하게 쿼리 1회로 처리한다(getWatchlist()의
+    // IN절 + Map 그룹핑 패턴과 동일). 등록이 하나도 없는 카드는 응답에서 제외되지 않고 0으로 채워진다.
+    public List<WatchlistCountResponse> getWatchlistCounts(List<Long> cardIds) {
+        if (cardIds == null || cardIds.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최소 1개 이상 지정해야 합니다.");
+        }
+        List<Long> distinctCardIds = cardIds.stream().distinct().toList();
+        if (distinctCardIds.size() > MAX_COUNT_CARD_IDS) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "cardIds는 최대 " + MAX_COUNT_CARD_IDS + "개까지 지정할 수 있습니다.");
+        }
+
+        Map<Long, Long> countByCardId = watchlistRepository.countGroupedByCardIdIn(distinctCardIds).stream()
+                .collect(Collectors.toMap(
+                        WatchlistRepository.WatchlistCardCountView::getCardId,
+                        WatchlistRepository.WatchlistCardCountView::getCount));
+
+        return distinctCardIds.stream()
+                .map(cardId -> new WatchlistCountResponse(cardId, countByCardId.getOrDefault(cardId, 0L)))
+                .toList();
     }
 
     @Transactional

--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                                 "/api/prices/*/trades")
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/listings").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/watchlist/counts").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/chat/query").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/chat/quick-questions").permitAll()

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.watchlist.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
+import com.pokade.domain.watchlist.dto.WatchlistCountResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
@@ -172,6 +173,40 @@ class WatchlistControllerTest {
                 .andExpect(jsonPath("$.data[0].currentPrice.sellPrice").value(8000))
                 .andExpect(jsonPath("$.data[0].changeRate").value(3.25))
                 .andExpect(jsonPath("$.data[0].targetReached").value(true));
+    }
+
+    @Test
+    void 관심수_조회에_성공하면_200과_카드별_등록수를_반환한다() throws Exception {
+        given(watchlistService.getWatchlistCounts(List.of(1L, 2L)))
+                .willReturn(List.of(new WatchlistCountResponse(1L, 3L), new WatchlistCountResponse(2L, 0L)));
+
+        mockMvc.perform(get("/api/watchlist/counts")
+                        .param("cardIds", "1,2")
+                        .with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].cardId").value(1L))
+                .andExpect(jsonPath("$.data[0].count").value(3))
+                .andExpect(jsonPath("$.data[1].cardId").value(2L))
+                .andExpect(jsonPath("$.data[1].count").value(0));
+    }
+
+    @Test
+    void 관심수_조회시_cardIds가_없으면_400을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/watchlist/counts").with(userId(100L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    void 관심수_조회시_상한을_초과하면_400을_반환한다() throws Exception {
+        given(watchlistService.getWatchlistCounts(List.of(1L, 2L)))
+                .willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최대 100개까지 지정할 수 있습니다."));
+
+        mockMvc.perform(get("/api/watchlist/counts")
+                        .param("cardIds", "1,2")
+                        .with(userId(100L)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -34,6 +34,8 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -199,14 +201,26 @@ class WatchlistControllerTest {
 
     @Test
     void 관심수_조회시_상한을_초과하면_400을_반환한다() throws Exception {
-        given(watchlistService.getWatchlistCounts(List.of(1L, 2L)))
+        // 소수(예: 2개)만 보내고 서비스가 예외를 던지도록 흉내내면 "쿼리 파라미터 파싱이 실제로 101개를
+        // 만들어내는지"는 검증되지 않는다 - 실제 1~101 cardId를 콤마로 이어 보내고, 서비스에 전달된
+        // 리스트를 캡처해 크기/내용까지 확인한다. 상한(100개) 초과 시 실제로 예외를 던지는 로직 자체는
+        // WatchlistServiceTest.getWatchlistCounts_tooManyCardIds에서 이미 검증한다 - 여기서는 컨트롤러의
+        // 파라미터 바인딩과 예외 -> 400 응답 변환만 확인한다.
+        List<Long> expectedCardIds = LongStream.rangeClosed(1, 101).boxed().toList();
+        String cardIdsParam = expectedCardIds.stream().map(String::valueOf).collect(Collectors.joining(","));
+
+        given(watchlistService.getWatchlistCounts(any()))
                 .willThrow(new BusinessException(ErrorCode.INVALID_INPUT, "cardIds는 최대 100개까지 지정할 수 있습니다."));
 
         mockMvc.perform(get("/api/watchlist/counts")
-                        .param("cardIds", "1,2")
+                        .param("cardIds", cardIdsParam)
                         .with(userId(100L)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+
+        ArgumentCaptor<List<Long>> cardIdsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(watchlistService).getWatchlistCounts(cardIdsCaptor.capture());
+        assertThat(cardIdsCaptor.getValue()).hasSize(101).containsExactlyElementsOf(expectedCardIds);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -93,6 +94,29 @@ class WatchlistRepositoryTest {
         assertThat(found).extracting(Watchlist::getId)
                 .contains(unnotified.getId())
                 .doesNotContain(notified.getId());
+    }
+
+    @Test
+    void countGroupedByCardIdIn은_카드별_등록수를_한번의_쿼리로_묶어서_반환한다() {
+        Long userA = insertUser("count-grouped-a@test.com");
+        Long userB = insertUser("count-grouped-b@test.com");
+        Long userC = insertUser("count-grouped-c@test.com");
+        Long cardWithTwo = insertCard("watch-grouped-two");
+        Long cardWithOne = insertCard("watch-grouped-one");
+        Long cardWithNone = insertCard("watch-grouped-none");
+        saveWatchlist(userA, cardWithTwo, 1000, null);
+        saveWatchlist(userB, cardWithTwo, 1000, null);
+        saveWatchlist(userC, cardWithOne, 1000, null);
+
+        List<WatchlistRepository.WatchlistCardCountView> counts =
+                watchlistRepository.countGroupedByCardIdIn(List.of(cardWithTwo, cardWithOne, cardWithNone));
+
+        // 등록이 없는 카드(cardWithNone)는 GROUP BY 결과에 행 자체가 생기지 않는다 - 0으로 채우는 건 서비스 계층 책임.
+        assertThat(counts).extracting(WatchlistRepository.WatchlistCardCountView::getCardId,
+                        WatchlistRepository.WatchlistCardCountView::getCount)
+                .containsExactlyInAnyOrder(
+                        tuple(cardWithTwo, 2L),
+                        tuple(cardWithOne, 1L));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -8,6 +8,7 @@ import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.watchlist.dto.WatchlistCountResponse;
 import com.pokade.domain.watchlist.dto.WatchlistCreateRequest;
 import com.pokade.domain.watchlist.dto.WatchlistResponse;
 import com.pokade.domain.watchlist.dto.WatchlistUpdateRequest;
@@ -27,9 +28,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -669,5 +672,59 @@ class WatchlistServiceTest {
         watchlistService.deleteWatchlist(1L, 1L);
 
         then(watchlistRepository).should().delete(target);
+    }
+
+    // ===== 관심수(워치리스트 등록 수) 배치 조회 =====
+
+    private record CountView(Long cardId, Long count) implements WatchlistRepository.WatchlistCardCountView {
+        public Long getCardId() { return cardId; }
+        public Long getCount() { return count; }
+    }
+
+    @Test
+    @DisplayName("관심수: cardIds가 null이면 INVALID_INPUT")
+    void getWatchlistCounts_nullCardIds() {
+        assertThatThrownBy(() -> watchlistService.getWatchlistCounts(null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        then(watchlistRepository).should(never()).countGroupedByCardIdIn(any());
+    }
+
+    @Test
+    @DisplayName("관심수: cardIds가 빈 리스트면 INVALID_INPUT")
+    void getWatchlistCounts_emptyCardIds() {
+        assertThatThrownBy(() -> watchlistService.getWatchlistCounts(List.of()))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        then(watchlistRepository).should(never()).countGroupedByCardIdIn(any());
+    }
+
+    @Test
+    @DisplayName("관심수: 상한(100개)을 초과하면 INVALID_INPUT")
+    void getWatchlistCounts_tooManyCardIds() {
+        List<Long> tooMany = LongStream.rangeClosed(1, 101).boxed().toList();
+
+        assertThatThrownBy(() -> watchlistService.getWatchlistCounts(tooMany))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_INPUT);
+        then(watchlistRepository).should(never()).countGroupedByCardIdIn(any());
+    }
+
+    @Test
+    @DisplayName("관심수: 등록이 없는 카드는 0으로 채워지고, repository는 정확히 1번만 호출된다(N+1 방지)")
+    void getWatchlistCounts_zeroFillsMissingCardsAndBatchesOnce() {
+        // cardId 10은 중복 입력 - distinct 처리되어 실제 조회에는 (10, 20, 30) 3건만 나가야 한다.
+        // 등록이 하나도 없는 카드(20, 30)는 GROUP BY 결과에 행 자체가 없으므로 스텁에서도 제외한다.
+        given(watchlistRepository.countGroupedByCardIdIn(List.of(10L, 20L, 30L)))
+                .willReturn(List.of(new CountView(10L, 3L)));
+
+        List<WatchlistCountResponse> result = watchlistService.getWatchlistCounts(List.of(10L, 20L, 10L, 30L));
+
+        assertThat(result).extracting(WatchlistCountResponse::cardId, WatchlistCountResponse::count)
+                .containsExactly(
+                        tuple(10L, 3L),
+                        tuple(20L, 0L),
+                        tuple(30L, 0L));
+        then(watchlistRepository).should(times(1)).countGroupedByCardIdIn(any());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #298 

## ✨ 작업 내용
- `GET /api/watchlist/counts?cardIds=1,2,3` — 카드ID 배치로 워치리스트 등록 수(관심수) 조회
- 기존 `CardRepository.findGradesByCardIds` / `WatchlistService.getWatchlist` 패턴과 동일하게 GROUP BY 1쿼리 + Map 그룹핑으로 N+1 방지
- 등록 없는 카드는 0으로 채워 반환, cardId 중복은 distinct 처리
- 워치리스트 등록 시 알림 발송 기능은 검토 후 범위에서 제외 — `addWatchlist()`가 이미 API 응답으로 즉시 피드백을 주고 있어 알림까지 남기면 정보 중복이고, 진짜 알림(목표가 도달)이 노이즈에 묻힐 수 있다고 판단

## 📸 스크린샷 / 테스트 결과
- Repository: 실 DB 그룹핑 쿼리 검증 (Flyway 마이그레이션 반영 후 통과 확인)
- Service: N+1 방지(times(1) 검증) + 0-fill 검증
- Controller: 200/400 케이스 검증

## 🔍 리뷰 포인트
- `SecurityConfig`(회원/인증 도메인)에 `GET /api/watchlist/counts` 화이트리스트 한 줄 추가했습니다. 
  카드 검색처럼 비로그인도 조회 가능해야 한다고 판단했고, 기존 `/api/listings` GET 패턴과 동일하게 맞췄습니다. 확인 부탁드립니다.
- 관심수를 카드 목록/상세 응답 어디에 노출할지는 FE 작업(#187)에서 별도로 결정 예정입니다. 
  이번 PR은 배치 조회 엔드포인트만 제공합니다.


## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 여러 카드의 워치리스트 등록 수를 한 번에 조회할 수 있습니다.
  * 등록된 항목이 없는 카드도 등록 수를 0으로 확인할 수 있습니다.
  * 별도 인증 없이 등록 수 조회가 가능합니다.
  * 한 번에 최대 100개의 카드까지 조회할 수 있습니다.

* **버그 수정**
  * 카드 ID 누락, 빈 목록 또는 100개 초과 입력 시 잘못된 요청으로 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->