### PR TITLE
[fix] #310 소셜 로그인 충돌 시 기존 가입 수단을 FE에 전달

### DIFF
--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -61,9 +61,10 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                             refreshTokenCookieFactory.create(loggedIn.refreshToken()).toString());
                     redirect(response, "/oauth2/success");
                 }
-                case OAuth2Outcome.Conflict ignored -> redirect(response, "/login?error=email_conflict");
+                case OAuth2Outcome.Conflict conflict -> redirect(response,
+                        "/login?error=email_conflict&provider=" + conflict.provider().name());
                 case OAuth2Outcome.SignupRequired signup -> redirect(response, "/signup/social#ticket="
-                                + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
+                        + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
             }
         } catch (BusinessException e) {   // resolve의 상태 가드(정지 등) → 에러 페이지
             redirect(response, "/login?error=" + e.getErrorCode().name().toLowerCase());


### PR DESCRIPTION
## 📌 관련 이슈

- #310 

## ✨ 작업 내용

이미 가입된 이메일로 다른 방식의 소셜 로그인을 시도하면 충돌로 판정한다. 이때 **기존 가입 수단을 담아 돌려주는데 성공 핸들러가 그 값을 버리고 있었다.**

```java
// OAuth2Outcome — provider를 담고 있다
record Conflict(Provider provider) implements OAuth2Outcome {}

// OAuth2LoginSuccessHandler — 그런데 쓰지 않았다
case OAuth2Outcome.Conflict ignored -> redirect(response, "/login?error=email_conflict");
```

그래서 FE는 "이미 다른 방법으로 가입된 이메일입니다"까지만 안내할 수 있었고, 사용자는 이메일·Google·카카오 중 무엇을 눌러야 하는지 알 수 없었다.

리다이렉트에 provider를 함께 붙인다.

```
/login?error=email_conflict&provider=GOOGLE
```

## 🔍 리뷰 포인트

### 충돌은 이메일 가입 계정만 해당하지 않는다

판정 조건이 `user.getProvider() != provider`이므로 **구글로 가입한 계정에 카카오로 로그인해도 같은 분기**를 탄다. provider를 넘기지 않으면 "이미 이메일로 가입된 계정입니다" 같은 안내가 절반은 틀리게 된다. 정확한 안내가 원천적으로 불가능해서 값을 전달하도록 고쳤다.

### 계정 열거 관점에서 안전하다

**이 분기는 노출 위험이 없다.** 도달하려면 구글·카카오에서 실제 인증을 마쳐야 하고, 콜백에 도착하는 이메일은 제공자가 본인 것이라고 확인해 준 주소다. 임의 주소를 넣어 볼 수 없으므로 스캔이 성립하지 않는다.

비밀번호 로그인 경로는 성질이 다르다. 인증 없이 아무 주소나 넣을 수 있어 계정 존재와 가입 수단이 함께 새어 나간다. 그래서 그쪽은 노출하지 않고 실패 문구에 일반적인 힌트만 덧붙이는 것으로 정했다.

### `URLEncoder`를 쓰지 않았다

`Provider`는 `LOCAL`·`GOOGLE`·`KAKAO` 세 값뿐인 enum이라 인코딩이 필요한 문자가 없다. 바로 아래 가입 티켓은 서명 JWT라 인코딩이 필수지만 이 값은 해당하지 않는다.

### 라벨을 BE에서 만들지 않는다

`name()`을 그대로 넘기고 화면 문구는 FE가 매핑한다. 표현은 FE가 갖는다는 기존 구분을 유지했다.

## 📸 테스트 결과

로컬에서 실제 OAuth 왕복으로 확인했다. 카카오로 가입된 계정의 `provider`만 다른 값으로 바꿔 두고 같은 카카오 계정으로 로그인했다. 충돌 판정이 상태 검사보다 먼저 일어나므로 이메일 인증이나 새 가입 없이 재현된다.

| 기존 provider | 화면 문구 |
|---|---|
| `GOOGLE` | 이미 Google로 가입된 계정입니다. Google 버튼으로 로그인해 주세요. |
| (이 커밋 이전) | 이미 다른 방법으로 가입된 이메일입니다. 기존 가입 방식으로 로그인해 주세요. |

| 확인 | 결과 |
|---|---|
| `./gradlew compileJava` | 통과 |
| 로그인 | 되지 않음 |
| 토큰 발급 | 없음 — Redis에 해당 유저의 refresh 세션이 생기지 않았다 |
| 계정 생성 | 없음 — 충돌 시 유저를 만들지 않는 설계대로 |

확인 후 DB는 원래 값으로 되돌렸다.

**FE는 이 값이 없어도 동작한다.** 값이 오면 구체적으로, 없으면 일반 문구로 안내하므로 배포 순서를 맞출 필요가 없다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (문서 변경 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * OAuth 로그인 이메일 충돌 시, 충돌한 로그인 제공자 정보가 리다이렉트 URL에 포함됩니다.
  * 회원가입 안내 및 일반적인 로그인 성공 흐름은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->