### PR TITLE
[Feature] #300 매물 재입고 알림 및 카드 검색 오타 허용 기능 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardResponse.java
@@ -17,10 +17,13 @@ public record CardResponse(
         String imageSmall,
         String imageMedium,
         String expansionId,
-        List<String> grades
+        List<String> grades,
+        // #187: 정확 검색(부분일치) 결과가 아니라 pg_trgm 유사도 폴백으로 찾은 카드인지 여부.
+        // 필터/연관 카드 조회처럼 폴백이 없는 경로에서는 항상 false다.
+        boolean fuzzyMatch
 ) {
 
-    public static CardResponse from(Card card, List<String> grades, String nameKo, List<String> types, String rarity) {
+    public static CardResponse from(Card card, List<String> grades, String nameKo, List<String> types, String rarity, boolean fuzzyMatch) {
         return new CardResponse(
                 card.getId(),
                 card.getExternalId(),
@@ -34,7 +37,8 @@ public record CardResponse(
                 card.getImageSmall(),
                 card.getImageMedium(),
                 card.getExpansion() != null ? card.getExpansion().getId() : null,
-                grades
+                grades,
+                fuzzyMatch
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -185,6 +185,19 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     Page<Card> findByNameContainingIgnoreCase(String name, Pageable pageable);
 
     /**
+     * 정확 검색(부분일치)이 0건일 때만 시도하는 오타 허용 폴백 검색(#187) - pg_trgm의 similarity()로
+     * name과의 유사도가 threshold 이상인 카드를 유사도 내림차순으로 조회한다. V4 마이그레이션에서
+     * 추가한 pg_trgm 확장 + GIN 인덱스(idx_cards_name_trgm)를 전제로 한다.
+     */
+    @Query(value = """
+            SELECT c.* FROM cards c WHERE similarity(c.name, :keyword) >= :threshold
+            ORDER BY similarity(c.name, :keyword) DESC, c.id ASC
+            """,
+            countQuery = "SELECT COUNT(*) FROM cards c WHERE similarity(c.name, :keyword) >= :threshold",
+            nativeQuery = true)
+    Page<Card> findByNameSimilarTo(@Param("keyword") String keyword, @Param("threshold") double threshold, Pageable pageable);
+
+    /**
      * 한글 검색어를 도감번호 목록으로 변환한 뒤(PokedexKoNameRepository, 부분일치/초성 검색이라 여러 건일 수 있음)
      * 조회하는 용도 - 배열 컬럼이라 unnest+IN으로 매칭한다(CARD_SEARCH_BASE의 types 필터와 동일한 패턴).
      */

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/PokedexKoNameRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/PokedexKoNameRepository.java
@@ -3,6 +3,8 @@ package com.pokade.domain.card.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.pokade.domain.card.entity.PokedexKoName;
 
@@ -11,4 +13,16 @@ public interface PokedexKoNameRepository extends JpaRepository<PokedexKoName, In
     List<PokedexKoName> findByNameKoContaining(String nameKo);
 
     List<PokedexKoName> findByNameKoChosungContaining(String chosung);
+
+    /**
+     * 정확 검색(부분일치)이 0건일 때만 시도하는 오타 허용 폴백 검색(#187) - pg_trgm의 similarity()로
+     * name_ko와의 유사도가 threshold 이상인 행을 유사도 내림차순으로 조회한다. V4 마이그레이션에서
+     * 추가한 pg_trgm 확장 + GIN 인덱스(idx_pokedex_ko_names_name_ko_trgm)를 전제로 한다.
+     */
+    @Query(value = """
+            SELECT * FROM pokedex_ko_names WHERE similarity(name_ko, :keyword) >= :threshold
+            ORDER BY similarity(name_ko, :keyword) DESC
+            """,
+            nativeQuery = true)
+    List<PokedexKoName> findByNameKoSimilarTo(@Param("keyword") String keyword, @Param("threshold") double threshold);
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
@@ -53,6 +53,12 @@ public class CardQueryService {
     private static final int MAX_FILTER_VALUES = 20;
     // 키워드 검색어 상한: cards.name 컬럼 길이(200자)보다 짧게 잡아 과도하게 긴 ILIKE 패턴을 차단.
     private static final int MAX_KEYWORD_LENGTH = 100;
+    // #187: pg_trgm similarity() 유사도 폴백 검색의 최소 점수 - 스파이크 테스트(리자옹→리자몽/리자드 0.33,
+    // 핏카츄→피카츄 0.14, 꼬부리→꼬부기 0.33) 기준으로 시작. 실제 운영에서 노이즈가 많으면 올리는 방향으로 조정.
+    private static final double SIMILARITY_THRESHOLD = 0.14;
+    // #187: 이보다 짧으면 유사도 폴백을 생략한다 - 1글자는 트라이그램 자체가 구분력이 없다(스파이크에서
+    // "리" 한 글자로는 후보 전체가 비슷한 점수로 몰려 무의미했음).
+    private static final int MIN_KEYWORD_LENGTH_FOR_SIMILARITY = 2;
     // 카드 목록/상세 응답에 표시할 등급 값. PSA10/9/8은 감정 등급이라 표시 대상이 아니다.
     // 네이티브 쿼리 IN (:validGrades) 바인드 파라미터로 전달하기 위한 리스트 형태.
     private static final List<String> GRADE_WHITELIST_LIST = List.of("S", "A", "B");
@@ -143,9 +149,19 @@ public class CardQueryService {
         }
         Page<Card> cards = (KoreanTextUtil.isKorean(keyword) || KoreanTextUtil.isChosungOnly(keyword))
                 ? searchByPokedexKoName(keyword, pageable)
-                : cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
+                : searchByName(keyword, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
         return cards.map(card -> toCardResponse(card, gradesByCardId));
+    }
+
+    // 영문 등 이름 검색 - 정확 검색(부분일치)이 0건이고 키워드가 최소 길이 이상일 때만 pg_trgm 유사도
+    // 검색으로 폴백한다(#187). 오타 없는 대다수 검색은 기존 LIKE 부분일치 그대로 동작/성능 유지.
+    private Page<Card> searchByName(String keyword, Pageable pageable) {
+        Page<Card> exact = cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
+        if (exact.getTotalElements() > 0 || keyword.length() < MIN_KEYWORD_LENGTH_FOR_SIMILARITY) {
+            return exact;
+        }
+        return cardRepository.findByNameSimilarTo(keyword, SIMILARITY_THRESHOLD, pageable);
     }
 
     // 한글 검색어를 도감번호 목록으로 변환해 조회한다. 매핑이 없으면 예외 대신 빈 페이지를 반환한다.
@@ -154,9 +170,18 @@ public class CardQueryService {
     // 도감번호가 없는 트레이너/에너지 카드는 이 경로로 검색되지 않는다 - 의도된 한계
     // (PokeAPI 도감번호 매핑 방식의 알려진 제약).
     private Page<Card> searchByPokedexKoName(String keyword, Pageable pageable) {
-        List<PokedexKoName> matches = KoreanTextUtil.isChosungOnly(keyword)
-                ? pokedexKoNameRepository.findByNameKoChosungContaining(keyword)
-                : pokedexKoNameRepository.findByNameKoContaining(keyword);
+        List<PokedexKoName> matches;
+        if (KoreanTextUtil.isChosungOnly(keyword)) {
+            matches = pokedexKoNameRepository.findByNameKoChosungContaining(keyword);
+        } else {
+            matches = pokedexKoNameRepository.findByNameKoContaining(keyword);
+            // 정확 검색(부분일치)이 0건이고 키워드가 최소 길이 이상일 때만 유사도 검색으로 폴백한다(#187).
+            // 초성 검색은 이미 자음 단위 매칭이라 대상에서 제외 - similarity()를 자음 문자열에 쓰는 건
+            // 스파이크로 검증된 시나리오가 아니다.
+            if (matches.isEmpty() && keyword.length() >= MIN_KEYWORD_LENGTH_FOR_SIMILARITY) {
+                matches = pokedexKoNameRepository.findByNameKoSimilarTo(keyword, SIMILARITY_THRESHOLD);
+            }
+        }
         if (matches.isEmpty()) {
             return Page.empty(pageable);
         }

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
@@ -108,7 +108,7 @@ public class CardQueryService {
                 ? cardRepository.search(expandedTypes, expandedRarities, expansionId, minPrice, maxPrice, sort, pageable)
                 : cardRepository.search(expandedTypes, expandedRarities, languages, expansionId, minPrice, maxPrice, sort, pageable);
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> toCardResponse(card, gradesByCardId));
+        return cards.map(card -> toCardResponse(card, gradesByCardId, false));
     }
 
     @Transactional
@@ -147,21 +147,27 @@ public class CardQueryService {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "검색어는 최대 " + MAX_KEYWORD_LENGTH + "자까지 입력할 수 있습니다.");
         }
-        Page<Card> cards = (KoreanTextUtil.isKorean(keyword) || KoreanTextUtil.isChosungOnly(keyword))
+        NameSearchResult result = (KoreanTextUtil.isKorean(keyword) || KoreanTextUtil.isChosungOnly(keyword))
                 ? searchByPokedexKoName(keyword, pageable)
                 : searchByName(keyword, pageable);
-        Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(cards.getContent());
-        return cards.map(card -> toCardResponse(card, gradesByCardId));
+        Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(result.cards().getContent());
+        return result.cards().map(card -> toCardResponse(card, gradesByCardId, result.fuzzyMatch()));
+    }
+
+    // searchByName()/searchByPokedexKoName()이 정확 검색과 유사도 폴백 중 어느 쪼을 탔는지(#187 fuzzyMatch
+    // 응답 플래그)를 함께 반환하기 위한 내부 홀더. Page<Card>만으로는 그 정보가 사라진다.
+    private record NameSearchResult(Page<Card> cards, boolean fuzzyMatch) {
     }
 
     // 영문 등 이름 검색 - 정확 검색(부분일치)이 0건이고 키워드가 최소 길이 이상일 때만 pg_trgm 유사도
     // 검색으로 폴백한다(#187). 오타 없는 대다수 검색은 기존 LIKE 부분일치 그대로 동작/성능 유지.
-    private Page<Card> searchByName(String keyword, Pageable pageable) {
+    private NameSearchResult searchByName(String keyword, Pageable pageable) {
         Page<Card> exact = cardRepository.findByNameContainingIgnoreCase(keyword, pageable);
         if (exact.getTotalElements() > 0 || keyword.length() < MIN_KEYWORD_LENGTH_FOR_SIMILARITY) {
-            return exact;
+            return new NameSearchResult(exact, false);
         }
-        return cardRepository.findByNameSimilarTo(keyword, SIMILARITY_THRESHOLD, pageable);
+        Page<Card> similar = cardRepository.findByNameSimilarTo(keyword, SIMILARITY_THRESHOLD, pageable);
+        return new NameSearchResult(similar, similar.getTotalElements() > 0);
     }
 
     // 한글 검색어를 도감번호 목록으로 변환해 조회한다. 매핑이 없으면 예외 대신 빈 페이지를 반환한다.
@@ -169,8 +175,9 @@ public class CardQueryService {
     // 한글/초성 검색은 도감번호(national_pokedex_numbers) 매핑 기반이라 포켓몬 카드만 지원한다.
     // 도감번호가 없는 트레이너/에너지 카드는 이 경로로 검색되지 않는다 - 의도된 한계
     // (PokeAPI 도감번호 매핑 방식의 알려진 제약).
-    private Page<Card> searchByPokedexKoName(String keyword, Pageable pageable) {
+    private NameSearchResult searchByPokedexKoName(String keyword, Pageable pageable) {
         List<PokedexKoName> matches;
+        boolean fuzzyMatch = false;
         if (KoreanTextUtil.isChosungOnly(keyword)) {
             matches = pokedexKoNameRepository.findByNameKoChosungContaining(keyword);
         } else {
@@ -180,13 +187,14 @@ public class CardQueryService {
             // 스파이크로 검증된 시나리오가 아니다.
             if (matches.isEmpty() && keyword.length() >= MIN_KEYWORD_LENGTH_FOR_SIMILARITY) {
                 matches = pokedexKoNameRepository.findByNameKoSimilarTo(keyword, SIMILARITY_THRESHOLD);
+                fuzzyMatch = !matches.isEmpty();
             }
         }
         if (matches.isEmpty()) {
-            return Page.empty(pageable);
+            return new NameSearchResult(Page.empty(pageable), false);
         }
         List<Integer> pokedexNumbers = matches.stream().map(PokedexKoName::getPokedexNumber).toList();
-        return cardRepository.findByNationalPokedexNumbersIn(pokedexNumbers, pageable);
+        return new NameSearchResult(cardRepository.findByNationalPokedexNumbersIn(pokedexNumbers, pageable), fuzzyMatch);
     }
 
     @Transactional(readOnly = true)
@@ -203,14 +211,14 @@ public class CardQueryService {
         }
         Map<Long, List<String>> gradesByCardId = fetchGradesByCardIds(related);
         return related.stream()
-                .map(relatedCard -> toCardResponse(relatedCard, gradesByCardId))
+                .map(relatedCard -> toCardResponse(relatedCard, gradesByCardId, false))
                 .toList();
     }
 
-    private CardResponse toCardResponse(Card card, Map<Long, List<String>> gradesByCardId) {
+    private CardResponse toCardResponse(Card card, Map<Long, List<String>> gradesByCardId, boolean fuzzyMatch) {
         return CardResponse.from(card, gradesByCardId.getOrDefault(card.getId(), List.of()),
                 cardNameKoResolver.resolve(card), CardTypeEnResolver.resolve(card.getTypes()),
-                CardRarityResolver.resolve(card.getRarityCode(), card.getRarity()));
+                CardRarityResolver.resolve(card.getRarityCode(), card.getRarity()), fuzzyMatch);
     }
 
     private Map<Long, List<String>> fetchGradesByCardIds(List<Card> cards) {

--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -39,6 +39,9 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
 
     long countBySellerIdAndStatus(Long sellerId, ListingStatus status);
 
+    // #300: 워치리스트 재입고 알림 판단용 - 이번에 등록된 매물이 해당 카드의 "유일한" 활성 매물인지 확인한다.
+    long countByCardIdAndStatus(Long cardId, ListingStatus status);
+
     boolean existsBySellerIdAndCardIdAndVariantIdAndStatus(
             Long sellerId, Long cardId, Long variantId, ListingStatus status);
 

--- a/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/repository/ListingRepository.java
@@ -39,8 +39,9 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
 
     long countBySellerIdAndStatus(Long sellerId, ListingStatus status);
 
-    // #300: 워치리스트 재입고 알림 판단용 - 이번에 등록된 매물이 해당 카드의 "유일한" 활성 매물인지 확인한다.
-    long countByCardIdAndStatus(Long cardId, ListingStatus status);
+    // #300: 워치리스트 재입고 알림 판단용 - 이번에 등록된 매물이 해당 (카드, variant)의 "유일한" 활성
+    // 매물인지 확인한다. variantId가 null이면 Spring Data가 자동으로 "IS NULL" 비교로 처리한다.
+    long countByCardIdAndVariantIdAndStatus(Long cardId, Long variantId, ListingStatus status);
 
     boolean existsBySellerIdAndCardIdAndVariantIdAndStatus(
             Long sellerId, Long cardId, Long variantId, ListingStatus status);

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
@@ -12,10 +12,12 @@ import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.global.event.ListingCreatedEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ public class ListingService {
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final UserAccessChecker userAccessChecker;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public ListingResponse createListing(Long sellerId, ListingCreateRequest request) {
@@ -47,6 +50,7 @@ public class ListingService {
                 .build();
 
         Listing saved = listingRepository.save(listing);
+        eventPublisher.publishEvent(new ListingCreatedEvent(saved.getCardId(), saved.getVariantId()));
         return ListingResponse.of(saved);
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
@@ -5,5 +5,6 @@ public enum NotificationType {
     PRICE_TARGET,
     TRADE_CONFIRMED,
     LISTING_STALE,
-    INQUIRY_HANDLED
+    INQUIRY_HANDLED,
+    LISTING_AVAILABLE
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -129,6 +129,22 @@ public class NotificationService {
         return String.format("%s 카드가 %s 목표가 %,d원에 도달했습니다.", cardName, targetLabel, reachedTargetPrice);
     }
 
+    // #300: 워치리스트에 등록한 카드에 매물이 없다가 새로 등록됐을 때(재입고) 알림 생성.
+    // card: 호출자(WatchlistListingAvailableNoticeListener)가 이미 조회해 둔 카드 - createPriceTargetNotification과
+    // 동일하게 여기서 다시 조회하지 않고 재사용해 SSE 즉시 푸시에도 카드 이미지를 채운다.
+    @Transactional
+    public void createListingAvailableNotification(Watchlist watchlist, String cardName, Card card) {
+        Notification notification = Notification.builder()
+                .userId(watchlist.getUserId())
+                .type(NotificationType.LISTING_AVAILABLE)
+                .message(String.format("%s 카드에 매물이 새로 등록됐어요. 지금 확인해보세요!", cardName))
+                .cardId(watchlist.getCardId())
+                .build();
+
+        notificationRepository.save(notification);
+        pushToSubscribers(watchlist.getUserId(), NotificationResponse.of(notification, card));
+    }
+
     // 1:1 문의 처리 완료 알림 생성 - 관리자의 답변 등록, 또는 상태를 HANDLED로 변경한 경우 호출된다.
     // 알림 저장은 호출자 트랜잭션에 그대로 포함시키되, SSE 푸시는 커밋이 실제로 성공한 뒤에만 보낸다 -
     // 커밋 전에 푸시하면 이후 같은 트랜잭션 안에서 다른 작업이 실패해 롤백되는 경우, 유저는 이미 알림을

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -44,9 +44,10 @@ public class Watchlist {
     @Column(name = "is_notified", nullable = false)
     private boolean isNotified;
 
-    // #300: 이 카드에 매물이 없다가 새로 생겼을 때 알림을 이미 보냈는지 여부. isNotified(목표가 알림)와
-    // 별개 플래그다 - 한 워치리스트가 두 종류 알림을 독립적으로 받을 수 있다. 한 번 true가 되면 이번
-    // 범위에서는 리셋하지 않는다(매물이 다시 사라졌다가 재입고돼도 재알림 없음 - 후속 작업에서 다룰 예정).
+    // #300: 이 카드(variant)에 매물이 없다가 새로 생겼을 때 알림을 이미 보냈는지 여부. isNotified(목표가
+    // 알림)와 별개 플래그다 - 한 워치리스트가 두 종류 알림을 독립적으로 받을 수 있다.
+    // WatchlistListingNotifiedResetProcessor 배치가 매물이 다시 소진된 걸 감지하면 false로 리셋해서
+    // 다음 재입고 때 또 알릴 수 있게 한다.
     @Column(name = "listing_notified", nullable = false)
     private boolean listingNotified;
 
@@ -72,6 +73,12 @@ public class Watchlist {
     // #300: 매물 재입고 알림을 보냈음을 표시한다. markAsNotified()(목표가 알림)와 독립적으로 동작한다.
     public void markAsListingNotified() {
         this.listingNotified = true;
+    }
+
+    // #300: 매물이 다시 소진돼(활성 매물 0개) 다음 재입고 때 또 알릴 수 있도록 리셋한다.
+    // WatchlistListingNotifiedResetProcessor 배치 전용 - resetNotification()(목표가 알림)과는 별개다.
+    public void resetListingNotified() {
+        this.listingNotified = false;
     }
 
     // updateTargetPrices()의 "가격이 실제로 바뀐 경우"에만 리셋하는 조건부 로직과 달리,

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -44,6 +44,12 @@ public class Watchlist {
     @Column(name = "is_notified", nullable = false)
     private boolean isNotified;
 
+    // #300: 이 카드에 매물이 없다가 새로 생겼을 때 알림을 이미 보냈는지 여부. isNotified(목표가 알림)와
+    // 별개 플래그다 - 한 워치리스트가 두 종류 알림을 독립적으로 받을 수 있다. 한 번 true가 되면 이번
+    // 범위에서는 리셋하지 않는다(매물이 다시 사라졌다가 재입고돼도 재알림 없음 - 후속 작업에서 다룰 예정).
+    @Column(name = "listing_notified", nullable = false)
+    private boolean listingNotified;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -56,10 +62,16 @@ public class Watchlist {
         this.targetBuyPrice = targetBuyPrice;
         this.targetSellPrice = targetSellPrice;
         this.isNotified = false;
+        this.listingNotified = false;
     }
 
     public void markAsNotified() {
         this.isNotified = true;
+    }
+
+    // #300: 매물 재입고 알림을 보냈음을 표시한다. markAsNotified()(목표가 알림)와 독립적으로 동작한다.
+    public void markAsListingNotified() {
+        this.listingNotified = true;
     }
 
     // updateTargetPrices()의 "가격이 실제로 바뀐 경우"에만 리셋하는 조건부 로직과 달리,

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -44,4 +44,14 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     @Modifying(flushAutomatically = true)
     @Query("UPDATE Watchlist w SET w.listingNotified = true WHERE w.id = :id AND w.listingNotified = false")
     int markListingNotifiedIfNotYet(@Param("id") Long id);
+
+    // #300 후속: 재입고 알림을 이미 보낸(리셋 대상 후보) 워치리스트 전체 조회 - 리셋 배치가 이 목록을
+    // 훑어 실제로 매물이 소진됐는지(활성 매물 0개) 재확인한다.
+    List<Watchlist> findByListingNotifiedTrue();
+
+    // #300 후속: markListingNotifiedIfNotYet과 대칭 - 조건부 원자적 UPDATE로 listingNotified=true인
+    // 행만 false로 되돌린다. 그 사이 다른 트랜잭션이 이미 리셋했거나 삭제된 경우 0을 반환해 안전하게 스킵한다.
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE Watchlist w SET w.listingNotified = false WHERE w.id = :id AND w.listingNotified = true")
+    int resetListingNotifiedIfTrue(@Param("id") Long id);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/repository/WatchlistRepository.java
@@ -36,4 +36,12 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
     @Modifying(flushAutomatically = true)
     @Query("UPDATE Watchlist w SET w.isNotified = true WHERE w.id = :id AND w.isNotified = false")
     int markAsNotifiedIfNotYet(@Param("id") Long id);
+
+    // #300: 매물 재입고 알림 대상 조회 - 이미 알림을 보낸(listingNotified=true) 워치리스트는 자동으로 제외된다.
+    List<Watchlist> findByCardIdAndListingNotifiedFalse(Long cardId);
+
+    // #300: markAsNotifiedIfNotYet과 동일한 이유로 조건부 원자적 UPDATE로 "알림 생성 권한"을 선점한다.
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE Watchlist w SET w.listingNotified = true WHERE w.id = :id AND w.listingNotified = false")
+    int markListingNotifiedIfNotYet(@Param("id") Long id);
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
@@ -30,8 +30,11 @@ import java.util.Objects;
 // 워치리스트 매칭 시에는 양쪽 null을 실제 대표 variant ID로 치환해서 비교한다 - 그대로 null==null로만
 // 비교하면 "대표 변형에 관심 있다"고 등록한 워치리스트가 구체적 variantId로 올라온 재입고 매물을 놓친다.
 //
+// listingNotified 리셋(매물이 다시 소진되면 다음 재입고 때 또 알릴 수 있게 false로 되돌리는 것)은 이
+// 리스너가 아니라 별도 배치(WatchlistListingNotifiedResetService, #300 후속)가 담당한다 - 매물이 ACTIVE를
+// 벗어나는 지점이 listing/trade/admin 3개 도메인에 흩어져 있어 이벤트 기반보다 배치가 결합이 적다.
+//
 // 스코프 제한(이번 범위에서 의도적으로 제외):
-// - 재알림 리셋 없음 - listingNotified는 한 번 true가 되면 매물이 다시 소진돼도 리셋되지 않는다.
 // - 같은 카드로 두 매물이 거의 동시에 등록되는 TOCTOU 경합(둘 다 count==1로 볼 수 있음)은 감내한다.
 // - "유일한 활성 매물" count는 variant_id 리터럴 값 기준이라, null-variant 매물과 명시적 대표-variant
 //   매물이 동시에 존재하는 드문 경우 실제보다 낮게 잡힐 수 있다(불필요한 알림이 한 번 더 갈 수 있는

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
@@ -25,10 +25,9 @@ import java.util.Objects;
 // 보낸다(#300). 매물 등록 트랜잭션이 실제로 커밋된 뒤에만 동작해야(그새 롤백되는 경우 유령 알림이 생기지
 // 않도록) AFTER_COMMIT에서 구독하고, 리스너 자체는 독립된 새 트랜잭션에서 DB에 쓴다.
 //
-// variantId는 null이면 "대표 변형 관심"을 뜻한다(Watchlist.variantId 주석과 동일한 규칙,
-// CardVariantRepository.findGradesByCardId의 COALESCE(variant_id, primary_id) 관례와도 일치).
-// 워치리스트 매칭 시에는 양쪽 null을 실제 대표 variant ID로 치환해서 비교한다 - 그대로 null==null로만
-// 비교하면 "대표 변형에 관심 있다"고 등록한 워치리스트가 구체적 variantId로 올라온 재입고 매물을 놓친다.
+// variantId는 null이면 "대표 변형 관심"을 뜻한다(WatchlistVariantResolver 참고). 워치리스트 매칭
+// 시에는 양쪽 null을 실제 대표 variant ID로 치환해서 비교한다 - 그대로 null==null로만 비교하면
+// "대표 변형에 관심 있다"고 등록한 워치리스트가 구체적 variantId로 올라온 재입고 매물을 놓친다.
 //
 // listingNotified 리셋(매물이 다시 소진되면 다음 재입고 때 또 알릴 수 있게 false로 되돌리는 것)은 이
 // 리스너가 아니라 별도 배치(WatchlistListingNotifiedResetService, #300 후속)가 담당한다 - 매물이 ACTIVE를
@@ -67,16 +66,13 @@ public class WatchlistListingAvailableNoticeListener {
         }
 
         // 대표 variant 정보 자체가 없으면(동기화 누락 등) primaryVariantId도 null로 남는다 - 그러면
-        // event/워치리스트 양쪽 다 null로 남아 Objects.equals(null, null)로 안전하게 매칭된다
-        // (requireNonNullElse는 폴백값이 null이면 NPE를 던져서 여기선 쓸 수 없다).
+        // event/워치리스트 양쪽 다 null로 남아 Objects.equals(null, null)로 안전하게 매칭된다.
         Long primaryVariantId = cardVariantRepository.findPrimaryVariantId(event.cardId()).orElse(null);
-        Long resolvedListingVariantId = event.variantId() != null ? event.variantId() : primaryVariantId;
+        Long resolvedListingVariantId = WatchlistVariantResolver.resolveOrPrimary(event.variantId(), primaryVariantId);
         List<Watchlist> watchers = candidates.stream()
-                .filter(watchlist -> {
-                    Long resolvedWatchVariantId = watchlist.getVariantId() != null
-                            ? watchlist.getVariantId() : primaryVariantId;
-                    return Objects.equals(resolvedWatchVariantId, resolvedListingVariantId);
-                })
+                .filter(watchlist -> Objects.equals(
+                        WatchlistVariantResolver.resolveOrPrimary(watchlist.getVariantId(), primaryVariantId),
+                        resolvedListingVariantId))
                 .toList();
         if (watchers.isEmpty()) {
             return;

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
@@ -1,0 +1,72 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.global.event.ListingCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Objects;
+
+// 관심 있는 카드에 매물이 없다가 새로 생겼을 때(재입고) 워치리스트 등록자에게 알림을 보낸다(#300).
+// 매물 등록 트랜잭션이 실제로 커밋된 뒤에만 동작해야(그새 롤백되는 경우 유령 알림이 생기지 않도록)
+// AFTER_COMMIT에서 구독하고, 리스너 자체는 독립된 새 트랜잭션에서 DB에 쓴다.
+//
+// 스코프 제한(이번 범위에서 의도적으로 제외):
+// - variant 단위 판단 없음 - ListingRepository.countByCardIdAndStatus가 카드 단위라 이와 동일하게 카드 단위로만 판단한다.
+// - 재알림 리셋 없음 - listingNotified는 한 번 true가 되면 매물이 다시 소진돼도 리셋되지 않는다.
+// - 같은 카드로 두 매물이 거의 동시에 등록되는 TOCTOU 경합(둘 다 count==1로 볼 수 있음)은 감내한다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WatchlistListingAvailableNoticeListener {
+
+    private final WatchlistRepository watchlistRepository;
+    private final ListingRepository listingRepository;
+    private final CardRepository cardRepository;
+    private final CardNameKoResolver cardNameKoResolver;
+    private final NotificationService notificationService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onListingCreated(ListingCreatedEvent event) {
+        long activeListingCount = listingRepository.countByCardIdAndStatus(event.cardId(), ListingStatus.ACTIVE);
+        if (activeListingCount != 1) {
+            // 이미 매물이 있던 카드에 하나 더 등록된 경우(재입고 아님) - 알림 대상 없음.
+            return;
+        }
+
+        List<Watchlist> watchers = watchlistRepository.findByCardIdAndListingNotifiedFalse(event.cardId());
+        if (watchers.isEmpty()) {
+            return;
+        }
+
+        Card card = cardRepository.findById(event.cardId()).orElse(null);
+        if (card == null) {
+            log.warn("재입고 알림 대상 카드를 찾을 수 없어 스킵합니다: cardId={}", event.cardId());
+            return;
+        }
+        String cardName = Objects.requireNonNullElse(cardNameKoResolver.resolve(card), card.getName());
+
+        for (Watchlist watchlist : watchers) {
+            int claimed = watchlistRepository.markListingNotifiedIfNotYet(watchlist.getId());
+            if (claimed == 0) {
+                continue;
+            }
+            watchlist.markAsListingNotified();
+            notificationService.createListingAvailableNotification(watchlist, cardName, card);
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListener.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
@@ -20,14 +21,21 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import java.util.List;
 import java.util.Objects;
 
-// 관심 있는 카드에 매물이 없다가 새로 생겼을 때(재입고) 워치리스트 등록자에게 알림을 보낸다(#300).
-// 매물 등록 트랜잭션이 실제로 커밋된 뒤에만 동작해야(그새 롤백되는 경우 유령 알림이 생기지 않도록)
-// AFTER_COMMIT에서 구독하고, 리스너 자체는 독립된 새 트랜잭션에서 DB에 쓴다.
+// 관심 있는 카드(variant 포함)에 매물이 없다가 새로 생겼을 때(재입고) 워치리스트 등록자에게 알림을
+// 보낸다(#300). 매물 등록 트랜잭션이 실제로 커밋된 뒤에만 동작해야(그새 롤백되는 경우 유령 알림이 생기지
+// 않도록) AFTER_COMMIT에서 구독하고, 리스너 자체는 독립된 새 트랜잭션에서 DB에 쓴다.
+//
+// variantId는 null이면 "대표 변형 관심"을 뜻한다(Watchlist.variantId 주석과 동일한 규칙,
+// CardVariantRepository.findGradesByCardId의 COALESCE(variant_id, primary_id) 관례와도 일치).
+// 워치리스트 매칭 시에는 양쪽 null을 실제 대표 variant ID로 치환해서 비교한다 - 그대로 null==null로만
+// 비교하면 "대표 변형에 관심 있다"고 등록한 워치리스트가 구체적 variantId로 올라온 재입고 매물을 놓친다.
 //
 // 스코프 제한(이번 범위에서 의도적으로 제외):
-// - variant 단위 판단 없음 - ListingRepository.countByCardIdAndStatus가 카드 단위라 이와 동일하게 카드 단위로만 판단한다.
 // - 재알림 리셋 없음 - listingNotified는 한 번 true가 되면 매물이 다시 소진돼도 리셋되지 않는다.
 // - 같은 카드로 두 매물이 거의 동시에 등록되는 TOCTOU 경합(둘 다 count==1로 볼 수 있음)은 감내한다.
+// - "유일한 활성 매물" count는 variant_id 리터럴 값 기준이라, null-variant 매물과 명시적 대표-variant
+//   매물이 동시에 존재하는 드문 경우 실제보다 낮게 잡힐 수 있다(불필요한 알림이 한 번 더 갈 수 있는
+//   정도의 사소한 영향이라 감내한다) - 워치리스트 매칭 쪽의 null 치환과 별개 이슈다.
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -36,19 +44,37 @@ public class WatchlistListingAvailableNoticeListener {
     private final WatchlistRepository watchlistRepository;
     private final ListingRepository listingRepository;
     private final CardRepository cardRepository;
+    private final CardVariantRepository cardVariantRepository;
     private final CardNameKoResolver cardNameKoResolver;
     private final NotificationService notificationService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onListingCreated(ListingCreatedEvent event) {
-        long activeListingCount = listingRepository.countByCardIdAndStatus(event.cardId(), ListingStatus.ACTIVE);
+        long activeListingCount = listingRepository.countByCardIdAndVariantIdAndStatus(
+                event.cardId(), event.variantId(), ListingStatus.ACTIVE);
         if (activeListingCount != 1) {
-            // 이미 매물이 있던 카드에 하나 더 등록된 경우(재입고 아님) - 알림 대상 없음.
+            // 같은 (카드, variant)에 이미 매물이 있던 상태에서 하나 더 등록된 경우(재입고 아님) - 알림 대상 없음.
             return;
         }
 
-        List<Watchlist> watchers = watchlistRepository.findByCardIdAndListingNotifiedFalse(event.cardId());
+        List<Watchlist> candidates = watchlistRepository.findByCardIdAndListingNotifiedFalse(event.cardId());
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        // 대표 variant 정보 자체가 없으면(동기화 누락 등) primaryVariantId도 null로 남는다 - 그러면
+        // event/워치리스트 양쪽 다 null로 남아 Objects.equals(null, null)로 안전하게 매칭된다
+        // (requireNonNullElse는 폴백값이 null이면 NPE를 던져서 여기선 쓸 수 없다).
+        Long primaryVariantId = cardVariantRepository.findPrimaryVariantId(event.cardId()).orElse(null);
+        Long resolvedListingVariantId = event.variantId() != null ? event.variantId() : primaryVariantId;
+        List<Watchlist> watchers = candidates.stream()
+                .filter(watchlist -> {
+                    Long resolvedWatchVariantId = watchlist.getVariantId() != null
+                            ? watchlist.getVariantId() : primaryVariantId;
+                    return Objects.equals(resolvedWatchVariantId, resolvedListingVariantId);
+                })
+                .toList();
         if (watchers.isEmpty()) {
             return;
         }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetProcessor.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetProcessor.java
@@ -1,0 +1,52 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+// WatchlistTargetPriceNoticeProcessor와 같은 이유로 별도 빈으로 분리한다(self-invocation 시
+// @Transactional이 AOP 프록시를 안 거쳐 적용되지 않는 문제) - 워치리스트 1건마다 독립된 새 트랜잭션에서
+// 처리해 한 건의 예외가 다른 건에 영향을 주지 않는다(#300 후속).
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WatchlistListingNotifiedResetProcessor {
+
+    private final WatchlistRepository watchlistRepository;
+    private final ListingRepository listingRepository;
+
+    // resolvedVariantId: 호출자(WatchlistListingNotifiedResetService)가 watchlist.variantId==null이면
+    // 카드의 대표 variant ID로 이미 치환해서 넘긴다(WatchlistListingAvailableNoticeListener와 동일한
+    // null=대표 변형 해석 규칙) - 대표 variant 정보 자체가 없으면 null 그대로 넘어온다.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void process(Long watchlistId, Long resolvedVariantId) {
+        // 새 트랜잭션에서 재조회한다 - 스케줄러가 후보를 읽은 시점과 이 트랜잭션이 열리는 시점 사이에
+        // 삭제/변경(예: 그 사이 재입고 알림이 다시 발송됨)됐을 수 있어 이전 인스턴스를 그대로 쓰지 않는다.
+        Watchlist watchlist = watchlistRepository.findById(watchlistId).orElse(null);
+        if (watchlist == null || !watchlist.isListingNotified()) {
+            return;
+        }
+
+        long activeListingCount = listingRepository.countByCardIdAndVariantIdAndStatus(
+                watchlist.getCardId(), resolvedVariantId, ListingStatus.ACTIVE);
+        if (activeListingCount > 0) {
+            // 아직 활성 매물이 남아있음 - 리셋하지 않는다.
+            return;
+        }
+
+        // 조건부 원자적 UPDATE로 "리셋 권한"을 먼저 선점한다 - 그 사이 재입고 알림 리스너가 먼저
+        // markListingNotifiedIfNotYet으로 다시 true를 선점했다면(막 재입고된 경우) 0이 반환돼 안전하게 스킵한다.
+        int reset = watchlistRepository.resetListingNotifiedIfTrue(watchlist.getId());
+        if (reset == 0) {
+            log.info("워치리스트 재입고 알림 리셋 권한을 확보하지 못해 스킵합니다: watchlistId={}", watchlistId);
+            return;
+        }
+        watchlist.resetListingNotified();
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetService.java
@@ -1,0 +1,60 @@
+package com.pokade.domain.watchlist.service;
+
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// 재입고 알림을 이미 보낸(listingNotified=true) 워치리스트를 훑어, 실제로 매물이 다시 소진됐는지(활성
+// 매물 0개) 확인하고 소진됐으면 리셋한다(#300 후속) - 다음 재입고 때 또 알릴 수 있게 하는 목적.
+//
+// 이벤트 기반(매물이 사라지는 시점마다 즉시 감지) 대신 배치로 만든 이유: 매물이 ACTIVE를 벗어나는
+// 지점이 listing 도메인(판매자 취소)뿐 아니라 trade 도메인(구매 시작)·admin 도메인(숨김 처리)에도
+// 흩어져 있어, 이벤트 발행을 전부 커버하려면 3개 도메인에 손을 대야 한다. 배치는 그중 몇 곳에서
+// ACTIVE를 벗어났는지와 무관하게 "지금 활성 매물이 있는지"만 다시 확인하면 되므로 도메인 결합이 없다.
+//
+// 배치 주기(30분, 목표가 배치보다 짧게)의 근거: 리셋이 늦어지면 단순히 "리셋이 늦게 반영"되는 게
+// 아니라, 그 지연 구간 안에 실제로 재입고가 발생하면 listingNotified가 아직 true라 그 재입고에 대한
+// 알림이 완전히 누락된다(다음 리셋 전까지 재시도되지 않음). 목표가 배치(1시간, 지연돼도 결국 언젠가
+// 알림이 감)보다 리셋 배치의 지연 비용이 더 크다고 판단해 더 짧은 주기로 시작한다.
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WatchlistListingNotifiedResetService {
+
+    private final WatchlistRepository watchlistRepository;
+    private final CardVariantRepository cardVariantRepository;
+    private final WatchlistListingNotifiedResetProcessor processor;
+
+    @Scheduled(cron = "0 0,30 * * * *")
+    public void resetListingNotifiedIfSoldOut() {
+        List<Watchlist> watchlists = watchlistRepository.findByListingNotifiedTrue();
+        if (watchlists.isEmpty()) {
+            return;
+        }
+
+        // variantId가 null(대표 변형 관심)인 워치리스트가 여러 개여도 카드별로 한 번만 조회하도록
+        // 배치 조회한다(WatchlistTargetPriceNoticeService의 cardById/allTimeRangeByCardId와 동일한 패턴).
+        List<Long> cardIds = watchlists.stream().map(Watchlist::getCardId).distinct().toList();
+        Map<Long, Long> primaryVariantIdByCardId = cardVariantRepository.findPrimaryVariantIdsByCardIds(cardIds).stream()
+                .collect(Collectors.toMap(CardVariantRepository.PrimaryVariantIdView::getCardId,
+                        CardVariantRepository.PrimaryVariantIdView::getVariantId));
+
+        for (Watchlist watchlist : watchlists) {
+            try {
+                Long resolvedVariantId = watchlist.getVariantId() != null
+                        ? watchlist.getVariantId() : primaryVariantIdByCardId.get(watchlist.getCardId());
+                processor.process(watchlist.getId(), resolvedVariantId);
+            } catch (Exception e) {
+                log.warn("워치리스트 재입고 알림 리셋 확인 실패: watchlistId={}", watchlist.getId(), e);
+            }
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetService.java
@@ -49,8 +49,8 @@ public class WatchlistListingNotifiedResetService {
 
         for (Watchlist watchlist : watchlists) {
             try {
-                Long resolvedVariantId = watchlist.getVariantId() != null
-                        ? watchlist.getVariantId() : primaryVariantIdByCardId.get(watchlist.getCardId());
+                Long resolvedVariantId = WatchlistVariantResolver.resolveOrPrimary(
+                        watchlist.getVariantId(), primaryVariantIdByCardId.get(watchlist.getCardId()));
                 processor.process(watchlist.getId(), resolvedVariantId);
             } catch (Exception e) {
                 log.warn("워치리스트 재입고 알림 리셋 확인 실패: watchlistId={}", watchlist.getId(), e);

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistVariantResolver.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistVariantResolver.java
@@ -1,0 +1,21 @@
+package com.pokade.domain.watchlist.service;
+
+// variantId가 null이면 "대표 변형 관심"을 뜻한다(Watchlist.variantId 주석과 동일한 규칙,
+// CardVariantRepository.findGradesByCardId의 COALESCE(variant_id, primary_id) 관례와도 일치) - #300.
+//
+// WatchlistListingAvailableNoticeListener(단건 - 이벤트 하나당 CardVariantRepository.findPrimaryVariantId
+// 1회 조회)와 WatchlistListingNotifiedResetService(배치 - findPrimaryVariantIdsByCardIds로 여러 카드를
+// 한 번에 조회해 Map으로 보관)는 대표 variant ID를 구하는 방법이 서로 다르다(단건 조회 성능 특성이 달라
+// 하나로 통일하면 한쪽이 손해를 본다). 이 클래스는 그 차이를 신경 쓰지 않고, "이미 구해온 대표 variant
+// ID"와 "이 워치리스트/매물이 가진 variantId"를 합치는 규칙만 공용화한다.
+public final class WatchlistVariantResolver {
+
+    private WatchlistVariantResolver() {
+    }
+
+    // primaryVariantId가 null이면(동기화 누락 등으로 대표 variant 정보 자체가 없는 경우) 그대로 null을
+    // 반환한다 - Objects.requireNonNullElse는 폴백값이 null이면 NPE를 던져서 여기선 쓸 수 없다.
+    public static Long resolveOrPrimary(Long variantId, Long primaryVariantId) {
+        return variantId != null ? variantId : primaryVariantId;
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/event/ListingCreatedEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/ListingCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.pokade.global.event;
+
+public record ListingCreatedEvent(Long cardId, Long variantId) {
+}

--- a/Pokade/src/main/resources/db/migration/V4__add_pg_trgm_typo_tolerant_search.sql
+++ b/Pokade/src/main/resources/db/migration/V4__add_pg_trgm_typo_tolerant_search.sql
@@ -1,0 +1,18 @@
+-- 카드 이름 오타 허용 검색(#187)을 위해 pg_trgm 확장과 트라이그램 GIN 인덱스를 추가한다.
+--
+-- 주의: CardQueryService의 폴백 쿼리(similarity(col, :keyword) >= :threshold)는 함수 호출 형태의
+-- 조건이라 플래너가 이 GIN 인덱스를 직접 타지 않는다(인덱스로 가속하려면 %/<-> 연산자를 써야 하는데,
+-- 그건 pg_trgm.similarity_threshold를 세션 단위로 바꿔야 해서 커넥션 풀에 값이 새어나갈 위험이 있어
+-- 이번 범위에서는 피했다). 폴백은 "정확 검색 0건일 때만" 도는 저빈도 경로라 순차 스캔이어도 현재
+-- 테이블 크기(수천 행)에서는 감내할 만하다고 보고 시작한다 - 카드 수가 크게 늘면 재검토 필요.
+-- 이 인덱스는 대신 기존 LIKE/ILIKE 부분일치 검색(findByNameContainingIgnoreCase 등)이 테이블이
+-- 커졌을 때 순차 스캔에 의존하지 않도록 미리 깔아두는 목적이 크다.
+--
+-- pg_trgm은 PostgreSQL 13+부터 "trusted extension"이라 슈퍼유저 없이도 스키마 생성 권한만으로
+-- 설치 가능하다(관리형 Postgres에서도 대부분 허용). fuzzystrmatch(Levenshtein)는 스파이크 테스트
+-- 결과 짧은 한글 이름에서 pg_trgm과 동일한 동점 문제를 겪으면서 슈퍼유저 권한 리스크만 추가돼
+-- 이번 범위에서 제외했다.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_cards_name_trgm ON cards USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_pokedex_ko_names_name_ko_trgm ON pokedex_ko_names USING gin (name_ko gin_trgm_ops);

--- a/Pokade/src/main/resources/db/migration/V5__add_watchlist_listing_notified.sql
+++ b/Pokade/src/main/resources/db/migration/V5__add_watchlist_listing_notified.sql
@@ -1,0 +1,4 @@
+-- 워치리스트 등록 카드에 매물이 없다가 새로 생겼을 때(재입고) 알림을 이미 보냈는지 추적한다(#300).
+-- 목표가 알림용 is_notified와 별개 플래그다 - 한 워치리스트가 두 종류 알림을 독립적으로 받을 수 있다.
+-- 이번 범위에서는 리셋 로직이 없어 한 번 true가 되면 계속 true로 유지된다(후속 작업에서 다룰 예정).
+ALTER TABLE watchlist ADD COLUMN IF NOT EXISTS listing_notified boolean NOT NULL DEFAULT false;

--- a/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/controller/CardControllerTest.java
@@ -55,7 +55,7 @@ class CardControllerTest {
     @DisplayName("t1 쿼리 파라미터로 카드를 검색하면 200과 페이지 결과를 반환한다")
     void t1() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", null, "EN", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1", List.of());
+                List.of("Fire"), null, null, "base1", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(eq(List.of("Fire")), eq(List.of("Rare Holo")), isNull(), eq("base1"), isNull(), isNull(), isNull(), any(Pageable.class)))
@@ -73,7 +73,7 @@ class CardControllerTest {
     @DisplayName("t27 languages 쿼리 파라미터를 서비스에 그대로 위임한다(#263)")
     void t27() {
         CardResponse card = new CardResponse(1L, "sv10_ja-1", "クヌギダマ", "피콘", "JA", "サンダー", "Common", "Pokémon",
-                List.of("Grass"), null, null, "sv10_ja", List.of());
+                List.of("Grass"), null, null, "sv10_ja", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(isNull(), isNull(), eq(List.of("EN", "JA")), isNull(), isNull(), isNull(), isNull(), any(Pageable.class)))
@@ -120,7 +120,7 @@ class CardControllerTest {
     @DisplayName("t12 sort 쿼리 파라미터를 서비스에 그대로 위임한다")
     void t12() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", null, "EN", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1", List.of());
+                List.of("Fire"), null, null, "base1", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), eq("name"), any(Pageable.class)))
@@ -171,7 +171,7 @@ class CardControllerTest {
     @DisplayName("t20 minPrice/maxPrice 쿼리 파라미터를 서비스에 그대로 위임한다")
     void t20() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", null, "EN", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1", List.of());
+                List.of("Fire"), null, null, "base1", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.search(isNull(), isNull(), isNull(), isNull(), eq(10000), eq(50000), isNull(), any(Pageable.class)))
@@ -275,7 +275,7 @@ class CardControllerTest {
     @DisplayName("t6 검색어로 카드 이름 키워드 검색을 하면 200과 페이지 결과를 반환한다")
     void t6() {
         CardResponse card = new CardResponse(1L, "base1-4", "Charizard", null, "EN", "Base", "Rare Holo", "Pokémon",
-                List.of("Fire"), null, null, "base1", List.of());
+                List.of("Fire"), null, null, "base1", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.searchByKeyword(eq("char"), any(Pageable.class))).willReturn(page);
@@ -306,7 +306,7 @@ class CardControllerTest {
     @DisplayName("t8 존재하는 카드 id로 유사 카드를 조회하면 200과 목록을 반환한다")
     void t8() {
         CardResponse related = new CardResponse(2L, "sv3pt5-6", "Charizard ex", null, "EN", "151", "Double Rare", "Pokémon",
-                List.of("Fire"), null, null, "sv3pt5", List.of());
+                List.of("Fire"), null, null, "sv3pt5", List.of(), false);
         given(cardService.getRelated(1L)).willReturn(List.of(related));
 
         mockMvcTester.get()
@@ -370,7 +370,7 @@ class CardControllerTest {
     @DisplayName("t24 한글 검색어로 요청하면 서비스에 그대로 위임하고 200과 페이지 결과를 반환한다")
     void t24() {
         CardResponse card = new CardResponse(1L, "sv3pt5-25", "피카츄", null, "JA", "151", "Common", "Pokémon",
-                List.of("Lightning"), null, null, "sv3pt5", List.of());
+                List.of("Lightning"), null, null, "sv3pt5", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.searchByKeyword(eq("피카츄"), any(Pageable.class))).willReturn(page);
@@ -388,7 +388,7 @@ class CardControllerTest {
     @DisplayName("t25 초성 검색어도 판별 없이 서비스에 그대로 위임한다")
     void t25() {
         CardResponse card = new CardResponse(1L, "sv3pt5-25", "피카츄", null, "JA", "151", "Common", "Pokémon",
-                List.of("Lightning"), null, null, "sv3pt5", List.of());
+                List.of("Lightning"), null, null, "sv3pt5", List.of(), false);
         Pageable pageable = PageRequest.of(0, 20);
         Page<CardResponse> page = new PageImpl<>(List.of(card), pageable, 1);
         given(cardService.searchByKeyword(eq("ㅍㅋㅊ"), any(Pageable.class))).willReturn(page);

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -143,6 +143,24 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("t31 오타(Charizrd)와 유사도가 threshold 이상인 카드를 유사도 내림차순으로 조회한다(#187, pg_trgm)")
+    void t31() {
+        Page<Card> result = cardRepository.findByNameSimilarTo("Charizrd", 0.14, PageRequest.of(0, 10));
+
+        assertThat(result.getContent())
+                .extracting(Card::getName)
+                .containsExactly("Charizard", "Charizard ex");
+    }
+
+    @Test
+    @DisplayName("t32 threshold 미달이면 조회되지 않는다(#187, pg_trgm)")
+    void t32() {
+        Page<Card> result = cardRepository.findByNameSimilarTo("전혀다른키워드입니다", 0.14, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
     @DisplayName("t2 types 배열에 검색 타입이 포함된 카드만 조회한다")
     void t2() {
         Page<Card> result = cardRepository.search(List.of("Fire"), null, null, null, null, null, PageRequest.of(0, 10));

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/PokedexKoNameRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/PokedexKoNameRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.pokade.domain.card.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import com.pokade.domain.card.entity.PokedexKoName;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+@DataJpaTest
+class PokedexKoNameRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private PokedexKoNameRepository pokedexKoNameRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        persist(5, "Charmeleon", "리자드", "ㄹㅈㄷ");
+        persist(6, "Charizard", "리자몽", "ㄹㅈㅁ");
+        persist(25, "Pikachu", "피카츄", "ㅍㅋㅊ");
+        persist(7, "Squirtle", "꼬부기", "ㄲㅂㄱ");
+    }
+
+    private void persist(int pokedexNumber, String nameEn, String nameKo, String chosung) {
+        entityManager.persist(PokedexKoName.builder()
+                .pokedexNumber(pokedexNumber)
+                .nameEn(nameEn)
+                .nameKo(nameKo)
+                .nameKoChosung(chosung)
+                .build());
+    }
+
+    @Test
+    @DisplayName("t1 오타(리자옹)와 유사도가 threshold 이상인 이름들을 유사도 내림차순으로 조회한다(#187, pg_trgm)")
+    void t1() {
+        List<PokedexKoName> result = pokedexKoNameRepository.findByNameKoSimilarTo("리자옹", 0.14);
+
+        assertThat(result).extracting(PokedexKoName::getNameKo)
+                .containsExactlyInAnyOrder("리자드", "리자몽");
+    }
+
+    @Test
+    @DisplayName("t2 오타(핏카츄)와 유사도가 threshold 이상인 이름을 조회한다(#187, pg_trgm)")
+    void t2() {
+        List<PokedexKoName> result = pokedexKoNameRepository.findByNameKoSimilarTo("핏카츄", 0.14);
+
+        assertThat(result).extracting(PokedexKoName::getNameKo).containsExactly("피카츄");
+    }
+
+    @Test
+    @DisplayName("t3 오타(꼬부리)와 유사도가 threshold 이상인 이름을 조회한다(#187, pg_trgm)")
+    void t3() {
+        List<PokedexKoName> result = pokedexKoNameRepository.findByNameKoSimilarTo("꼬부리", 0.14);
+
+        assertThat(result).extracting(PokedexKoName::getNameKo).containsExactly("꼬부기");
+    }
+
+    @Test
+    @DisplayName("t4 threshold 미달이면 조회되지 않는다(#187, pg_trgm)")
+    void t4() {
+        List<PokedexKoName> result = pokedexKoNameRepository.findByNameKoSimilarTo("전혀다른이름입니다", 0.14);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
@@ -470,6 +470,8 @@ class CardQueryServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
         Page<Card> page = new PageImpl<>(List.of(), pageable, 0);
         given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
+        // #187: 정확 검색이 0건이면 유사도 폴백을 시도한다 - 폴백도 0건이어야 최종 결과가 비게 된다.
+        given(cardRepository.findByNameSimilarTo("char", 0.14, pageable)).willReturn(page);
 
         Page<CardResponse> result = cardQueryService.searchByKeyword("char", pageable);
 
@@ -524,12 +526,92 @@ class CardQueryServiceTest {
     void t45() {
         Pageable pageable = PageRequest.of(0, 20);
         given(pokedexKoNameRepository.findByNameKoContaining("존재안하는한글이름")).willReturn(List.of());
+        // #187: 정확 검색이 0건이면 유사도 폴백을 시도한다 - 폴백도 0건이어야 최종 결과가 비게 된다.
+        given(pokedexKoNameRepository.findByNameKoSimilarTo("존재안하는한글이름", 0.14)).willReturn(List.of());
 
         Page<CardResponse> result = cardQueryService.searchByKeyword("존재안하는한글이름", pageable);
 
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isEqualTo(0);
         verify(cardRepository, never()).findByNationalPokedexNumbersIn(any(), any());
+    }
+
+    // ===== #187: 오타 허용(유사도) 검색 폴백 =====
+
+    @Test
+    @DisplayName("t51 영문 정확 검색이 0건이고 키워드가 2글자 이상이면 유사도 검색으로 폴백한다")
+    void t51() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        Card charizard = Card.builder().id(1L).name("Charizard").build();
+        Page<Card> similarPage = new PageImpl<>(List.of(charizard), pageable, 1);
+        given(cardRepository.findByNameContainingIgnoreCase("Charizrd", pageable)).willReturn(emptyPage);
+        given(cardRepository.findByNameSimilarTo("Charizrd", 0.14, pageable)).willReturn(similarPage);
+
+        Page<CardResponse> result = cardQueryService.searchByKeyword("Charizrd", pageable);
+
+        assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        verify(cardRepository).findByNameSimilarTo("Charizrd", 0.14, pageable);
+    }
+
+    @Test
+    @DisplayName("t52 영문 정확 검색 결과가 있으면 유사도 검색으로 폴백하지 않는다(회귀 확인)")
+    void t52() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Card charizard = Card.builder().id(1L).name("Charizard").build();
+        Page<Card> page = new PageImpl<>(List.of(charizard), pageable, 1);
+        given(cardRepository.findByNameContainingIgnoreCase("char", pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardQueryService.searchByKeyword("char", pageable);
+
+        assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        verify(cardRepository, never()).findByNameSimilarTo(any(), any(Double.class), any());
+    }
+
+    @Test
+    @DisplayName("t48 영문 키워드가 1글자면 정확 검색이 0건이어도 유사도 검색을 생략한다")
+    void t48() {
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Card> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        given(cardRepository.findByNameContainingIgnoreCase("c", pageable)).willReturn(emptyPage);
+
+        Page<CardResponse> result = cardQueryService.searchByKeyword("c", pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(cardRepository, never()).findByNameSimilarTo(any(), any(Double.class), any());
+    }
+
+    @Test
+    @DisplayName("t49 한글 정확 검색이 0건이고 키워드가 2글자 이상이면 유사도 검색으로 폴백한다")
+    void t49() {
+        Pageable pageable = PageRequest.of(0, 20);
+        PokedexKoName charizard = PokedexKoName.builder()
+                .pokedexNumber(6).nameKo("리자몽").nameKoChosung("ㄹㅈㅁ").build();
+        PokedexKoName charmeleon = PokedexKoName.builder()
+                .pokedexNumber(5).nameKo("리자드").nameKoChosung("ㄹㅈㄷ").build();
+        Card charizardCard = Card.builder().id(1L).name("Charizard").nationalPokedexNumbers(List.of(6)).build();
+        Page<Card> page = new PageImpl<>(List.of(charizardCard), pageable, 1);
+        given(pokedexKoNameRepository.findByNameKoContaining("리자옹")).willReturn(List.of());
+        given(pokedexKoNameRepository.findByNameKoSimilarTo("리자옹", 0.14))
+                .willReturn(List.of(charizard, charmeleon));
+        given(cardRepository.findByNationalPokedexNumbersIn(List.of(6, 5), pageable)).willReturn(page);
+
+        Page<CardResponse> result = cardQueryService.searchByKeyword("리자옹", pageable);
+
+        assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        verify(pokedexKoNameRepository).findByNameKoSimilarTo("리자옹", 0.14);
+    }
+
+    @Test
+    @DisplayName("t50 한글 키워드가 1글자면 정확 검색이 0건이어도 유사도 검색을 생략한다")
+    void t50() {
+        Pageable pageable = PageRequest.of(0, 20);
+        given(pokedexKoNameRepository.findByNameKoContaining("리")).willReturn(List.of());
+
+        Page<CardResponse> result = cardQueryService.searchByKeyword("리", pageable);
+
+        assertThat(result.getContent()).isEmpty();
+        verify(pokedexKoNameRepository, never()).findByNameKoSimilarTo(any(), any(Double.class));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
@@ -383,6 +383,7 @@ class CardQueryServiceTest {
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Charizard");
+        assertThat(result.getContent().get(0).fuzzyMatch()).isFalse();
     }
 
     @Test
@@ -497,6 +498,7 @@ class CardQueryServiceTest {
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).name()).isEqualTo("Pikachu");
+        assertThat(result.getContent().get(0).fuzzyMatch()).isFalse();
         verify(cardRepository).findByNationalPokedexNumbersIn(List.of(25), pageable);
     }
 
@@ -551,6 +553,7 @@ class CardQueryServiceTest {
         Page<CardResponse> result = cardQueryService.searchByKeyword("Charizrd", pageable);
 
         assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        assertThat(result.getContent()).extracting(CardResponse::fuzzyMatch).containsExactly(true);
         verify(cardRepository).findByNameSimilarTo("Charizrd", 0.14, pageable);
     }
 
@@ -565,6 +568,7 @@ class CardQueryServiceTest {
         Page<CardResponse> result = cardQueryService.searchByKeyword("char", pageable);
 
         assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        assertThat(result.getContent()).extracting(CardResponse::fuzzyMatch).containsExactly(false);
         verify(cardRepository, never()).findByNameSimilarTo(any(), any(Double.class), any());
     }
 
@@ -599,6 +603,7 @@ class CardQueryServiceTest {
         Page<CardResponse> result = cardQueryService.searchByKeyword("리자옹", pageable);
 
         assertThat(result.getContent()).extracting(CardResponse::name).containsExactly("Charizard");
+        assertThat(result.getContent()).extracting(CardResponse::fuzzyMatch).containsExactly(true);
         verify(pokedexKoNameRepository).findByNameKoSimilarTo("리자옹", 0.14);
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
@@ -8,6 +8,7 @@ import com.pokade.domain.listing.dto.ListingUpdateRequest;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.global.event.ListingCreatedEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.port.UserAccessChecker;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.Optional;
 
@@ -24,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,6 +45,9 @@ class ListingServiceTest {
 
     @Mock
     private UserAccessChecker userAccessChecker;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private ListingService listingService;
@@ -70,6 +76,18 @@ class ListingServiceTest {
 
         assertThat(response.sellerId()).isEqualTo(100L);
         assertThat(response.price()).isEqualTo(10000);
+    }
+
+    @Test
+    void 매물_등록에_성공하면_ListingCreatedEvent가_저장된_카드ID_변형ID로_발행된다() {
+        ListingCreateRequest request = new ListingCreateRequest(1L, 2L, 10000, ListingGrade.A);
+        given(listingRepository.existsBySellerIdAndCardIdAndVariantIdAndStatus(
+                anyLong(), any(), any(), any())).willReturn(false);
+        given(listingRepository.save(any(Listing.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        listingService.createListing(100L, request);
+
+        then(eventPublisher).should().publishEvent(new ListingCreatedEvent(1L, 2L));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/repository/WatchlistRepositoryTest.java
@@ -96,6 +96,46 @@ class WatchlistRepositoryTest {
     }
 
     @Test
+    void findByListingNotifiedTrue는_재입고_알림을_보낸_항목만_조회한다() {
+        Long userId = insertUser("listing-notified@test.com");
+        Long notifiedCardId = insertCard("watch-listing-notified-a");
+        Long unnotifiedCardId = insertCard("watch-listing-notified-b");
+        Watchlist notified = saveWatchlist(userId, notifiedCardId, 1000, null);
+        Watchlist unnotified = saveWatchlist(userId, unnotifiedCardId, 1000, null);
+        notified.markAsListingNotified();
+        watchlistRepository.save(notified);
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Watchlist> found = watchlistRepository.findByListingNotifiedTrue();
+
+        // 전역 조회라 다른 테스트/기존 데이터가 섞여 있을 수 있어, "이 테스트가 만든 항목이 기대한 대로
+        // 포함/제외되는지"만 검증한다(findByIsNotifiedFalse 테스트와 동일한 방식).
+        assertThat(found).extracting(Watchlist::getId)
+                .contains(notified.getId())
+                .doesNotContain(unnotified.getId());
+    }
+
+    @Test
+    void resetListingNotifiedIfTrue는_listingNotified가_true인_행만_false로_되돌리고_이미_false면_0을_반환한다() {
+        Long userId = insertUser("reset-listing-notified@test.com");
+        Watchlist notified = saveWatchlist(userId, insertCard("watch-reset-a"), 1000, null);
+        Watchlist unnotified = saveWatchlist(userId, insertCard("watch-reset-b"), 1000, null);
+        notified.markAsListingNotified();
+        watchlistRepository.save(notified);
+        entityManager.flush();
+
+        int resetCount = watchlistRepository.resetListingNotifiedIfTrue(notified.getId());
+        int noopCount = watchlistRepository.resetListingNotifiedIfTrue(unnotified.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(resetCount).isEqualTo(1);
+        assertThat(noopCount).isEqualTo(0);
+        assertThat(watchlistRepository.findById(notified.getId()).orElseThrow().isListingNotified()).isFalse();
+    }
+
+    @Test
     void 같은_유저가_같은_카드로_두번_저장하면_UNIQUE_제약으로_예외가_발생한다() {
         Long userId = insertUser("dup@test.com");
         Long cardId = insertCard("watch-dup");

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.card.support.PokedexKoNameCache;
 import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.dto.ListingResponse;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.service.ListingService;
 import com.pokade.domain.notification.entity.Notification;
@@ -45,11 +46,15 @@ import jakarta.persistence.EntityManager;
 @DataJpaTest
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Import({ListingService.class, WatchlistListingAvailableNoticeListener.class, NotificationService.class,
-        CardNameKoResolver.class, PokedexKoNameCache.class, UserAccessGuard.class, SseEmitterStore.class})
+        CardNameKoResolver.class, PokedexKoNameCache.class, UserAccessGuard.class, SseEmitterStore.class,
+        WatchlistListingNotifiedResetService.class, WatchlistListingNotifiedResetProcessor.class})
 class WatchlistListingAvailableNoticeIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private ListingService listingService;
+
+    @Autowired
+    private WatchlistListingNotifiedResetService watchlistListingNotifiedResetService;
 
     @Autowired
     private WatchlistRepository watchlistRepository;
@@ -189,6 +194,34 @@ class WatchlistListingAvailableNoticeIntegrationTest extends AbstractIntegration
 
         assertThat(notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId))
                 .extracting(Notification::getType).contains(NotificationType.LISTING_AVAILABLE);
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isTrue();
+    }
+
+    @Test
+    void 매물이_취소되고_리셋_배치가_돌면_다음_재입고_때_또_알림이_간다() {
+        Long sellerId = persistActiveUser("listing-notice-seller5@test.com");
+        Long watcherId = persistActiveUser("listing-notice-watcher5@test.com");
+        Long cardId = persistCard("listing-notice-card-5", "Charizard");
+        Long watchlistId = persistWatchlist(watcherId, cardId);
+
+        Long listingId = transactionTemplate().execute(status ->
+                listingService.createListing(sellerId, new ListingCreateRequest(cardId, null, 10000, ListingGrade.A)).id());
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isTrue();
+        int notificationCountAfterFirstListing = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId).size();
+
+        // 판매자가 취소 - 활성 매물이 0개가 된다. 리셋 배치가 돌기 전까지는 listingNotified가 그대로 true다.
+        runInNewTransaction(() -> listingService.deleteListing(sellerId, listingId));
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isTrue();
+
+        watchlistListingNotifiedResetService.resetListingNotifiedIfSoldOut();
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isFalse();
+
+        // 리셋됐으니 재입고 매물 등록 시 다시 알림이 간다.
+        runInNewTransaction(() ->
+                listingService.createListing(sellerId, new ListingCreateRequest(cardId, null, 9000, ListingGrade.A)));
+
+        List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId);
+        assertThat(notifications).hasSizeGreaterThan(notificationCountAfterFirstListing);
         assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isTrue();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
@@ -89,12 +89,26 @@ class WatchlistListingAvailableNoticeIntegrationTest extends AbstractIntegration
     }
 
     private Long persistWatchlist(Long userId, Long cardId) {
+        return persistWatchlist(userId, cardId, null);
+    }
+
+    private Long persistWatchlist(Long userId, Long cardId, Long variantId) {
         return transactionTemplate().execute(status -> {
             Watchlist watchlist = Watchlist.builder()
-                    .userId(userId).cardId(cardId).targetBuyPrice(1000).build();
+                    .userId(userId).cardId(cardId).variantId(variantId).targetBuyPrice(1000).build();
             entityManager.persist(watchlist);
             return watchlist.getId();
         });
+    }
+
+    private Long persistVariant(Long cardId, String variantName, boolean primary) {
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO card_variants (card_id, variant_name, is_primary, synced_at) "
+                                + "VALUES (:cardId, :variantName, :primary, now()) RETURNING id")
+                .setParameter("cardId", cardId)
+                .setParameter("variantName", variantName)
+                .setParameter("primary", primary)
+                .getSingleResult()).longValue());
     }
 
     private void runInNewTransaction(Runnable action) {
@@ -151,5 +165,30 @@ class WatchlistListingAvailableNoticeIntegrationTest extends AbstractIntegration
 
         List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId);
         assertThat(notifications).hasSize(notificationCountAfterFirst);
+    }
+
+    @Test
+    void 다른_variant를_관심등록한_워치리스트에는_재입고_알림이_가지_않는다() {
+        Long sellerId = persistActiveUser("listing-notice-seller4@test.com");
+        Long watcherId = persistActiveUser("listing-notice-watcher4@test.com");
+        Long cardId = persistCard("listing-notice-card-4", "Charizard");
+        Long variantA = persistVariant(cardId, "holo", true);
+        Long variantB = persistVariant(cardId, "normal", false);
+        Long watchlistId = persistWatchlist(watcherId, cardId, variantA);
+
+        // variantB로 매물 등록 - watcherId는 variantA만 관심 등록했으니 알림이 가면 안 된다.
+        runInNewTransaction(() ->
+                listingService.createListing(sellerId, new ListingCreateRequest(cardId, variantB, 10000, ListingGrade.A)));
+
+        assertThat(notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId)).isEmpty();
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isFalse();
+
+        // variantA로 매물 등록 - 이번엔 관심 등록한 variant와 일치하므로 알림이 간다.
+        runInNewTransaction(() ->
+                listingService.createListing(sellerId, new ListingCreateRequest(cardId, variantA, 9000, ListingGrade.A)));
+
+        assertThat(notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId))
+                .extracting(Notification::getType).contains(NotificationType.LISTING_AVAILABLE);
+        assertThat(watchlistRepository.findById(watchlistId).orElseThrow().isListingNotified()).isTrue();
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.pokade.domain.watchlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.card.support.PokedexKoNameCache;
+import com.pokade.domain.listing.dto.ListingCreateRequest;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.service.ListingService;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.notification.store.SseEmitterStore;
+import com.pokade.domain.user.service.UserAccessGuard;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.support.AbstractIntegrationTest;
+
+import jakarta.persistence.EntityManager;
+
+// listing 도메인이 실제로 ListingCreatedEvent를 발행하고, watchlist/notification 도메인이 그걸 구독해
+// 재입고 알림을 만드는 전체 경로를 검증한다(#300). 단위 테스트(WatchlistListingAvailableNoticeListenerTest)는
+// 리스너를 직접 호출해 판단 로직만 보므로, Spring의 @TransactionalEventListener(AFTER_COMMIT) 배선
+// 자체(트랜잭션이 실제로 커밋된 뒤에만 동작하는지)는 이 통합 테스트가 아니면 검증할 방법이 없다.
+//
+// @SpringBootTest(전체 컨텍스트) 대신 @DataJpaTest + 필요한 빈만 @Import한 슬라이스를 쓴다 - 전체
+// 컨텍스트는 S3/메일/OAuth2 등 이 테스트와 무관한 빈까지 띄우며 실제 자격 증명을 요구해 로컬에서 깨진다.
+//
+// 클래스에 @Transactional(NOT_SUPPORTED)을 직접 선언해 @DataJpaTest가 기본으로 씌우는 "테스트당 1개
+// 트랜잭션(끝나면 롤백)"을 끈다 - 그 기본 동작 위에서는 아래 TransactionTemplate로 열었다 커밋한
+// "것처럼 보이는" 트랜잭션도 실제로는 바깥의 테스트 트랜잭션에 참여할 뿐이라 물리적으로 커밋되지
+// 않고, AFTER_COMMIT 리스너가 테스트 도중 전혀 발동하지 않는다.
+@DataJpaTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({ListingService.class, WatchlistListingAvailableNoticeListener.class, NotificationService.class,
+        CardNameKoResolver.class, PokedexKoNameCache.class, UserAccessGuard.class, SseEmitterStore.class})
+class WatchlistListingAvailableNoticeIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ListingService listingService;
+
+    @Autowired
+    private WatchlistRepository watchlistRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private TransactionTemplate transactionTemplate() {
+        return new TransactionTemplate(transactionManager);
+    }
+
+    // 클래스 트랜잭션을 껐으므로(위 주석 참고) 준비 데이터 삽입도 각자 자기 트랜잭션에서 커밋해야
+    // entityManager.persist()가 TransactionRequiredException 없이 동작한다.
+    private Long persistActiveUser(String email) {
+        // nickname은 UNIQUE 제약이라 email에서 파생시킨다 - 이 테스트는 클래스 트랜잭션을 껐으므로
+        // (AFTER_COMMIT 검증을 위해 필요) 테스트 메서드 사이에 데이터가 자동 롤백되지 않는다.
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE') RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue());
+    }
+
+    private Long persistCard(String externalId, String name) {
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, :name) RETURNING id")
+                .setParameter("externalId", externalId)
+                .setParameter("name", name)
+                .getSingleResult()).longValue());
+    }
+
+    private Long persistWatchlist(Long userId, Long cardId) {
+        return transactionTemplate().execute(status -> {
+            Watchlist watchlist = Watchlist.builder()
+                    .userId(userId).cardId(cardId).targetBuyPrice(1000).build();
+            entityManager.persist(watchlist);
+            return watchlist.getId();
+        });
+    }
+
+    private void runInNewTransaction(Runnable action) {
+        transactionTemplate().executeWithoutResult(status -> action.run());
+    }
+
+    @Test
+    void 매물이_처음_등록되면_워치리스트_등록자에게_재입고_알림이_생성된다() {
+        Long sellerId = persistActiveUser("listing-notice-seller1@test.com");
+        Long watcherId = persistActiveUser("listing-notice-watcher1@test.com");
+        Long cardId = persistCard("listing-notice-card-1", "Charizard");
+        Long watchlistId = persistWatchlist(watcherId, cardId);
+
+        runInNewTransaction(() ->
+                listingService.createListing(sellerId, new ListingCreateRequest(cardId, null, 10000, ListingGrade.A)));
+
+        List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId);
+        assertThat(notifications).extracting(Notification::getType).contains(NotificationType.LISTING_AVAILABLE);
+        Watchlist reloaded = watchlistRepository.findById(watchlistId).orElseThrow();
+        assertThat(reloaded.isListingNotified()).isTrue();
+    }
+
+    @Test
+    void 매물_등록_트랜잭션이_롤백되면_재입고_알림이_생성되지_않는다() {
+        Long sellerId = persistActiveUser("listing-notice-seller2@test.com");
+        Long watcherId = persistActiveUser("listing-notice-watcher2@test.com");
+        Long cardId = persistCard("listing-notice-card-2", "Blastoise");
+        persistWatchlist(watcherId, cardId);
+
+        transactionTemplate().executeWithoutResult(status -> {
+            listingService.createListing(sellerId, new ListingCreateRequest(cardId, null, 10000, ListingGrade.A));
+            status.setRollbackOnly();
+        });
+
+        List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId);
+        assertThat(notifications).isEmpty();
+    }
+
+    @Test
+    void 이미_매물이_있는_카드에_매물이_추가로_등록되면_재입고_알림이_가지_않는다() {
+        Long seller1Id = persistActiveUser("listing-notice-seller3a@test.com");
+        Long seller2Id = persistActiveUser("listing-notice-seller3b@test.com");
+        Long watcherId = persistActiveUser("listing-notice-watcher3@test.com");
+        Long cardId = persistCard("listing-notice-card-3", "Pikachu");
+        persistWatchlist(watcherId, cardId);
+
+        runInNewTransaction(() ->
+                listingService.createListing(seller1Id, new ListingCreateRequest(cardId, null, 10000, ListingGrade.A)));
+        // 첫 등록으로 이미 재입고 알림 1건이 생성된 상태 - 두 번째 등록은 "이미 매물이 있던 카드"라 알림이 추가되면 안 된다.
+        int notificationCountAfterFirst = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId).size();
+
+        runInNewTransaction(() ->
+                listingService.createListing(seller2Id, new ListingCreateRequest(cardId, null, 12000, ListingGrade.A)));
+
+        List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(watcherId);
+        assertThat(notifications).hasSize(notificationCountAfterFirst);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListenerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListenerTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
@@ -40,6 +41,9 @@ class WatchlistListingAvailableNoticeListenerTest {
     private CardRepository cardRepository;
 
     @Mock
+    private CardVariantRepository cardVariantRepository;
+
+    @Mock
     private CardNameKoResolver cardNameKoResolver;
 
     @Mock
@@ -49,15 +53,20 @@ class WatchlistListingAvailableNoticeListenerTest {
     private WatchlistListingAvailableNoticeListener listener;
 
     private Watchlist watchlist(Long id, Long cardId) {
-        Watchlist watchlist = Watchlist.builder().userId(id).cardId(cardId).targetBuyPrice(1000).build();
+        return watchlist(id, cardId, null);
+    }
+
+    private Watchlist watchlist(Long id, Long cardId, Long variantId) {
+        Watchlist watchlist = Watchlist.builder()
+                .userId(id).cardId(cardId).variantId(variantId).targetBuyPrice(1000).build();
         org.springframework.test.util.ReflectionTestUtils.setField(watchlist, "id", id);
         return watchlist;
     }
 
     @Test
-    @DisplayName("이미 매물이 있던 카드(count != 1)면 워치리스트 조회 자체를 하지 않는다")
+    @DisplayName("이미 매물이 있던 (카드, variant)면(count != 1) 워치리스트 조회 자체를 하지 않는다")
     void onListingCreated_skipsWhenNotUniqueActiveListing() {
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(2L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(2L);
 
         listener.onListingCreated(new ListingCreatedEvent(1L, null));
 
@@ -68,7 +77,7 @@ class WatchlistListingAvailableNoticeListenerTest {
     @Test
     @DisplayName("유일한 활성 매물이지만 워치리스트 등록자가 없으면 알림을 만들지 않는다")
     void onListingCreated_noWatchersMeansNoNotification() {
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of());
 
         listener.onListingCreated(new ListingCreatedEvent(1L, null));
@@ -82,8 +91,9 @@ class WatchlistListingAvailableNoticeListenerTest {
     void onListingCreated_createsNotificationAndMarksListingNotified() {
         Watchlist w1 = watchlist(10L, 1L);
         Card card = Card.builder().id(1L).name("Charizard").build();
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
         given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
@@ -99,8 +109,9 @@ class WatchlistListingAvailableNoticeListenerTest {
     void onListingCreated_fallsBackToOriginalNameWhenNoKoreanName() {
         Watchlist w1 = watchlist(10L, 1L);
         Card card = Card.builder().id(1L).name("Charizard").build();
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardNameKoResolver.resolve(card)).willReturn(null);
         given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
@@ -115,8 +126,9 @@ class WatchlistListingAvailableNoticeListenerTest {
     void onListingCreated_skipsWhenClaimFails() {
         Watchlist w1 = watchlist(10L, 1L);
         Card card = Card.builder().id(1L).name("Charizard").build();
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
         given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(0);
@@ -133,8 +145,9 @@ class WatchlistListingAvailableNoticeListenerTest {
         Watchlist w1 = watchlist(10L, 1L);
         Watchlist w2 = watchlist(20L, 1L);
         Card card = Card.builder().id(1L).name("Charizard").build();
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1, w2));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
         given(cardRepository.findById(1L)).willReturn(Optional.of(card));
         given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
         given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
@@ -150,13 +163,73 @@ class WatchlistListingAvailableNoticeListenerTest {
     @DisplayName("카드를 찾을 수 없으면 알림을 만들지 않는다")
     void onListingCreated_skipsWhenCardNotFound() {
         Watchlist w1 = watchlist(10L, 1L);
-        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
         given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
         given(cardRepository.findById(1L)).willReturn(Optional.empty());
 
         listener.onListingCreated(new ListingCreatedEvent(1L, null));
 
         then(watchlistRepository).should(never()).markListingNotifiedIfNotYet(any());
         then(notificationService).should(never()).createListingAvailableNotification(any(), any(), any());
+    }
+
+    // ===== #300 후속: variant 단위 판단 =====
+
+    @Test
+    @DisplayName("매물의 variant와 다른 variant를 관심 등록한 워치리스트는 알림 대상에서 제외된다")
+    void onListingCreated_skipsWatcherWatchingDifferentVariant() {
+        Watchlist watchingVariantA = watchlist(10L, 1L, 100L);
+        Watchlist watchingVariantB = watchlist(20L, 1L, 200L);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        // 이번에 등록된 매물은 variantId=100L(A) - 유일한 활성 매물이라 count는 1.
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, 100L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L))
+                .willReturn(List.of(watchingVariantA, watchingVariantB));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.of(100L));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, 100L));
+
+        then(notificationService).should().createListingAvailableNotification(eq(watchingVariantA), any(), any());
+        then(notificationService).should(never()).createListingAvailableNotification(eq(watchingVariantB), any(), any());
+        then(watchlistRepository).should(never()).markListingNotifiedIfNotYet(20L);
+    }
+
+    @Test
+    @DisplayName("대표 변형에 관심 등록(variantId=null)한 워치리스트는 실제 대표 variant로 올라온 매물과 매칭된다")
+    void onListingCreated_matchesNullWatcherAgainstResolvedPrimaryVariant() {
+        Watchlist watchingPrimary = watchlist(10L, 1L, null);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        // 매물은 명시적으로 variantId=100L(대표 variant)로 등록됐다.
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, 100L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(watchingPrimary));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.of(100L));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, 100L));
+
+        then(notificationService).should().createListingAvailableNotification(watchingPrimary, "리자몽", card);
+    }
+
+    @Test
+    @DisplayName("대표 variant 정보 자체가 없으면 variantId가 null인 워치리스트끼리만 매칭된다")
+    void onListingCreated_matchesNullToNullWhenNoPrimaryVariantInfo() {
+        Watchlist watchingNull = watchlist(10L, 1L, null);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, null, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(watchingNull));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(notificationService).should().createListingAvailableNotification(watchingNull, "리자몽", card);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListenerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingAvailableNoticeListenerTest.java
@@ -1,0 +1,162 @@
+package com.pokade.domain.watchlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.global.event.ListingCreatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistListingAvailableNoticeListenerTest {
+
+    @Mock
+    private WatchlistRepository watchlistRepository;
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private CardNameKoResolver cardNameKoResolver;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private WatchlistListingAvailableNoticeListener listener;
+
+    private Watchlist watchlist(Long id, Long cardId) {
+        Watchlist watchlist = Watchlist.builder().userId(id).cardId(cardId).targetBuyPrice(1000).build();
+        org.springframework.test.util.ReflectionTestUtils.setField(watchlist, "id", id);
+        return watchlist;
+    }
+
+    @Test
+    @DisplayName("이미 매물이 있던 카드(count != 1)면 워치리스트 조회 자체를 하지 않는다")
+    void onListingCreated_skipsWhenNotUniqueActiveListing() {
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(2L);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(watchlistRepository).should(never()).findByCardIdAndListingNotifiedFalse(any());
+        then(notificationService).should(never()).createListingAvailableNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("유일한 활성 매물이지만 워치리스트 등록자가 없으면 알림을 만들지 않는다")
+    void onListingCreated_noWatchersMeansNoNotification() {
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of());
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(cardRepository).should(never()).findById(any());
+        then(notificationService).should(never()).createListingAvailableNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("유일한 활성 매물이고 워치리스트 등록자가 있으면 알림을 생성하고 listingNotified를 true로 표시한다")
+    void onListingCreated_createsNotificationAndMarksListingNotified() {
+        Watchlist w1 = watchlist(10L, 1L);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        assertThat(w1.isListingNotified()).isTrue();
+        then(notificationService).should().createListingAvailableNotification(w1, "리자몽", card);
+    }
+
+    @Test
+    @DisplayName("한글명 매핑이 없으면 카드 원본 이름으로 폴백한다")
+    void onListingCreated_fallsBackToOriginalNameWhenNoKoreanName() {
+        Watchlist w1 = watchlist(10L, 1L);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn(null);
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(notificationService).should().createListingAvailableNotification(w1, "Charizard", card);
+    }
+
+    @Test
+    @DisplayName("이미 다른 트랜잭션이 선점(claim 실패)한 워치리스트는 알림을 만들지 않는다")
+    void onListingCreated_skipsWhenClaimFails() {
+        Watchlist w1 = watchlist(10L, 1L);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(0);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        assertThat(w1.isListingNotified()).isFalse();
+        then(notificationService).should(never()).createListingAvailableNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("여러 워치리스트 등록자 중 일부만 claim에 성공하면 성공한 대상에게만 알림을 보낸다")
+    void onListingCreated_notifiesOnlyClaimedWatchers() {
+        Watchlist w1 = watchlist(10L, 1L);
+        Watchlist w2 = watchlist(20L, 1L);
+        Card card = Card.builder().id(1L).name("Charizard").build();
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1, w2));
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+        given(watchlistRepository.markListingNotifiedIfNotYet(10L)).willReturn(1);
+        given(watchlistRepository.markListingNotifiedIfNotYet(20L)).willReturn(0);
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(notificationService).should().createListingAvailableNotification(eq(w1), any(), any());
+        then(notificationService).should(never()).createListingAvailableNotification(eq(w2), any(), any());
+    }
+
+    @Test
+    @DisplayName("카드를 찾을 수 없으면 알림을 만들지 않는다")
+    void onListingCreated_skipsWhenCardNotFound() {
+        Watchlist w1 = watchlist(10L, 1L);
+        given(listingRepository.countByCardIdAndStatus(1L, ListingStatus.ACTIVE)).willReturn(1L);
+        given(watchlistRepository.findByCardIdAndListingNotifiedFalse(1L)).willReturn(List.of(w1));
+        given(cardRepository.findById(1L)).willReturn(Optional.empty());
+
+        listener.onListingCreated(new ListingCreatedEvent(1L, null));
+
+        then(watchlistRepository).should(never()).markListingNotifiedIfNotYet(any());
+        then(notificationService).should(never()).createListingAvailableNotification(any(), any(), any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetProcessorTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetProcessorTest.java
@@ -1,0 +1,105 @@
+package com.pokade.domain.watchlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistListingNotifiedResetProcessorTest {
+
+    @Mock
+    private WatchlistRepository watchlistRepository;
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @InjectMocks
+    private WatchlistListingNotifiedResetProcessor processor;
+
+    private Watchlist notifiedWatchlist(Long id, Long cardId, Long variantId) {
+        Watchlist watchlist = Watchlist.builder()
+                .userId(id).cardId(cardId).variantId(variantId).targetBuyPrice(1000).build();
+        ReflectionTestUtils.setField(watchlist, "id", id);
+        watchlist.markAsListingNotified();
+        return watchlist;
+    }
+
+    @Test
+    @DisplayName("활성 매물이 남아있으면 리셋하지 않는다")
+    void process_keepsNotifiedWhenActiveListingRemains() {
+        Watchlist watchlist = notifiedWatchlist(10L, 1L, 100L);
+        given(watchlistRepository.findById(10L)).willReturn(Optional.of(watchlist));
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, 100L, ListingStatus.ACTIVE)).willReturn(1L);
+
+        processor.process(10L, 100L);
+
+        assertThat(watchlist.isListingNotified()).isTrue();
+        then(watchlistRepository).should(never()).resetListingNotifiedIfTrue(any());
+    }
+
+    @Test
+    @DisplayName("활성 매물이 0개면 리셋한다")
+    void process_resetsWhenNoActiveListingRemains() {
+        Watchlist watchlist = notifiedWatchlist(10L, 1L, 100L);
+        given(watchlistRepository.findById(10L)).willReturn(Optional.of(watchlist));
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, 100L, ListingStatus.ACTIVE)).willReturn(0L);
+        given(watchlistRepository.resetListingNotifiedIfTrue(10L)).willReturn(1);
+
+        processor.process(10L, 100L);
+
+        assertThat(watchlist.isListingNotified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 다른 트랜잭션이 리셋을 선점(claim 실패)했으면 엔티티를 건드리지 않는다")
+    void process_skipsWhenResetClaimFails() {
+        Watchlist watchlist = notifiedWatchlist(10L, 1L, 100L);
+        given(watchlistRepository.findById(10L)).willReturn(Optional.of(watchlist));
+        given(listingRepository.countByCardIdAndVariantIdAndStatus(1L, 100L, ListingStatus.ACTIVE)).willReturn(0L);
+        given(watchlistRepository.resetListingNotifiedIfTrue(10L)).willReturn(0);
+
+        processor.process(10L, 100L);
+
+        assertThat(watchlist.isListingNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("워치리스트가 삭제됐으면(재조회 결과 없음) 아무것도 하지 않는다")
+    void process_skipsWhenWatchlistNotFound() {
+        given(watchlistRepository.findById(10L)).willReturn(Optional.empty());
+
+        processor.process(10L, 100L);
+
+        then(listingRepository).should(never()).countByCardIdAndVariantIdAndStatus(any(), any(), any());
+        then(watchlistRepository).should(never()).resetListingNotifiedIfTrue(any());
+    }
+
+    @Test
+    @DisplayName("이미 listingNotified가 false면(그 사이 다른 경로로 리셋됨) 아무것도 하지 않는다")
+    void process_skipsWhenAlreadyNotNotified() {
+        Watchlist watchlist = Watchlist.builder().userId(10L).cardId(1L).targetBuyPrice(1000).build();
+        ReflectionTestUtils.setField(watchlist, "id", 10L);
+        given(watchlistRepository.findById(10L)).willReturn(Optional.of(watchlist));
+
+        processor.process(10L, 100L);
+
+        then(listingRepository).should(never()).countByCardIdAndVariantIdAndStatus(any(), any(), any());
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistListingNotifiedResetServiceTest.java
@@ -1,0 +1,115 @@
+package com.pokade.domain.watchlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.watchlist.entity.Watchlist;
+import com.pokade.domain.watchlist.repository.WatchlistRepository;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistListingNotifiedResetServiceTest {
+
+    @Mock
+    private WatchlistRepository watchlistRepository;
+
+    @Mock
+    private CardVariantRepository cardVariantRepository;
+
+    @Mock
+    private WatchlistListingNotifiedResetProcessor processor;
+
+    @InjectMocks
+    private WatchlistListingNotifiedResetService service;
+
+    private Watchlist watchlist(Long id, Long cardId, Long variantId) {
+        Watchlist watchlist = Watchlist.builder()
+                .userId(id).cardId(cardId).variantId(variantId).targetBuyPrice(1000).build();
+        ReflectionTestUtils.setField(watchlist, "id", id);
+        return watchlist;
+    }
+
+    private record PrimaryVariantIdView(Long cardId, Long variantId) implements CardVariantRepository.PrimaryVariantIdView {
+        public Long getCardId() { return cardId; }
+        public Long getVariantId() { return variantId; }
+    }
+
+    @Test
+    @DisplayName("리셋 후보가 없으면 카드/프로세서 조회를 하지 않는다")
+    void resetListingNotifiedIfSoldOut_noCandidatesMeansNoop() {
+        given(watchlistRepository.findByListingNotifiedTrue()).willReturn(List.of());
+
+        service.resetListingNotifiedIfSoldOut();
+
+        then(cardVariantRepository).should(never()).findPrimaryVariantIdsByCardIds(any());
+        then(processor).should(never()).process(any(), any());
+    }
+
+    @Test
+    @DisplayName("variantId가 명시된 워치리스트는 그 값을 그대로 프로세서에 전달한다")
+    void resetListingNotifiedIfSoldOut_passesExplicitVariantIdThrough() {
+        Watchlist explicit = watchlist(10L, 1L, 100L);
+        given(watchlistRepository.findByListingNotifiedTrue()).willReturn(List.of(explicit));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L))).willReturn(List.of());
+
+        service.resetListingNotifiedIfSoldOut();
+
+        then(processor).should().process(10L, 100L);
+    }
+
+    @Test
+    @DisplayName("variantId가 null인 워치리스트는 카드의 대표 variant ID로 치환해서 프로세서에 전달한다")
+    void resetListingNotifiedIfSoldOut_resolvesNullVariantIdToPrimary() {
+        Watchlist watchingPrimary = watchlist(10L, 1L, null);
+        given(watchlistRepository.findByListingNotifiedTrue()).willReturn(List.of(watchingPrimary));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L)))
+                .willReturn(List.of(new PrimaryVariantIdView(1L, 999L)));
+
+        service.resetListingNotifiedIfSoldOut();
+
+        then(processor).should().process(10L, 999L);
+    }
+
+    @Test
+    @DisplayName("대표 variant 정보가 없으면 null을 그대로 프로세서에 전달한다")
+    void resetListingNotifiedIfSoldOut_passesNullWhenNoPrimaryVariantInfo() {
+        Watchlist watchingPrimary = watchlist(10L, 1L, null);
+        given(watchlistRepository.findByListingNotifiedTrue()).willReturn(List.of(watchingPrimary));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L))).willReturn(List.of());
+
+        service.resetListingNotifiedIfSoldOut();
+
+        then(processor).should().process(10L, null);
+    }
+
+    @Test
+    @DisplayName("한 건의 프로세서 처리 중 예외가 발생해도 다른 건은 계속 처리된다")
+    void resetListingNotifiedIfSoldOut_continuesAfterOneItemFails() {
+        Watchlist w1 = watchlist(10L, 1L, null);
+        Watchlist w2 = watchlist(20L, 2L, null);
+        given(watchlistRepository.findByListingNotifiedTrue()).willReturn(List.of(w1, w2));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L, 2L))).willReturn(List.of());
+        org.mockito.Mockito.doThrow(new RuntimeException("boom")).when(processor).process(10L, null);
+
+        service.resetListingNotifiedIfSoldOut();
+
+        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+        then(processor).should(times(2)).process(idCaptor.capture(), any());
+        assertThat(idCaptor.getAllValues()).containsExactly(10L, 20L);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistVariantResolverTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistVariantResolverTest.java
@@ -1,0 +1,27 @@
+package com.pokade.domain.watchlist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class WatchlistVariantResolverTest {
+
+    @Test
+    @DisplayName("variantId가 있으면 그 값을 그대로 반환한다")
+    void resolveOrPrimary_returnsVariantIdWhenPresent() {
+        assertThat(WatchlistVariantResolver.resolveOrPrimary(100L, 999L)).isEqualTo(100L);
+    }
+
+    @Test
+    @DisplayName("variantId가 null이면 대표 variant ID로 치환한다")
+    void resolveOrPrimary_fallsBackToPrimaryWhenVariantIdNull() {
+        assertThat(WatchlistVariantResolver.resolveOrPrimary(null, 999L)).isEqualTo(999L);
+    }
+
+    @Test
+    @DisplayName("variantId와 대표 variant ID가 둘 다 null이면 null을 반환한다(NPE 없음)")
+    void resolveOrPrimary_returnsNullWhenBothNull() {
+        assertThat(WatchlistVariantResolver.resolveOrPrimary(null, null)).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #300 

## ✨ 작업 내용
- 매물 등록 시 `ListingCreatedEvent` 발행 (listing 도메인, 이벤트 발행 한 줄만 추가)
- 관심 있는 카드/판본(variant)에 매물이 없다가 새로 등록되면 워치리스트 등록자에게 재입고 알림 발송
- variant(판본) 단위로 판단 — null(대표 판본 관심)과 명시적 variant 관심 둘 다 정확히 매칭
- 매물이 소진되면 30분 주기 배치로 `listing_notified` 리셋 → 다음 재입고 때 다시 알림 가능
- 카드 이름 오타 허용 검색 — `pg_trgm` 유사도 검색, 정확 검색 0건일 때만 폴백
- 검색 응답에 `fuzzyMatch` 플래그 추가 (FE 안내 문구 연동용)
- null-variant 해석 로직 공용화 (`WatchlistVariantResolver`)

## 📸 스크린샷 / 테스트 결과
- 재입고 알림: variant 2개(대표/일반) 등록 후 한쪽만 관심 등록 → 다른 variant 매물 등록 시 무알림, 관심 등록한 variant는 정상 알림 확인
- 리셋 배치: 매물 등록→취소→리셋 배치 실행→재입고 시 재알림까지 end-to-end 통합 테스트로 확인
- 오타 허용 검색: 실제 API로 `q=리자옹`(오타) → `fuzzyMatch: true` 3건, `q=char`(정확) → `fuzzyMatch: false` 확인
- 전체 브랜치 점검 완료 — listing/trade/admin 도메인 diff 최소화 확인, 죽은 코드 없음, N+1/보안 이슈 없음

## 🔍 리뷰 포인트
- `ListingService.java`, `ListingRepository.java`(listing 도메인)를 이벤트 발행 1줄, 조회 메서드 1개 순수 추가만 했습니다. 
   기존 로직은 무변경
- 리셋은 30분 주기 배치 스캔 방식입니다. 
  매물 소멸 지점이 3개 도메인에 흩어져 있어, 이벤트로 전부 커버하는 대신 "지금 매물이 있는지"를 주기적으로 재확인하는 방식
- 오타 허용 검색(`pg_trgm`)은 정확 검색 0건일 때만 도는 저빈도 경로라 인덱스 없이 순차 스캔으로 처리됩니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?