### PR TITLE
[fix] #318 알림 문구의 "매물"을 "상품"으로 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -137,7 +137,7 @@ public class NotificationService {
         Notification notification = Notification.builder()
                 .userId(watchlist.getUserId())
                 .type(NotificationType.LISTING_AVAILABLE)
-                .message(String.format("%s 카드에 매물이 새로 등록됐어요. 지금 확인해보세요!", cardName))
+                .message(String.format("%s 카드에 상품이 새로 등록됐어요. 지금 확인해보세요!", cardName))
                 .cardId(watchlist.getCardId())
                 .build();
 


### PR DESCRIPTION
## 📌 관련 이슈

- #318

## ✨ 작업 내용

중간 피드백 반영. 화면 용어는 `상품`인데 알림 문구만 `매물`이었다.

```java
// NotificationService.java:140
.message(String.format("%s 카드에 매물이 새로 등록됐어요. 지금 확인해보세요!", cardName))
```

알림 도메인이 생성하는 문구는 3개이며 그중 이 하나만 해당한다.

| 위치 | 문구 | 처리 |
|---|---|---|
| L129 | `%s 카드가 %s 목표가 %,d원에 도달했습니다.` | 해당 없음 |
| L140 | `%s 카드에 매물이 새로 등록됐어요. 지금 확인해보세요!` | `상품`으로 변경 |
| L157 | `'%s' 문의가 처리 완료되었습니다.` | 해당 없음 |

피드백 원문은 `매물` → `상품 등록`이나, 이 문장에서는 "상품 등록이 새로 등록됐어요"가 되므로 `상품`으로 바꿨다.

`상품`으로 통일한 근거는 이용약관 4조가 `"상품"`을 정의어로 사용하기 때문이다("상품이란 판매회원이 서비스에 등록한 거래대상 카드 정보를 말합니다").

컨트롤러 Swagger 설명과 API 응답 메시지의 `매물`은 사용자 화면에 노출되지 않으므로 이번 범위에서 제외했다.

## 🔍 리뷰 포인트

**이미 저장된 알림은 바뀌지 않는다.** `message`가 DB에 문자열로 저장되는 구조라 새로 생성되는 알림부터 적용된다. 아래 검증 결과에서 기존 알림과 신규 알림이 다른 문구로 남아 있는 것을 확인할 수 있다.

## 📸 테스트 결과

로컬에서 실제 알림을 생성해 확인했다. `test1`이 워치리스트에 등록한 카드(판매 중 매물 0건)에 `test2`가 매물을 등록해 `LISTING_AVAILABLE` 알림을 발생시켰다.

```
id | user_id |       type        |                    message
 2 |       3 | LISTING_AVAILABLE | 리자몽 ex 카드에 상품이 새로 등록됐어요. 지금 확인해보세요!
 1 |       3 | LISTING_AVAILABLE | 리자몽 ex 카드에 매물이 새로 등록됐어요. 지금 확인해보세요!
```

`id=2`가 이번 변경 후 생성된 알림이고 `id=1`은 변경 전 알림이다. 알림 화면에서도 정상 표시되는 것을 확인했다.

| 항목 | 결과 |
|---|---|
| `./gradlew compileJava` | 통과 |
| 알림 생성 | 새 문구로 저장됨 |
| 알림 화면 표시 | 정상 |

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (문서 변경 없음)