### PR TITLE
[Feature] #307 구매입찰 오더북 조회 API 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.price.dto.BuyOfferOrderbookEntryResponse;
 import com.pokade.domain.price.dto.CardPricePointResponse;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceRankingResponse;
@@ -40,6 +41,15 @@ public class PriceController {
             @RequestParam(required = false, defaultValue = "false") boolean includeRecentTradePrice
     ) {
         return ApiResponse.ok(priceService.getSummaries(cardIds, grade, includeRecentTradePrice));
+    }
+
+    @GetMapping("/{cardId}/buy-offers")
+    public ApiResponse<List<BuyOfferOrderbookEntryResponse>> getBuyOfferOrderbook(
+            @PathVariable Long cardId,
+            @RequestParam(required = false) Long variantId,
+            @RequestParam(required = false) ListingGrade grade
+    ) {
+        return ApiResponse.ok(priceService.getBuyOfferOrderbook(cardId, variantId, grade));
     }
 
     @GetMapping("/{cardId}/trades")

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/BuyOfferOrderbookEntryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/BuyOfferOrderbookEntryResponse.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.price.dto;
+
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.price.entity.BuyOffer;
+
+public record BuyOfferOrderbookEntryResponse(
+        Long buyOfferId,
+        Integer price,
+        ListingGrade grade
+) {
+
+    public static BuyOfferOrderbookEntryResponse of(BuyOffer buyOffer) {
+        return new BuyOfferOrderbookEntryResponse(buyOffer.getId(), buyOffer.getPrice(), buyOffer.getGrade());
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/entity/BuyOffer.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/entity/BuyOffer.java
@@ -1,10 +1,14 @@
 package com.pokade.domain.price.entity;
 
+import com.pokade.domain.listing.entity.ListingGrade;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,5 +29,21 @@ public class BuyOffer {
 
     private Integer price;
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private ListingGrade grade;
+
     private String status;
+
+    // 아직 구매입찰 등록 API가 없어(테이블은 매수자가 직접 만들지 못하고 시드/향후 배치로만 채워짐)
+    // 오직 테스트 픽스처 구성용으로만 쓰인다 - Listing.builder()와 동일한 성격.
+    @Builder
+    public BuyOffer(Long id, Long cardId, Long variantId, Integer price, ListingGrade grade, String status) {
+        this.id = id;
+        this.cardId = cardId;
+        this.variantId = variantId;
+        this.price = price;
+        this.grade = grade;
+        this.status = status;
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/BuyOfferRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/BuyOfferRepository.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.price.repository;
 
+import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.price.entity.BuyOffer;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +18,16 @@ public interface BuyOfferRepository extends JpaRepository<BuyOffer, Long> {
     @Query("SELECT b.variantId AS variantId, MAX(b.price) AS price FROM BuyOffer b "
             + "WHERE b.variantId IN :variantIds AND b.status = 'ACTIVE' GROUP BY b.variantId")
     List<VariantPriceView> findHighestActivePricesByVariantIds(@Param("variantIds") List<Long> variantIds);
+
+    // 구매입찰 호가창 - domain.listing의 findOrderbook(매도 호가창)과 대응되는 매수 호가창.
+    // 매수 쪽은 높은 값부터 체결 우선순위가 높으므로 가격 내림차순.
+    @Query("SELECT b FROM BuyOffer b "
+            + "WHERE b.cardId = :cardId AND b.variantId = :variantId AND b.status = 'ACTIVE' "
+            + "AND (:grade IS NULL OR b.grade = :grade) "
+            + "ORDER BY b.price DESC")
+    List<BuyOffer> findOrderbook(@Param("cardId") Long cardId,
+                                  @Param("variantId") Long variantId,
+                                  @Param("grade") ListingGrade grade);
 
     interface VariantPriceView {
         Long getVariantId();

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -11,6 +11,7 @@ import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.price.ChartPeriod;
 import com.pokade.domain.price.RankingType;
 import com.pokade.domain.price.StatsPeriod;
+import com.pokade.domain.price.dto.BuyOfferOrderbookEntryResponse;
 import com.pokade.domain.price.dto.CardPricePointResponse;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceRankingResponse;
@@ -154,6 +155,25 @@ public class PriceService {
                             marketPrice != null ? marketPrice.getMarket() : null,
                             marketPrice != null ? marketPrice.getCurrency() : null);
                 })
+                .toList();
+    }
+
+    // 구매입찰 호가창 - domain.listing.getOrderbook()(매도)과 대응되는 매수 호가창 조회.
+    // BuyOffer는 domain.price가 소유한 엔티티라 이 서비스에 둔다.
+    public List<BuyOfferOrderbookEntryResponse> getBuyOfferOrderbook(Long cardId, Long variantId, ListingGrade grade) {
+        if (!cardRepository.existsById(cardId)) {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
+        Long resolvedVariantId = variantId != null
+                ? variantId
+                : cardVariantRepository.findPrimaryVariantId(cardId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.PRIMARY_VARIANT_NOT_FOUND));
+
+        return buyOfferRepository
+                .findOrderbook(cardId, resolvedVariantId, grade)
+                .stream()
+                .map(BuyOfferOrderbookEntryResponse::of)
                 .toList();
     }
 

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -361,6 +361,32 @@ VALUES (
        );
 
 -- =========================================================
+-- 구매입찰 호가창(GET /api/prices/{cardId}/buy-offers) 검증용 추가 시드
+-- Charizard base1-4 : 기존 grade=NULL 2건에 등급별 3건을 추가 — 전체/등급 필터, 가격 내림차순 검증용
+-- =========================================================
+INSERT INTO buy_offers (card_id, buyer_id, variant_id, price, grade, status, expires_at, price_updated_at, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2950000, 'S', 'ACTIVE', now() + interval '30 days', now(), now(), now()
+       );
+INSERT INTO buy_offers (card_id, buyer_id, variant_id, price, grade, status, expires_at, price_updated_at, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3100000, 'S', 'ACTIVE', now() + interval '30 days', now(), now(), now()
+       );
+INSERT INTO buy_offers (card_id, buyer_id, variant_id, price, grade, status, expires_at, price_updated_at, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3900000, 'PSA10', 'ACTIVE', now() + interval '30 days', now(), now(), now()
+       );
+
+-- =========================================================
 -- FR-PRICE-03 검증용 시드 (chart — 30일/90일/1년 구간별 추이 확인용 체결 데이터 확장)
 -- Charizard base1-4 : 기존 3건(1일/3일/10일 전)에 13건을 추가해 총 16건.
 -- 30일 이내 6건, 90일 이내 10건, 1년 이내 16건이 조회되도록 confirmed_at을 스태거링하고,

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -312,6 +312,14 @@ VALUES (
            (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
            3050000, 'S', 'ACTIVE', now(), now()
        );
+-- 같은 (등급, 가격) 조합 중복 1건 추가 — FE 판매입찰 탭의 "수량"(같은 가격에 몇 건 걸려있는지) 집계 검증용.
+INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller2@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           3050000, 'S', 'ACTIVE', now(), now()
+       );
 INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status, created_at, updated_at)
 VALUES (
            (SELECT id FROM cards WHERE external_id = 'base1-4'),
@@ -384,6 +392,15 @@ VALUES (
            (SELECT id FROM users WHERE email = 'seller2@test.com'),
            (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
            3900000, 'PSA10', 'ACTIVE', now() + interval '30 days', now(), now(), now()
+       );
+
+-- 같은 (등급, 가격) 조합 중복 1건 추가 — FE 구매입찰 탭의 "수량"(같은 가격에 몇 건 걸려있는지) 집계 검증용.
+INSERT INTO buy_offers (card_id, buyer_id, variant_id, price, grade, status, expires_at, price_updated_at, created_at, updated_at)
+VALUES (
+           (SELECT id FROM cards WHERE external_id = 'base1-4'),
+           (SELECT id FROM users WHERE email = 'seller1@test.com'),
+           (SELECT id FROM card_variants WHERE card_id = (SELECT id FROM cards WHERE external_id = 'base1-4') AND variant_name = 'unlimitedHolofoil'),
+           2950000, 'S', 'ACTIVE', now() + interval '30 days', now(), now(), now()
        );
 
 -- =========================================================

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.price.controller;
 
 import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.price.dto.BuyOfferOrderbookEntryResponse;
 import com.pokade.domain.price.dto.CardPricePointResponse;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceRankingResponse;
@@ -49,6 +50,41 @@ class PriceControllerTest {
 
     @MockitoBean
     private TokenBlacklistStore tokenBlacklistStore;
+
+    @Test
+    void 구매입찰_호가창_조회시_가격_내림차순_목록을_반환한다() throws Exception {
+        List<BuyOfferOrderbookEntryResponse> entries = List.of(
+                new BuyOfferOrderbookEntryResponse(1L, 3100000, ListingGrade.S),
+                new BuyOfferOrderbookEntryResponse(2L, 2700000, null)
+        );
+        given(priceService.getBuyOfferOrderbook(1L, null, null)).willReturn(entries);
+
+        mockMvc.perform(get("/api/prices/1/buy-offers"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].price").value(3100000))
+                .andExpect(jsonPath("$.data[0].grade").value("S"))
+                .andExpect(jsonPath("$.data[1].grade").value(nullValue()));
+    }
+
+    @Test
+    void 구매입찰_호가창_조회시_grade_variantId를_그대로_서비스에_전달한다() throws Exception {
+        given(priceService.getBuyOfferOrderbook(1L, 10L, ListingGrade.PSA10)).willReturn(List.of());
+
+        mockMvc.perform(get("/api/prices/1/buy-offers").param("variantId", "10").param("grade", "PSA10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    void 구매입찰_호가창_조회시_존재하지_않는_카드면_404를_반환한다() throws Exception {
+        given(priceService.getBuyOfferOrderbook(999L, null, null))
+                .willThrow(new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        mockMvc.perform(get("/api/prices/999/buy-offers"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("CARD_NOT_FOUND"));
+    }
 
     @Test
     void 체결_내역이_있으면_200과_최신순_목록을_반환한다() throws Exception {

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/BuyOfferRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/BuyOfferRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.pokade.domain.price.repository;
+
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.price.entity.BuyOffer;
+import com.pokade.support.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class BuyOfferRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private BuyOfferRepository buyOfferRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    @DisplayName("t1 grade 필터 없이 조회하면 ACTIVE 구매입찰을 가격 내림차순으로 반환한다")
+    void t1() {
+        Long buyerId = insertUser("buyer-a@test.com");
+        Long cardId = insertCard("buy-offer-orderbook-1");
+        Long variantId = insertVariant(cardId, "unlimitedHolofoil");
+
+        insertBuyOffer(cardId, buyerId, variantId, 2700000, null, "ACTIVE");
+        insertBuyOffer(cardId, buyerId, variantId, 3100000, "S", "ACTIVE");
+        insertBuyOffer(cardId, buyerId, variantId, 2900000, "PSA10", "ACTIVE");
+        insertBuyOffer(cardId, buyerId, variantId, 9999000, "S", "EXPIRED");
+
+        List<BuyOffer> result = buyOfferRepository.findOrderbook(cardId, variantId, null);
+
+        assertThat(result).extracting(BuyOffer::getPrice).containsExactly(3100000, 2900000, 2700000);
+    }
+
+    @Test
+    @DisplayName("t2 grade를 지정하면 해당 등급만 가격 내림차순으로 반환한다")
+    void t2() {
+        Long buyerId = insertUser("buyer-b@test.com");
+        Long cardId = insertCard("buy-offer-orderbook-2");
+        Long variantId = insertVariant(cardId, "unlimitedHolofoil");
+
+        insertBuyOffer(cardId, buyerId, variantId, 2700000, "S", "ACTIVE");
+        insertBuyOffer(cardId, buyerId, variantId, 3100000, "S", "ACTIVE");
+        insertBuyOffer(cardId, buyerId, variantId, 5000000, "PSA10", "ACTIVE");
+
+        List<BuyOffer> result = buyOfferRepository.findOrderbook(cardId, variantId, ListingGrade.S);
+
+        assertThat(result).extracting(BuyOffer::getPrice).containsExactly(3100000, 2700000);
+        assertThat(result).allMatch(offer -> offer.getGrade() == ListingGrade.S);
+    }
+
+    @Test
+    @DisplayName("t3 활성 구매입찰이 없으면 빈 목록을 반환한다")
+    void t3() {
+        Long cardId = insertCard("buy-offer-orderbook-3");
+        Long variantId = insertVariant(cardId, "unlimitedHolofoil");
+
+        List<BuyOffer> result = buyOfferRepository.findOrderbook(cardId, variantId, null);
+
+        assertThat(result).isEmpty();
+    }
+
+    private Long insertUser(String email) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status) "
+                                + "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE') RETURNING id")
+                .setParameter("email", email)
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertCard(String externalId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, 'Repo Test Card') RETURNING id")
+                .setParameter("externalId", externalId)
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertVariant(Long cardId, String variantName) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO card_variants (card_id, variant_name, synced_at) "
+                                + "VALUES (:cardId, :variantName, now()) RETURNING id")
+                .setParameter("cardId", cardId)
+                .setParameter("variantName", variantName)
+                .getSingleResult()).longValue();
+    }
+
+    private void insertBuyOffer(Long cardId, Long buyerId, Long variantId, int price, String grade, String status) {
+        entityManager.createNativeQuery(
+                        "INSERT INTO buy_offers (card_id, buyer_id, variant_id, price, grade, status) "
+                                + "VALUES (:cardId, :buyerId, :variantId, :price, :grade, :status)")
+                .setParameter("cardId", cardId)
+                .setParameter("buyerId", buyerId)
+                .setParameter("variantId", variantId)
+                .setParameter("price", price)
+                .setParameter("grade", grade)
+                .setParameter("status", status)
+                .executeUpdate();
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -9,11 +9,13 @@ import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.price.dto.BuyOfferOrderbookEntryResponse;
 import com.pokade.domain.price.dto.CardPricePointResponse;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
+import com.pokade.domain.price.entity.BuyOffer;
 import com.pokade.domain.price.repository.BuyOfferRepository;
 import com.pokade.domain.price.repository.PriceCardStatsRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
@@ -570,6 +572,59 @@ class PriceServiceTest {
 
         assertThat(result.changeRate()).isEqualByComparingTo("1.20");
         assertThat(result.changeAmount()).isNull();
+    }
+
+    @Test
+    @DisplayName("t33 구매입찰 호가창을 조회하면 리포지토리가 반환한 순서 그대로 응답으로 변환한다")
+    void t33() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        BuyOffer highest = BuyOffer.builder().id(1L).cardId(1L).variantId(10L).price(3100000).grade(ListingGrade.S).build();
+        BuyOffer lowest = BuyOffer.builder().id(2L).cardId(1L).variantId(10L).price(2700000).grade(null).build();
+        given(buyOfferRepository.findOrderbook(1L, 10L, null)).willReturn(List.of(highest, lowest));
+
+        List<BuyOfferOrderbookEntryResponse> result = priceService.getBuyOfferOrderbook(1L, 10L, null);
+
+        assertThat(result).containsExactly(
+                new BuyOfferOrderbookEntryResponse(1L, 3100000, ListingGrade.S),
+                new BuyOfferOrderbookEntryResponse(2L, 2700000, null));
+    }
+
+    @Test
+    @DisplayName("t34 존재하지 않는 카드면 CARD_NOT_FOUND 예외가 발생하고 리포지토리를 조회하지 않는다")
+    void t34() {
+        given(cardRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> priceService.getBuyOfferOrderbook(999L, 10L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        verify(buyOfferRepository, never()).findOrderbook(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("t35 variantId를 지정하지 않으면 대표 변형을 조회해 사용한다")
+    void t35() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(java.util.Optional.of(10L));
+        given(buyOfferRepository.findOrderbook(1L, 10L, ListingGrade.PSA10)).willReturn(List.of());
+
+        List<BuyOfferOrderbookEntryResponse> result = priceService.getBuyOfferOrderbook(1L, null, ListingGrade.PSA10);
+
+        assertThat(result).isEmpty();
+        verify(buyOfferRepository).findOrderbook(1L, 10L, ListingGrade.PSA10);
+    }
+
+    @Test
+    @DisplayName("t36 variantId 미지정이고 대표 변형이 없으면 PRIMARY_VARIANT_NOT_FOUND 예외가 발생한다")
+    void t36() {
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> priceService.getBuyOfferOrderbook(1L, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.PRIMARY_VARIANT_NOT_FOUND);
+        verify(buyOfferRepository, never()).findOrderbook(any(), any(), any());
     }
 
     private PriceCardStatsRepository.CardPriceChangeView cardPriceChangeView(BigDecimal changePct, BigDecimal change7dAmount) {


### PR DESCRIPTION
## 📌 관련 이슈
- #307

## ✨ 작업 내용
- `GET /api/prices/{cardId}/buy-offers?variantId=&grade=` 신규 API 추가 — 구매입찰(매수 호가) 오더북 조회
- 기존 판매 매물 오더북(`GET /api/listings/{cardId}/orderbook`)과 대응되는 매수 쪽, 활성(ACTIVE) 구매입찰을 가격 내림차순으로 반환
- `BuyOffer` 엔티티에 `grade` 필드 매핑 추가(테이블엔 이미 있던 컬럼, 지금까지 매핑이 안 돼 있었음)
- `BuyOfferRepository.findOrderbook()` 신규 — `variantId`/`grade` optional 필터
- 로컬 시드(`data.sql`)에 구매입찰 등급별 데이터 + 동일 (등급, 가격) 중복 데이터 추가

## 📸 스크린샷 / 테스트 결과
- 신규/수정 테스트 전부 통과 — `BuyOfferRepositoryTest` 3개(Testcontainers), `PriceServiceTest` +4, `PriceControllerTest` +3
- 로컬 서버 curl로 실제 동작 확인: 가격 내림차순 정렬, `grade` 필터, 미인증 401 응답

## 🔍 리뷰 포인트
- `BuyOffer`는 `domain.price`가 소유한 엔티티라 이번에 `grade` 필드와 테스트용 `@Builder`를 직접 추가
- `findOrderbook`의 `grade IS NULL` 처리가 기존 매도 오더북(`ListingRepository.findOrderbook`)과 동일한 패턴을 따르고 있습니다.
- 구매입찰 "등록" API는 아직 없어서(기존 백로그) 이번 PR은 조회만 다룸

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카드별 구매 오퍼 호가창 조회 API를 추가했습니다.
  * 카드, 선택적 변형 및 등급 기준으로 활성 구매 오퍼를 확인할 수 있습니다.
  * 구매 오퍼를 가격 내림차순으로 표시합니다.
  * 변형을 지정하지 않으면 대표 변형을 자동으로 조회합니다.

* **버그 수정**
  * 존재하지 않는 카드 조회 시 명확한 404 오류를 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->