### PR TITLE
[Feature] #322 포트폴리오 세트 통계 개선 및 도감 조회 버그 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -100,9 +100,7 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-    # 커밋 추가 시마다 재리뷰하면 개발자별 리뷰 한도(rate limit)를 빨리 소진하므로 끕니다.
-    # 재리뷰가 필요하면 PR 코멘트에 "@coderabbitai review"를 직접 입력하세요.
-    auto_incremental_review: false
+    auto_incremental_review: true
     base_branches:
       - "main"
       - "develop"

--- a/Pokade/build.gradle.kts
+++ b/Pokade/build.gradle.kts
@@ -70,4 +70,11 @@ dependencyManagement {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    jvmArgs(
+        "-XX:+EnableDynamicAgentLoading",
+        "-Xshare:off",
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens", "java.base/java.util=ALL-UNNAMED"
+    )
 }

--- a/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.ai.dto;
 
 import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.card.entity.Card;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -23,12 +24,19 @@ public record GradeResponse(
         int pointUsed,
         boolean retryAllowed,    // QUALITY_FAIL 시 무료 재업로드 가능 여부
         String notice,           // 법적 고지 문구
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        // vision_card_id(externalId)로 해석된 카드 — 자체 DB에 없는 카드거나 인식 실패 시 전부 null.
+        // FR-AI-04(도감 등록) 진입 가능 여부를 FE가 판단하는 기준이기도 하다.
+        Long cardId,
+        String cardName,
+        String cardImageSmall,
+        // 카드 인식 신뢰도(%) — 등급 산출 신뢰도(confidence)와는 별개 지표.
+        BigDecimal cardConfidence
 ) {
     private static final String LEGAL_NOTICE =
             "본 결과는 AI 기반 참고용 예비진단이며, 정식 카드 감정을 대체하지 않습니다.";
 
-    public static GradeResponse from(GradeResult result) {
+    public static GradeResponse from(GradeResult result, Card card) {
         return new GradeResponse(
                 result.getId(),
                 result.getStatus().name(),
@@ -42,7 +50,11 @@ public record GradeResponse(
                 result.getPointUsed(),
                 result.isRetryAllowed(),
                 LEGAL_NOTICE,
-                result.getCreatedAt()
+                result.getCreatedAt(),
+                card != null ? card.getId() : null,
+                card != null ? card.getName() : null,
+                card != null ? card.getImageSmall() : null,
+                result.getVisionConfidence()
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
@@ -25,7 +25,8 @@ public record GradeResponse(
         boolean retryAllowed,    // QUALITY_FAIL 시 무료 재업로드 가능 여부
         String notice,           // 법적 고지 문구
         LocalDateTime createdAt,
-        // vision_card_id(externalId)로 해석된 카드 — 자체 DB에 없는 카드거나 인식 실패 시 전부 null.
+        // vision_card_id(externalId)로 해석된 카드 — 자체 DB에 없는 카드거나 인식 실패 시
+        // cardId/cardName/cardImageSmall만 전부 null(cardConfidence는 별도로 채워질 수 있음).
         // FR-AI-04(도감 등록) 진입 가능 여부를 FE가 판단하는 기준이기도 하다.
         Long cardId,
         String cardName,

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -7,6 +7,8 @@ import com.pokade.domain.ai.dto.VisionResult;
 import com.pokade.domain.ai.entity.*;
 import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.infra.storage.S3FileStorage;
@@ -30,8 +32,10 @@ import java.io.UncheckedIOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -53,6 +57,7 @@ public class AiGradeService {
     private final ImageQualityChecker imageQualityChecker;
     private final GradeResultRepository gradeResultRepository;
     private final GradeResultImageRepository gradeResultImageRepository;
+    private final CardRepository cardRepository;
 
     // TODO: User 파트 개발 완료 후 아래 Repository 주입 및 포인트 차감 로직 연동 예정
     // private final UserRepository userRepository;
@@ -121,7 +126,7 @@ public class AiGradeService {
                         .imageUrl(key)
                         .build()));
 
-        return GradeResponse.from(gradeResult);
+        return GradeResponse.from(gradeResult, resolveCard(gradeResult));
     }
 
     public GradeResponse getGradeResult(Long userId, Long resultId) {
@@ -132,13 +137,34 @@ public class AiGradeService {
             throw new BusinessException(ErrorCode.ACCESS_DENIED);
         }
 
-        return GradeResponse.from(gradeResult);
+        return GradeResponse.from(gradeResult, resolveCard(gradeResult));
+    }
+
+    // vision_card_id(externalId)가 자체 DB에 없거나(신규 세트 동기화 지연 등) 아예 인식 실패면 null —
+    // FE는 cardId=null을 "도감 등록 불가"로 취급한다(FR-AI-04).
+    private Card resolveCard(GradeResult gradeResult) {
+        return gradeResult.getVisionCardId() != null
+                ? cardRepository.findByExternalId(gradeResult.getVisionCardId()).orElse(null)
+                : null;
     }
 
     public Page<GradeResponse> getGradeHistory(Long userId, Pageable pageable) {
         PageableValidator.validatePageSize(pageable, MAX_PAGE_SIZE);
-        return gradeResultRepository.findByUserId(userId, pageable)
-                .map(GradeResponse::from);
+        Page<GradeResult> results = gradeResultRepository.findByUserId(userId, pageable);
+
+        // 페이지 안에서 같은 카드가 여러 번 나올 수 있어 externalId 기준으로 배치 조회(N+1 방지).
+        List<String> externalIds = results.getContent().stream()
+                .map(GradeResult::getVisionCardId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<String, Card> cardByExternalId = externalIds.isEmpty()
+                ? Map.of()
+                : cardRepository.findByExternalIdIn(externalIds).stream()
+                        .collect(Collectors.toMap(Card::getExternalId, c -> c));
+
+        return results.map(r -> GradeResponse.from(r,
+                r.getVisionCardId() != null ? cardByExternalId.get(r.getVisionCardId()) : null));
     }
 
     private void validateImageFormats(GradeRequest request) {

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardPriceRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardPriceRepository.java
@@ -16,7 +16,9 @@ public interface CardPriceRepository extends JpaRepository<CardPrice, Long> {
             Long variantId, String priceType, String grade, String company);
 
     // 검색 목록의 "가격 정보 없음" fallback용 - 여러 판본의 비등급(raw) 시세를 한 번에 조회(가격 요약 배치 조회용).
-    @Query("SELECT cp.variant.id AS variantId, cp.market AS market, cp.currency AS currency FROM CardPrice cp "
+    // change1dPct는 포트폴리오 총 평가액의 전일 대비 등락 계산에 쓰인다(getGradeChart와 동일하게 market을 거슬러 올라가는 방식).
+    @Query("SELECT cp.variant.id AS variantId, cp.market AS market, cp.currency AS currency, cp.change1dPct AS change1dPct "
+            + "FROM CardPrice cp "
             + "WHERE cp.variant.id IN :variantIds AND cp.priceType = :priceType AND cp.grade = :grade AND cp.company = :company")
     List<VariantMarketPriceView> findMarketPricesByVariantIds(
             @Param("variantIds") List<Long> variantIds,
@@ -30,5 +32,7 @@ public interface CardPriceRepository extends JpaRepository<CardPrice, Long> {
         BigDecimal getMarket();
 
         String getCurrency();
+
+        BigDecimal getChange1dPct();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -206,6 +206,9 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 
     Optional<Card> findByExternalId(String externalId);
 
+    // AI 등급 진단 이력 응답에서 vision_card_id(externalId)로 카드 정보를 배치 조회할 때 사용(N+1 방지).
+    List<Card> findByExternalIdIn(List<String> externalIds);
+
     /**
      * 필터 옵션(Facet) API용 - 현재 cards에 실제로 존재하는 타입 값(원본 텍스트, 다국어 혼재)별로
      * 그 타입을 가진 카드 수를 조회한다(#263). types는 배열 컬럼이라 unnest로 펼친 뒤 카드 단위로

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -1,0 +1,61 @@
+package com.pokade.domain.portfolio.controller;
+
+import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
+import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.service.PortfolioService;
+import com.pokade.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/portfolio")
+@RequiredArgsConstructor
+public class PortfolioController {
+
+    private final PortfolioService portfolioService;
+
+    @PostMapping
+    public ApiResponse<PortfolioItemResponse> addItem(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PortfolioItemAddRequest request
+    ) {
+        return ApiResponse.ok("포트폴리오에 추가되었습니다.", portfolioService.addItem(userId, request));
+    }
+
+    @GetMapping
+    public ApiResponse<List<PortfolioItemResponse>> getMyPortfolio(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.ok(portfolioService.getMyPortfolio(userId));
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<PortfolioItemResponse> updateItem(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody PortfolioItemUpdateRequest request
+    ) {
+        return ApiResponse.ok("포트폴리오 항목이 수정되었습니다.", portfolioService.updateItem(userId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteItem(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        portfolioService.deleteItem(userId, id);
+        return ApiResponse.ok("포트폴리오에서 삭제되었습니다.");
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.portfolio.controller;
 
+import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
@@ -56,6 +57,13 @@ public class PortfolioController {
             @PathVariable Long id
     ) {
         return ApiResponse.ok(portfolioService.getPnl(userId, id));
+    }
+
+    @GetMapping("/analytics")
+    public ApiResponse<PortfolioAnalyticsResponse> getAnalytics(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.ok(portfolioService.getAnalytics(userId));
     }
 
     @PutMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.portfolio.controller;
 
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
 import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
@@ -47,6 +48,14 @@ public class PortfolioController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.ok(portfolioService.getSummary(userId));
+    }
+
+    @GetMapping("/{id}/pnl")
+    public ApiResponse<PortfolioItemPnlResponse> getPnl(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id
+    ) {
+        return ApiResponse.ok(portfolioService.getPnl(userId, id));
     }
 
     @PutMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -5,6 +5,7 @@ import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.dto.PortfolioSetCompletionResponse;
 import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
 import com.pokade.domain.portfolio.service.PortfolioService;
 import com.pokade.global.response.ApiResponse;
@@ -64,6 +65,14 @@ public class PortfolioController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.ok(portfolioService.getAnalytics(userId));
+    }
+
+    // FR-PORT-07: 세트 완성도 - 보유한 세트별로 전체 카드 중 몇 %를 모았는지.
+    @GetMapping("/set-completion")
+    public ApiResponse<List<PortfolioSetCompletionResponse>> getSetCompletion(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.ok(portfolioService.getSetCompletion(userId));
     }
 
     // FR-AI-04: AI 등급 진단 결과를 바탕으로 도감에 카드 즉시 등록.

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -3,6 +3,7 @@ package com.pokade.domain.portfolio.controller;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
 import com.pokade.domain.portfolio.service.PortfolioService;
 import com.pokade.global.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -39,6 +40,13 @@ public class PortfolioController {
             @AuthenticationPrincipal Long userId
     ) {
         return ApiResponse.ok(portfolioService.getMyPortfolio(userId));
+    }
+
+    @GetMapping("/summary")
+    public ApiResponse<PortfolioSummaryResponse> getSummary(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ApiResponse.ok(portfolioService.getSummary(userId));
     }
 
     @PutMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -66,6 +66,15 @@ public class PortfolioController {
         return ApiResponse.ok(portfolioService.getAnalytics(userId));
     }
 
+    // FR-AI-04: AI 등급 진단 결과를 바탕으로 도감에 카드 즉시 등록.
+    @PostMapping("/from-grade/{resultId}")
+    public ApiResponse<PortfolioItemResponse> addFromGradeResult(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long resultId
+    ) {
+        return ApiResponse.ok("도감에 등록되었습니다.", portfolioService.addFromGradeResult(userId, resultId));
+    }
+
     @PutMapping("/{id}")
     public ApiResponse<PortfolioItemResponse> updateItem(
             @AuthenticationPrincipal Long userId,

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioAnalyticsItemResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioAnalyticsItemResponse.java
@@ -1,0 +1,10 @@
+package com.pokade.domain.portfolio.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioAnalyticsItemResponse(
+        String label,
+        BigDecimal value,
+        BigDecimal ratio
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioAnalyticsResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioAnalyticsResponse.java
@@ -1,0 +1,9 @@
+package com.pokade.domain.portfolio.dto;
+
+import java.util.List;
+
+public record PortfolioAnalyticsResponse(
+        List<PortfolioAnalyticsItemResponse> bySet,
+        List<PortfolioAnalyticsItemResponse> byRarity
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemAddRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemAddRequest.java
@@ -1,0 +1,23 @@
+package com.pokade.domain.portfolio.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record PortfolioItemAddRequest(
+        @NotNull(message = "cardId는 필수입니다.")
+        Long cardId,
+
+        Long variantId,
+
+        @NotNull(message = "수량은 필수입니다.")
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+        Integer quantity,
+
+        @Min(value = 0, message = "취득가는 0 이상이어야 합니다.")
+        Integer acquiredPrice,
+
+        LocalDateTime acquiredAt
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemPnlResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemPnlResponse.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.portfolio.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioItemPnlResponse(
+        Long id,
+        Long cardId,
+        Integer quantity,
+        Integer acquiredPrice,
+        BigDecimal currentMarketPrice,
+        String currency,
+        BigDecimal pnlAmount,
+        BigDecimal pnlRate
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
@@ -1,0 +1,48 @@
+package com.pokade.domain.portfolio.dto;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.repository.CardPriceRepository;
+import com.pokade.domain.portfolio.entity.PortfolioItem;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PortfolioItemResponse(
+        Long id,
+        Long cardId,
+        String cardName,
+        String cardImageSmall,
+        Long variantId,
+        String variantName,
+        Integer quantity,
+        Integer acquiredPrice,
+        LocalDateTime acquiredAt,
+        Long tradeId,
+        // 대표 변형(raw NM) 기준 Scrydex 시세. 데이터 없으면 null
+        BigDecimal currentMarketPrice,
+        String currency
+) {
+
+    public static PortfolioItemResponse of(
+            PortfolioItem item,
+            Card card,
+            CardVariant variant,
+            CardPriceRepository.VariantMarketPriceView priceView
+    ) {
+        return new PortfolioItemResponse(
+                item.getId(),
+                item.getCardId(),
+                card != null ? card.getName() : null,
+                card != null ? card.getImageSmall() : null,
+                item.getVariantId(),
+                variant != null ? variant.getVariantName() : null,
+                item.getQuantity(),
+                item.getAcquiredPrice(),
+                item.getAcquiredAt(),
+                item.getTradeId(),
+                priceView != null ? priceView.getMarket() : null,
+                priceView != null ? priceView.getCurrency() : null
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.pokade.domain.portfolio.dto;
+
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+
+public record PortfolioItemUpdateRequest(
+        @Min(value = 1, message = "수량은 1 이상이어야 합니다.")
+        Integer quantity,
+
+        @Min(value = 0, message = "취득가는 0 이상이어야 합니다.")
+        Integer acquiredPrice,
+
+        LocalDateTime acquiredAt
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioSetCompletionResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioSetCompletionResponse.java
@@ -1,0 +1,15 @@
+package com.pokade.domain.portfolio.dto;
+
+import java.math.BigDecimal;
+
+// GET /api/portfolio/set-completion 응답 항목 - 세트 하나에 대한 수집 완성도.
+// ownedCount는 해당 세트에서 보유 중인 "서로 다른 카드" 개수(수량은 무시), totalCount는
+// 그 세트의 공식 전체 카드 수(Expansion.total)다.
+public record PortfolioSetCompletionResponse(
+        String expansionId,
+        String setName,
+        int ownedCount,
+        int totalCount,
+        BigDecimal completionRate
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioSummaryResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioSummaryResponse.java
@@ -1,0 +1,11 @@
+package com.pokade.domain.portfolio.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioSummaryResponse(
+        BigDecimal totalValue,
+        BigDecimal changeAmount,
+        BigDecimal changeRate,
+        String currency
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
@@ -46,9 +46,14 @@ public class PortfolioItem {
     @Column(name = "trade_id", unique = true)
     private Long tradeId;
 
+    // AI 등급 진단 결과로부터 등록된 경우 연결 (UNIQUE 제약) — 동일 진단 결과의 중복 등록 방지용.
+    @Column(name = "grade_result_id", unique = true)
+    private Long gradeResultId;
+
     @Builder
     public PortfolioItem(Long userId, Long cardId, Long variantId, Integer quantity,
-                         Integer acquiredPrice, LocalDateTime acquiredAt, Long tradeId) {
+                         Integer acquiredPrice, LocalDateTime acquiredAt, Long tradeId,
+                         Long gradeResultId) {
         this.userId = userId;
         this.cardId = cardId;
         this.variantId = variantId;
@@ -56,6 +61,7 @@ public class PortfolioItem {
         this.acquiredPrice = acquiredPrice;
         this.acquiredAt = acquiredAt;
         this.tradeId = tradeId;
+        this.gradeResultId = gradeResultId;
     }
 
     public void update(Integer quantity, Integer acquiredPrice, LocalDateTime acquiredAt) {

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
@@ -1,0 +1,72 @@
+package com.pokade.domain.portfolio.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "portfolio_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PortfolioItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "card_id", nullable = false)
+    private Long cardId;
+
+    // NULL이면 대표 변형 기준으로 시세 계산
+    @Column(name = "variant_id")
+    private Long variantId;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @Column(name = "acquired_price")
+    private Integer acquiredPrice;
+
+    @Column(name = "acquired_at")
+    private LocalDateTime acquiredAt;
+
+    // 거래를 통해 취득한 경우 연결 (UNIQUE 제약)
+    @Column(name = "trade_id", unique = true)
+    private Long tradeId;
+
+    @Builder
+    public PortfolioItem(Long userId, Long cardId, Long variantId, Integer quantity,
+                         Integer acquiredPrice, LocalDateTime acquiredAt, Long tradeId) {
+        this.userId = userId;
+        this.cardId = cardId;
+        this.variantId = variantId;
+        this.quantity = quantity != null ? quantity : 1;
+        this.acquiredPrice = acquiredPrice;
+        this.acquiredAt = acquiredAt;
+        this.tradeId = tradeId;
+    }
+
+    public void update(Integer quantity, Integer acquiredPrice, LocalDateTime acquiredAt) {
+        if (quantity != null) {
+            this.quantity = quantity;
+        }
+        if (acquiredPrice != null) {
+            this.acquiredPrice = acquiredPrice;
+        }
+        if (acquiredAt != null) {
+            this.acquiredAt = acquiredAt;
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/repository/PortfolioItemRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/repository/PortfolioItemRepository.java
@@ -1,0 +1,16 @@
+package com.pokade.domain.portfolio.repository;
+
+import com.pokade.domain.portfolio.entity.PortfolioItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PortfolioItemRepository extends JpaRepository<PortfolioItem, Long> {
+
+    List<PortfolioItem> findByUserIdOrderByIdDesc(Long userId);
+
+    Optional<PortfolioItem> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByTradeId(Long tradeId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/repository/PortfolioItemRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/repository/PortfolioItemRepository.java
@@ -13,4 +13,6 @@ public interface PortfolioItemRepository extends JpaRepository<PortfolioItem, Lo
     Optional<PortfolioItem> findByIdAndUserId(Long id, Long userId);
 
     boolean existsByTradeId(Long tradeId);
+
+    boolean existsByGradeResultId(Long gradeResultId);
 }

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -5,6 +5,8 @@ import com.pokade.domain.card.entity.CardVariant;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.portfolio.dto.PortfolioAnalyticsItemResponse;
+import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
@@ -23,7 +25,9 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +41,7 @@ public class PortfolioService {
     private static final String RAW_PRICE_TYPE = "raw";
     private static final String EMPTY_GRADE = "";
     private static final String EMPTY_COMPANY = "";
+    private static final String UNCLASSIFIED = "미분류";
 
     private final PortfolioItemRepository portfolioItemRepository;
     private final CardRepository cardRepository;
@@ -190,6 +195,75 @@ public class PortfolioService {
         return new PortfolioItemPnlResponse(
                 item.getId(), item.getCardId(), item.getQuantity(), item.getAcquiredPrice(),
                 price.getMarket(), price.getCurrency(), pnlAmount, pnlRate);
+    }
+
+    // FR-PORT-06: 평가액(FR-PORT-02와 동일한 raw NM 시세) 기준으로 세트별·레어도별 구성 비율을 계산한다.
+    // 시세 없는 항목은 평가액에 못 넣으므로 getSummary()와 동일하게 계산에서 제외한다.
+    public PortfolioAnalyticsResponse getAnalytics(Long userId) {
+        List<PortfolioItem> items = portfolioItemRepository.findByUserIdOrderByIdDesc(userId);
+        if (items.isEmpty()) {
+            return new PortfolioAnalyticsResponse(List.of(), List.of());
+        }
+
+        Map<Long, Long> variantIdByItemId = resolveVariantIdsByItemId(items);
+        Set<Long> variantIds = Set.copyOf(variantIdByItemId.values());
+
+        Map<Long, CardPriceRepository.VariantMarketPriceView> priceMap = variantIds.isEmpty()
+                ? Map.of()
+                : cardPriceRepository.findMarketPricesByVariantIds(
+                        new ArrayList<>(variantIds), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                CardPriceRepository.VariantMarketPriceView::getVariantId, v -> v));
+
+        // 시세 있는 항목만 남긴다 - 없는 카드는 cardRepository 조회 대상에서도 제외한다(불필요한 배치 조회 방지).
+        Map<PortfolioItem, BigDecimal> valueByPricedItem = new LinkedHashMap<>();
+        BigDecimal totalValue = BigDecimal.ZERO;
+        for (PortfolioItem item : items) {
+            Long variantId = variantIdByItemId.get(item.getId());
+            CardPriceRepository.VariantMarketPriceView price = variantId != null ? priceMap.get(variantId) : null;
+            if (price == null || price.getMarket() == null) {
+                continue;
+            }
+            BigDecimal value = price.getMarket().multiply(BigDecimal.valueOf(item.getQuantity()));
+            valueByPricedItem.put(item, value);
+            totalValue = totalValue.add(value);
+        }
+
+        if (valueByPricedItem.isEmpty()) {
+            return new PortfolioAnalyticsResponse(List.of(), List.of());
+        }
+
+        Set<Long> cardIds = valueByPricedItem.keySet().stream().map(PortfolioItem::getCardId).collect(Collectors.toSet());
+        Map<Long, Card> cardMap = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, c -> c));
+
+        Map<String, BigDecimal> valueBySet = new LinkedHashMap<>();
+        Map<String, BigDecimal> valueByRarity = new LinkedHashMap<>();
+        for (Map.Entry<PortfolioItem, BigDecimal> entry : valueByPricedItem.entrySet()) {
+            Card card = cardMap.get(entry.getKey().getCardId());
+            String setKey = card != null && card.getSetName() != null ? card.getSetName() : UNCLASSIFIED;
+            String rarityKey = card != null && card.getRarity() != null ? card.getRarity() : UNCLASSIFIED;
+
+            valueBySet.merge(setKey, entry.getValue(), BigDecimal::add);
+            valueByRarity.merge(rarityKey, entry.getValue(), BigDecimal::add);
+        }
+
+        return new PortfolioAnalyticsResponse(
+                toAnalyticsItems(valueBySet, totalValue),
+                toAnalyticsItems(valueByRarity, totalValue));
+    }
+
+    private List<PortfolioAnalyticsItemResponse> toAnalyticsItems(Map<String, BigDecimal> valueByLabel, BigDecimal totalValue) {
+        return valueByLabel.entrySet().stream()
+                .map(entry -> new PortfolioAnalyticsItemResponse(
+                        entry.getKey(),
+                        entry.getValue().setScale(0, RoundingMode.HALF_UP),
+                        entry.getValue().divide(totalValue, 4, RoundingMode.HALF_UP)
+                                .multiply(BigDecimal.valueOf(100))
+                                .setScale(2, RoundingMode.HALF_UP)))
+                .sorted(Comparator.comparing(PortfolioAnalyticsItemResponse::value).reversed())
+                .toList();
     }
 
     // variantId가 명시된 항목은 그대로, null인 항목은 카드의 대표 변형으로 일괄 해석한다(enrich()의 변형 해석 로직과 동일한 규칙).

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -1,0 +1,203 @@
+package com.pokade.domain.portfolio.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.repository.CardPriceRepository;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
+import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.entity.PortfolioItem;
+import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PortfolioService {
+
+    private static final String RAW_PRICE_TYPE = "raw";
+    private static final String EMPTY_GRADE = "";
+    private static final String EMPTY_COMPANY = "";
+
+    private final PortfolioItemRepository portfolioItemRepository;
+    private final CardRepository cardRepository;
+    private final CardVariantRepository cardVariantRepository;
+    private final CardPriceRepository cardPriceRepository;
+    private final UserAccessChecker userAccessChecker;
+
+    @Transactional
+    public PortfolioItemResponse addItem(Long userId, PortfolioItemAddRequest request) {
+        userAccessChecker.assertWritable(userId);
+
+        Card card = cardRepository.findById(request.cardId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+
+        if (request.variantId() != null) {
+            cardVariantRepository.findById(request.variantId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+        }
+
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(userId)
+                .cardId(request.cardId())
+                .variantId(request.variantId())
+                .quantity(request.quantity())
+                .acquiredPrice(request.acquiredPrice())
+                .acquiredAt(request.acquiredAt())
+                .build();
+
+        portfolioItemRepository.save(item);
+        return enrichSingle(item, card);
+    }
+
+    public List<PortfolioItemResponse> getMyPortfolio(Long userId) {
+        List<PortfolioItem> items = portfolioItemRepository.findByUserIdOrderByIdDesc(userId);
+        if (items.isEmpty()) {
+            return List.of();
+        }
+        return enrich(items);
+    }
+
+    @Transactional
+    public PortfolioItemResponse updateItem(Long userId, Long itemId, PortfolioItemUpdateRequest request) {
+        userAccessChecker.assertWritable(userId);
+
+        PortfolioItem item = portfolioItemRepository.findByIdAndUserId(itemId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
+
+        item.update(request.quantity(), request.acquiredPrice(), request.acquiredAt());
+
+        Card card = cardRepository.findById(item.getCardId()).orElse(null);
+        return enrichSingle(item, card);
+    }
+
+    @Transactional
+    public void deleteItem(Long userId, Long itemId) {
+        PortfolioItem item = portfolioItemRepository.findByIdAndUserId(itemId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
+
+        portfolioItemRepository.delete(item);
+    }
+
+    /**
+     * 거래 완료(구매 확정) 시 포트폴리오에 자동으로 카드를 추가한다.
+     * TradeService.confirmTrade()에서 호출된다.
+     * 동일 trade_id로 이미 등록된 경우 멱등성 보장을 위해 무시한다.
+     */
+    @Transactional
+    public void addFromCompletedTrade(Long buyerId, Long tradeId, Long cardId, Long variantId, Integer price) {
+        if (portfolioItemRepository.existsByTradeId(tradeId)) {
+            return;
+        }
+
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(buyerId)
+                .cardId(cardId)
+                .variantId(variantId)
+                .quantity(1)
+                .acquiredPrice(price)
+                .acquiredAt(LocalDateTime.now())
+                .tradeId(tradeId)
+                .build();
+
+        portfolioItemRepository.save(item);
+    }
+
+    // ─── 내부 enrichment 헬퍼 ────────────────────────────────────────────────
+
+    private List<PortfolioItemResponse> enrich(List<PortfolioItem> items) {
+        // 1. 카드 일괄 조회
+        Set<Long> cardIds = items.stream().map(PortfolioItem::getCardId).collect(Collectors.toSet());
+        Map<Long, Card> cardMap = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, c -> c));
+
+        // 2. variantId 결정: 명시된 variant → 그대로 / null → 대표 변형으로 조회
+        Set<Long> explicitVariantIds = items.stream()
+                .filter(i -> i.getVariantId() != null)
+                .map(PortfolioItem::getVariantId)
+                .collect(Collectors.toSet());
+
+        Set<Long> nullVariantCardIds = items.stream()
+                .filter(i -> i.getVariantId() == null)
+                .map(PortfolioItem::getCardId)
+                .collect(Collectors.toSet());
+
+        // null variantId 아이템을 위한 cardId→primaryVariantId 매핑
+        Map<Long, Long> primaryVariantByCard = nullVariantCardIds.isEmpty()
+                ? Map.of()
+                : cardVariantRepository.findPrimaryVariantIdsByCardIds(new ArrayList<>(nullVariantCardIds))
+                        .stream()
+                        .collect(Collectors.toMap(
+                                CardVariantRepository.PrimaryVariantIdView::getCardId,
+                                CardVariantRepository.PrimaryVariantIdView::getVariantId));
+
+        // 시세 조회에 쓸 최종 variantId 집합
+        Set<Long> priceQueryVariantIds = new java.util.HashSet<>(explicitVariantIds);
+        priceQueryVariantIds.addAll(primaryVariantByCard.values());
+
+        // 3. variant 일괄 조회
+        Map<Long, CardVariant> variantMap = priceQueryVariantIds.isEmpty()
+                ? Map.of()
+                : cardVariantRepository.findAllById(priceQueryVariantIds).stream()
+                        .collect(Collectors.toMap(CardVariant::getId, v -> v));
+
+        // 4. 시세 일괄 조회 (raw NM 기준)
+        Map<Long, CardPriceRepository.VariantMarketPriceView> priceMap = priceQueryVariantIds.isEmpty()
+                ? Map.of()
+                : cardPriceRepository.findMarketPricesByVariantIds(
+                        new ArrayList<>(priceQueryVariantIds), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                CardPriceRepository.VariantMarketPriceView::getVariantId,
+                                v -> v));
+
+        // 5. 조립
+        return items.stream().map(item -> {
+            Card card = cardMap.get(item.getCardId());
+
+            Long resolvedVariantId = item.getVariantId() != null
+                    ? item.getVariantId()
+                    : primaryVariantByCard.get(item.getCardId());
+
+            CardVariant variant = resolvedVariantId != null ? variantMap.get(resolvedVariantId) : null;
+            CardPriceRepository.VariantMarketPriceView price = resolvedVariantId != null
+                    ? priceMap.get(resolvedVariantId)
+                    : null;
+
+            return PortfolioItemResponse.of(item, card, variant, price);
+        }).toList();
+    }
+
+    private PortfolioItemResponse enrichSingle(PortfolioItem item, Card card) {
+        Long resolvedVariantId = item.getVariantId() != null
+                ? item.getVariantId()
+                : cardVariantRepository.findPrimaryVariantId(item.getCardId()).orElse(null);
+
+        CardVariant variant = resolvedVariantId != null
+                ? cardVariantRepository.findById(resolvedVariantId).orElse(null)
+                : null;
+
+        CardPriceRepository.VariantMarketPriceView price = null;
+        if (resolvedVariantId != null) {
+            List<CardPriceRepository.VariantMarketPriceView> prices = cardPriceRepository
+                    .findMarketPricesByVariantIds(List.of(resolvedVariantId), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY);
+            price = prices.isEmpty() ? null : prices.get(0);
+        }
+
+        return PortfolioItemResponse.of(item, card, variant, price);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -6,6 +6,7 @@ import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
 import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
@@ -151,6 +152,44 @@ public class PortfolioService {
                         .setScale(2, RoundingMode.HALF_UP);
 
         return new PortfolioSummaryResponse(totalValue.setScale(0, RoundingMode.HALF_UP), changeAmount, changeRate, currency);
+    }
+
+    // FR-PORT-05: 취득가(플랫폼 거래로 취득 시 체결가가 그대로 저장됨) 대비 현재 시세로 손익을 계산한다.
+    public PortfolioItemPnlResponse getPnl(Long userId, Long itemId) {
+        PortfolioItem item = portfolioItemRepository.findByIdAndUserId(itemId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
+
+        if (item.getAcquiredPrice() == null) {
+            throw new BusinessException(ErrorCode.PORTFOLIO_ACQUIRED_PRICE_REQUIRED);
+        }
+
+        Long resolvedVariantId = item.getVariantId() != null
+                ? item.getVariantId()
+                : cardVariantRepository.findPrimaryVariantId(item.getCardId()).orElse(null);
+
+        CardPriceRepository.VariantMarketPriceView price = resolvedVariantId != null
+                ? cardPriceRepository.findMarketPricesByVariantIds(
+                        List.of(resolvedVariantId), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY)
+                        .stream().findFirst().orElse(null)
+                : null;
+
+        if (price == null || price.getMarket() == null) {
+            throw new BusinessException(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
+        }
+
+        BigDecimal quantity = BigDecimal.valueOf(item.getQuantity());
+        BigDecimal acquiredTotal = BigDecimal.valueOf(item.getAcquiredPrice()).multiply(quantity);
+        BigDecimal currentTotal = price.getMarket().multiply(quantity);
+        BigDecimal pnlAmount = currentTotal.subtract(acquiredTotal).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal pnlRate = acquiredTotal.signum() == 0
+                ? BigDecimal.ZERO
+                : pnlAmount.divide(acquiredTotal, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+
+        return new PortfolioItemPnlResponse(
+                item.getId(), item.getCardId(), item.getQuantity(), item.getAcquiredPrice(),
+                price.getMarket(), price.getCurrency(), pnlAmount, pnlRate);
     }
 
     // variantId가 명시된 항목은 그대로, null인 항목은 카드의 대표 변형으로 일괄 해석한다(enrich()의 변형 해석 로직과 동일한 규칙).

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -8,6 +8,7 @@ import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
 import com.pokade.domain.portfolio.entity.PortfolioItem;
 import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
 import com.pokade.global.exception.BusinessException;
@@ -17,8 +18,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -91,6 +95,87 @@ public class PortfolioService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
 
         portfolioItemRepository.delete(item);
+    }
+
+    // FR-PORT-02: 시세 없는 항목은 평가액 계산에서 제외한다(현재가를 모르면 전일가도 추정할 수 없음).
+    // 전일가는 getGradeChart와 동일한 방식으로 change_1d_pct를 거슬러 올라가 추정한다(체결 이력 기반이 아닌 근사치).
+    public PortfolioSummaryResponse getSummary(Long userId) {
+        List<PortfolioItem> items = portfolioItemRepository.findByUserIdOrderByIdDesc(userId);
+        if (items.isEmpty()) {
+            return new PortfolioSummaryResponse(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, null);
+        }
+
+        Map<Long, Long> variantIdByItemId = resolveVariantIdsByItemId(items);
+        Set<Long> variantIds = Set.copyOf(variantIdByItemId.values());
+
+        Map<Long, CardPriceRepository.VariantMarketPriceView> priceMap = variantIds.isEmpty()
+                ? Map.of()
+                : cardPriceRepository.findMarketPricesByVariantIds(
+                        new ArrayList<>(variantIds), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                CardPriceRepository.VariantMarketPriceView::getVariantId, v -> v));
+
+        BigDecimal totalValue = BigDecimal.ZERO;
+        BigDecimal previousValue = BigDecimal.ZERO;
+        String currency = null;
+
+        for (PortfolioItem item : items) {
+            Long variantId = variantIdByItemId.get(item.getId());
+            CardPriceRepository.VariantMarketPriceView price = variantId != null ? priceMap.get(variantId) : null;
+            if (price == null || price.getMarket() == null) {
+                continue;
+            }
+
+            BigDecimal quantity = BigDecimal.valueOf(item.getQuantity());
+            totalValue = totalValue.add(price.getMarket().multiply(quantity));
+            if (currency == null) {
+                currency = price.getCurrency();
+            }
+
+            BigDecimal change1dPct = price.getChange1dPct();
+            BigDecimal divisor = change1dPct == null
+                    ? BigDecimal.ONE
+                    : BigDecimal.ONE.add(change1dPct.divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP));
+            BigDecimal previousUnitPrice = divisor.signum() == 0
+                    ? price.getMarket()
+                    : price.getMarket().divide(divisor, 2, RoundingMode.HALF_UP);
+            previousValue = previousValue.add(previousUnitPrice.multiply(quantity));
+        }
+
+        BigDecimal changeAmount = totalValue.subtract(previousValue).setScale(0, RoundingMode.HALF_UP);
+        BigDecimal changeRate = previousValue.signum() == 0
+                ? BigDecimal.ZERO
+                : changeAmount.divide(previousValue, 4, RoundingMode.HALF_UP)
+                        .multiply(BigDecimal.valueOf(100))
+                        .setScale(2, RoundingMode.HALF_UP);
+
+        return new PortfolioSummaryResponse(totalValue.setScale(0, RoundingMode.HALF_UP), changeAmount, changeRate, currency);
+    }
+
+    // variantId가 명시된 항목은 그대로, null인 항목은 카드의 대표 변형으로 일괄 해석한다(enrich()의 변형 해석 로직과 동일한 규칙).
+    private Map<Long, Long> resolveVariantIdsByItemId(List<PortfolioItem> items) {
+        Set<Long> nullVariantCardIds = items.stream()
+                .filter(i -> i.getVariantId() == null)
+                .map(PortfolioItem::getCardId)
+                .collect(Collectors.toSet());
+
+        Map<Long, Long> primaryVariantByCard = nullVariantCardIds.isEmpty()
+                ? Map.of()
+                : cardVariantRepository.findPrimaryVariantIdsByCardIds(new ArrayList<>(nullVariantCardIds))
+                        .stream()
+                        .collect(Collectors.toMap(
+                                CardVariantRepository.PrimaryVariantIdView::getCardId,
+                                CardVariantRepository.PrimaryVariantIdView::getVariantId));
+
+        Map<Long, Long> resolved = new HashMap<>();
+        for (PortfolioItem item : items) {
+            Long variantId = item.getVariantId() != null ? item.getVariantId() : primaryVariantByCard.get(item.getCardId());
+            if (variantId != null) {
+                resolved.put(item.getId(), variantId);
+            }
+        }
+        return resolved;
     }
 
     /**

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -106,6 +106,8 @@ public class PortfolioService {
 
     @Transactional
     public void deleteItem(Long userId, Long itemId) {
+        userAccessChecker.assertWritable(userId);
+
         PortfolioItem item = portfolioItemRepository.findByIdAndUserId(itemId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
 
@@ -293,9 +295,11 @@ public class PortfolioService {
                     int ownedCount = entry.getValue().size();
                     Integer total = expansion != null ? expansion.getTotal() : null;
                     int totalCount = total != null ? total : dbCountByExpansion.getOrDefault(expansionId, 0L).intValue();
+                    // Expansion.total은 외부 동기화 값이라 실제 적재된 카드 수보다 작게 들어올 수 있다 -
+                    // 그 경우에도 완성도가 100%를 넘지 않도록 ownedCount를 totalCount로 clamp한다.
                     BigDecimal completionRate = totalCount <= 0
                             ? BigDecimal.ZERO
-                            : BigDecimal.valueOf(ownedCount)
+                            : BigDecimal.valueOf(Math.min(ownedCount, totalCount))
                                     .divide(BigDecimal.valueOf(totalCount), 4, RoundingMode.HALF_UP)
                                     .multiply(BigDecimal.valueOf(100))
                                     .setScale(2, RoundingMode.HALF_UP);

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -5,15 +5,18 @@ import com.pokade.domain.ai.entity.GradeStatus;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
+import com.pokade.domain.card.entity.Expansion;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.repository.ExpansionRepository;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.dto.PortfolioSetCompletionResponse;
 import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
 import com.pokade.domain.portfolio.entity.PortfolioItem;
 import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
@@ -30,6 +33,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +54,7 @@ public class PortfolioService {
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final CardPriceRepository cardPriceRepository;
+    private final ExpansionRepository expansionRepository;
     private final GradeResultRepository gradeResultRepository;
     private final UserAccessChecker userAccessChecker;
 
@@ -201,72 +206,108 @@ public class PortfolioService {
                 price.getMarket(), price.getCurrency(), pnlAmount, pnlRate);
     }
 
-    // FR-PORT-06: 평가액(FR-PORT-02와 동일한 raw NM 시세) 기준으로 세트별·레어도별 구성 비율을 계산한다.
-    // 시세 없는 항목은 평가액에 못 넣으므로 getSummary()와 동일하게 계산에서 제외한다.
+    // FR-PORT-06: 세트별·레어도별 구성 비율을 계산한다. 시세 유무와 무관하게 항상 계산 가능하도록
+    // 평가액이 아닌 보유 수량(quantity) 기준으로 집계한다 - 시세가 없는 카드도 세트/레어도는
+    // 이미 알고 있으므로, 시세 없는 항목만 있을 때 결과가 통째로 비어버리는 걸 막는다.
     public PortfolioAnalyticsResponse getAnalytics(Long userId) {
         List<PortfolioItem> items = portfolioItemRepository.findByUserIdOrderByIdDesc(userId);
         if (items.isEmpty()) {
             return new PortfolioAnalyticsResponse(List.of(), List.of());
         }
 
-        Map<Long, Long> variantIdByItemId = resolveVariantIdsByItemId(items);
-        Set<Long> variantIds = Set.copyOf(variantIdByItemId.values());
-
-        Map<Long, CardPriceRepository.VariantMarketPriceView> priceMap = variantIds.isEmpty()
-                ? Map.of()
-                : cardPriceRepository.findMarketPricesByVariantIds(
-                        new ArrayList<>(variantIds), RAW_PRICE_TYPE, EMPTY_GRADE, EMPTY_COMPANY)
-                        .stream()
-                        .collect(Collectors.toMap(
-                                CardPriceRepository.VariantMarketPriceView::getVariantId, v -> v));
-
-        // 시세 있는 항목만 남긴다 - 없는 카드는 cardRepository 조회 대상에서도 제외한다(불필요한 배치 조회 방지).
-        Map<PortfolioItem, BigDecimal> valueByPricedItem = new LinkedHashMap<>();
-        BigDecimal totalValue = BigDecimal.ZERO;
-        for (PortfolioItem item : items) {
-            Long variantId = variantIdByItemId.get(item.getId());
-            CardPriceRepository.VariantMarketPriceView price = variantId != null ? priceMap.get(variantId) : null;
-            if (price == null || price.getMarket() == null) {
-                continue;
-            }
-            BigDecimal value = price.getMarket().multiply(BigDecimal.valueOf(item.getQuantity()));
-            valueByPricedItem.put(item, value);
-            totalValue = totalValue.add(value);
-        }
-
-        if (valueByPricedItem.isEmpty()) {
-            return new PortfolioAnalyticsResponse(List.of(), List.of());
-        }
-
-        Set<Long> cardIds = valueByPricedItem.keySet().stream().map(PortfolioItem::getCardId).collect(Collectors.toSet());
+        Set<Long> cardIds = items.stream().map(PortfolioItem::getCardId).collect(Collectors.toSet());
         Map<Long, Card> cardMap = cardRepository.findAllById(cardIds).stream()
                 .collect(Collectors.toMap(Card::getId, c -> c));
 
-        Map<String, BigDecimal> valueBySet = new LinkedHashMap<>();
-        Map<String, BigDecimal> valueByRarity = new LinkedHashMap<>();
-        for (Map.Entry<PortfolioItem, BigDecimal> entry : valueByPricedItem.entrySet()) {
-            Card card = cardMap.get(entry.getKey().getCardId());
+        Map<String, BigDecimal> countBySet = new LinkedHashMap<>();
+        Map<String, BigDecimal> countByRarity = new LinkedHashMap<>();
+        BigDecimal totalCount = BigDecimal.ZERO;
+        for (PortfolioItem item : items) {
+            Card card = cardMap.get(item.getCardId());
             String setKey = card != null && card.getSetName() != null ? card.getSetName() : UNCLASSIFIED;
             String rarityKey = card != null && card.getRarity() != null ? card.getRarity() : UNCLASSIFIED;
+            BigDecimal quantity = BigDecimal.valueOf(item.getQuantity());
 
-            valueBySet.merge(setKey, entry.getValue(), BigDecimal::add);
-            valueByRarity.merge(rarityKey, entry.getValue(), BigDecimal::add);
+            countBySet.merge(setKey, quantity, BigDecimal::add);
+            countByRarity.merge(rarityKey, quantity, BigDecimal::add);
+            totalCount = totalCount.add(quantity);
         }
 
         return new PortfolioAnalyticsResponse(
-                toAnalyticsItems(valueBySet, totalValue),
-                toAnalyticsItems(valueByRarity, totalValue));
+                toAnalyticsItems(countBySet, totalCount),
+                toAnalyticsItems(countByRarity, totalCount));
     }
 
-    private List<PortfolioAnalyticsItemResponse> toAnalyticsItems(Map<String, BigDecimal> valueByLabel, BigDecimal totalValue) {
-        return valueByLabel.entrySet().stream()
+    private List<PortfolioAnalyticsItemResponse> toAnalyticsItems(Map<String, BigDecimal> countByLabel, BigDecimal totalCount) {
+        return countByLabel.entrySet().stream()
                 .map(entry -> new PortfolioAnalyticsItemResponse(
                         entry.getKey(),
-                        entry.getValue().setScale(0, RoundingMode.HALF_UP),
-                        entry.getValue().divide(totalValue, 4, RoundingMode.HALF_UP)
+                        entry.getValue(),
+                        entry.getValue().divide(totalCount, 4, RoundingMode.HALF_UP)
                                 .multiply(BigDecimal.valueOf(100))
                                 .setScale(2, RoundingMode.HALF_UP)))
                 .sorted(Comparator.comparing(PortfolioAnalyticsItemResponse::value).reversed())
+                .toList();
+    }
+
+    // FR-PORT-07: 세트 완성도 - 사용자가 보유한 서로 다른 카드가 각 세트 전체 카드 중 몇 %인지 계산한다.
+    // 수량(quantity)은 완성도와 무관하므로(같은 카드를 여러 장 가져도 완성도는 그대로) distinct cardId 기준으로 센다.
+    // expansion이 없는 카드(비정규화된 setName만 있는 구버전 데이터 등)는 전체 카드 수를 알 수 없어 제외한다.
+    public List<PortfolioSetCompletionResponse> getSetCompletion(Long userId) {
+        List<PortfolioItem> items = portfolioItemRepository.findByUserIdOrderByIdDesc(userId);
+        if (items.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> cardIds = items.stream().map(PortfolioItem::getCardId).collect(Collectors.toSet());
+        Map<Long, Card> cardMap = cardRepository.findAllById(cardIds).stream()
+                .collect(Collectors.toMap(Card::getId, c -> c));
+
+        Map<String, Set<Long>> ownedCardIdsByExpansion = new LinkedHashMap<>();
+        for (Long cardId : cardIds) {
+            Card card = cardMap.get(cardId);
+            Expansion expansion = card != null ? card.getExpansion() : null;
+            if (expansion == null) {
+                continue;
+            }
+            ownedCardIdsByExpansion.computeIfAbsent(expansion.getId(), k -> new HashSet<>()).add(cardId);
+        }
+
+        if (ownedCardIdsByExpansion.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, Expansion> expansionMap = expansionRepository.findAllById(ownedCardIdsByExpansion.keySet()).stream()
+                .collect(Collectors.toMap(Expansion::getId, e -> e));
+
+        // Expansion.total이 비어 있는(동기화 누락) 세트는 실제 DB에 적재된 카드 수로 대신한다.
+        Map<String, Long> dbCountByExpansion = cardRepository.findCardCountsByExpansion().stream()
+                .collect(Collectors.toMap(
+                        CardRepository.ExpansionCardCountView::getExpansionId,
+                        CardRepository.ExpansionCardCountView::getCount));
+
+        return ownedCardIdsByExpansion.entrySet().stream()
+                .map(entry -> {
+                    String expansionId = entry.getKey();
+                    Expansion expansion = expansionMap.get(expansionId);
+                    int ownedCount = entry.getValue().size();
+                    Integer total = expansion != null ? expansion.getTotal() : null;
+                    int totalCount = total != null ? total : dbCountByExpansion.getOrDefault(expansionId, 0L).intValue();
+                    BigDecimal completionRate = totalCount <= 0
+                            ? BigDecimal.ZERO
+                            : BigDecimal.valueOf(ownedCount)
+                                    .divide(BigDecimal.valueOf(totalCount), 4, RoundingMode.HALF_UP)
+                                    .multiply(BigDecimal.valueOf(100))
+                                    .setScale(2, RoundingMode.HALF_UP);
+
+                    return new PortfolioSetCompletionResponse(
+                            expansionId,
+                            expansion != null ? expansion.getName() : UNCLASSIFIED,
+                            ownedCount,
+                            totalCount,
+                            completionRate);
+                })
+                .sorted(Comparator.comparing(PortfolioSetCompletionResponse::completionRate).reversed())
                 .toList();
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.portfolio.service;
 
+import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.ai.entity.GradeStatus;
+import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
 import com.pokade.domain.card.repository.CardPriceRepository;
@@ -47,6 +50,7 @@ public class PortfolioService {
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
     private final CardPriceRepository cardPriceRepository;
+    private final GradeResultRepository gradeResultRepository;
     private final UserAccessChecker userAccessChecker;
 
     @Transactional
@@ -313,6 +317,59 @@ public class PortfolioService {
                 .build();
 
         portfolioItemRepository.save(item);
+    }
+
+    // FR-AI-04: AI 등급 진단 결과를 바탕으로 도감에 카드를 등록한다.
+    // 도감 등록은 유저 선택(자동 아님) — 컨트롤러가 이 메서드를 명시적 요청에서만 호출한다.
+    @Transactional
+    public PortfolioItemResponse addFromGradeResult(Long userId, Long resultId) {
+        userAccessChecker.assertWritable(userId);
+
+        GradeResult gradeResult = gradeResultRepository.findById(resultId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GRADE_RESULT_NOT_FOUND));
+
+        if (!gradeResult.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        if (gradeResult.getStatus() != GradeStatus.SUCCESS || gradeResult.getGrade() == null) {
+            throw new BusinessException(ErrorCode.GRADE_RESULT_NOT_REGISTRABLE);
+        }
+
+        if (portfolioItemRepository.existsByGradeResultId(resultId)) {
+            throw new BusinessException(ErrorCode.GRADE_RESULT_ALREADY_REGISTERED);
+        }
+
+        // cardId/variantId는 카드 자동식별 연동 전까지 채워지지 않을 수 있어(현재 Vision은
+        // vision_card_id(externalId)만 반환), 저장된 값이 없으면 그 자리에서 externalId로 해석한다.
+        Long cardId = gradeResult.getCardId();
+        Card card;
+        if (cardId != null) {
+            card = cardRepository.findById(cardId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+        } else if (gradeResult.getVisionCardId() != null) {
+            card = cardRepository.findByExternalId(gradeResult.getVisionCardId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+            cardId = card.getId();
+        } else {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
+        Long variantId = gradeResult.getVariantId() != null
+                ? gradeResult.getVariantId()
+                : cardVariantRepository.findPrimaryVariantId(cardId).orElse(null);
+
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(userId)
+                .cardId(cardId)
+                .variantId(variantId)
+                .quantity(1)
+                .acquiredAt(LocalDateTime.now())
+                .gradeResultId(resultId)
+                .build();
+
+        portfolioItemRepository.save(item);
+        return enrichSingle(item, card);
     }
 
     // ─── 내부 enrichment 헬퍼 ────────────────────────────────────────────────

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -4,6 +4,7 @@ import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.portfolio.service.PortfolioService;
 import com.pokade.domain.trade.dto.MyTradeResponse;
 import com.pokade.domain.trade.dto.MyTradeSearchCondition;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
@@ -39,6 +40,7 @@ public class TradeService {
     private final PaymentRepository paymentRepository;
     private final CardRepository cardRepository;
     private final UserAccessChecker userAccessChecker;
+    private final PortfolioService portfolioService;
 
     private TradeResponse toResponse(Trade trade) {
         String cardName = cardRepository.findById(trade.getListing().getCardId())
@@ -132,6 +134,15 @@ public class TradeService {
         }
 
         trade.complete();
+
+        Listing listing = trade.getListing();
+        portfolioService.addFromCompletedTrade(
+                buyerId,
+                trade.getId(),
+                listing.getCardId(),
+                listing.getVariantId(),
+                trade.getPrice()
+        );
 
         return toResponse(trade);
     }

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -94,6 +94,8 @@ public enum ErrorCode {
     PORTFOLIO_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "포트폴리오 항목을 찾을 수 없습니다."),
     PORTFOLIO_PRICE_NOT_FOUND(HttpStatus.NOT_FOUND, "시세 정보가 없어 손익을 계산할 수 없습니다."),
     PORTFOLIO_ACQUIRED_PRICE_REQUIRED(HttpStatus.BAD_REQUEST, "취득가가 입력되지 않아 손익을 계산할 수 없습니다."),
+    GRADE_RESULT_NOT_REGISTRABLE(HttpStatus.BAD_REQUEST, "정상 산출된 진단 결과만 도감에 등록할 수 있습니다."),
+    GRADE_RESULT_ALREADY_REGISTERED(HttpStatus.CONFLICT, "이미 도감에 등록된 진단 결과입니다."),
 
     // ===== Scrydex 동기화 배치 (관리자 트리거) =====
     SYNC_ALREADY_RUNNING(HttpStatus.CONFLICT, "이미 동기화가 진행 중입니다.");

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -90,6 +90,9 @@ public enum ErrorCode {
     WATCHLIST_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "워치리스트는 최대 20개까지 등록할 수 있습니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "이미 읽음 처리된 알림입니다."),
 
+    // ===== 포트폴리오 =====
+    PORTFOLIO_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "포트폴리오 항목을 찾을 수 없습니다."),
+
     // ===== Scrydex 동기화 배치 (관리자 트리거) =====
     SYNC_ALREADY_RUNNING(HttpStatus.CONFLICT, "이미 동기화가 진행 중입니다.");
 

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -92,6 +92,8 @@ public enum ErrorCode {
 
     // ===== 포트폴리오 =====
     PORTFOLIO_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "포트폴리오 항목을 찾을 수 없습니다."),
+    PORTFOLIO_PRICE_NOT_FOUND(HttpStatus.NOT_FOUND, "시세 정보가 없어 손익을 계산할 수 없습니다."),
+    PORTFOLIO_ACQUIRED_PRICE_REQUIRED(HttpStatus.BAD_REQUEST, "취득가가 입력되지 않아 손익을 계산할 수 없습니다."),
 
     // ===== Scrydex 동기화 배치 (관리자 트리거) =====
     SYNC_ALREADY_RUNNING(HttpStatus.CONFLICT, "이미 동기화가 진행 중입니다.");

--- a/Pokade/src/main/resources/db/migration/V6__user_agreement_columns.sql
+++ b/Pokade/src/main/resources/db/migration/V6__user_agreement_columns.sql
@@ -1,0 +1,9 @@
+-- V3(user_agreements 이관)가 전제로 하는 컬럼들을 먼저 만든다.
+-- 가입 시점에 항상 동의한 것으로 하드코딩해 왔으므로 NOT NULL DEFAULT로 채워도 기존 데이터와 불일치가 없다.
+
+BEGIN;
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS terms_agreed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS marketing_opt_in BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;

--- a/Pokade/src/main/resources/db/migration/V7__user_agreements.sql
+++ b/Pokade/src/main/resources/db/migration/V7__user_agreements.sql
@@ -1,0 +1,62 @@
+-- 회원 약관 동의 이력 테이블 도입. 지금까지는 users.terms_agreed_at / marketing_opt_in에
+-- 값이 하드코딩되어 실제 동의를 받은 적이 없다(가입 요청에 동의 필드 자체가 없었다).
+--
+-- V2와 같은 전제로 작성한다 — 운영은 ddl-auto=validate, sql.init.mode=never이므로
+-- 배포 담당자가 psql로 수동 1회 실행한다.
+--
+-- 실행 시점: 신버전이 뜨기 전까지 끝나 있기만 하면 되고, 얼마나 일찍 돌리든 무해하다.
+--   develop 머지가 auto-promote → deploy로 이어져 자동 배포되므로, "배포 직전"에 끼워 넣을
+--   틈이 없다. 따라서 PR을 머지하기 "전에" 미리 실행해 둔다. 이 스크립트는 추가와 제약 완화뿐이라
+--   지금 돌려도 현재 운영 중인 구버전 앱의 동작이 달라지지 않는다.
+--   반대로 이걸 건너뛰고 신버전이 뜨면 ddl-auto=validate가 user_agreements 부재를 잡아 기동에 실패한다.
+--   - 이 스크립트를 돌리고 나면 구버전과 신버전이 같은 스키마에서 함께 동작한다.
+--     구버전은 terms_agreed_at에 계속 값을 넣고, 신버전은 그 컬럼을 매핑하지 않아 NULL로 남긴다.
+--   - users의 옛 컬럼 제거는 여기 넣지 않는다. 배포 전에 지우면 아직 도는 구버전 앱이
+--     그 컬럼을 요구해 재기동 시 validate에서 죽고, 배포 실패 시 롤백 경로도 막힌다.
+--     제거는 배포가 안정된 뒤 V4로 따로 돌린다(급하지 않다).
+
+-- 전체를 한 트랜잭션으로 묶는다. 중간에 실패하면 아무것도 남지 않아, 부분 적용 상태를
+-- 걱정하지 않고 그대로 다시 실행할 수 있다.
+BEGIN;
+
+-- 1) 동의 이력 테이블. 항목별 최신 행이 현재 상태이고, 철회도 agreed=false인 새 행으로 남긴다.
+CREATE TABLE IF NOT EXISTS user_agreements (
+                                               id        BIGSERIAL PRIMARY KEY,
+                                               user_id   BIGINT      NOT NULL REFERENCES users(id),
+    type      VARCHAR(30) NOT NULL,                  -- TERMS_OF_SERVICE / PRIVACY_POLICY / THIRD_PARTY_SHARING / MARKETING
+    agreed    BOOLEAN     NOT NULL,
+    agreed_at TIMESTAMP   NOT NULL,
+    version   VARCHAR(20) NOT NULL                   -- 동의 시점의 약관 버전. 기존 이관분은 'legacy'
+    );
+
+-- 유저·타입별 최신 행 조회가 유일한 접근 패턴이다.
+CREATE INDEX IF NOT EXISTS idx_user_agreements_user_type
+    ON user_agreements (user_id, type, agreed_at DESC);
+
+-- 2) 기존 가입자 이관. 실제로 받은 적 없는 동의라 version='legacy'로 표시해 신규 동의와 구분한다.
+--    이관해두지 않으면 기존 사용자가 전원 필수 미동의 상태가 되어 재동의 유도 화면이 필요해진다.
+--
+--    NOT EXISTS로 이미 이관된 유저를 건너뛴다 — 이 스크립트를 실수로 두 번 돌려도 행이
+--    중복되지 않는다. 없으면 재실행 시 동의 행이 2배가 되어 이관 확인 쿼리가 어긋난다.
+INSERT INTO user_agreements (user_id, type, agreed, agreed_at, version)
+SELECT u.id, t.type, TRUE, u.terms_agreed_at, 'legacy'
+FROM users u
+         CROSS JOIN (VALUES ('TERMS_OF_SERVICE'), ('PRIVACY_POLICY'), ('THIRD_PARTY_SHARING')) AS t(type)
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_agreements a WHERE a.user_id = u.id AND a.type = t.type
+);
+
+-- 마케팅은 기존 값을 그대로 옮긴다(대부분 false).
+INSERT INTO user_agreements (user_id, type, agreed, agreed_at, version)
+SELECT u.id, 'MARKETING', u.marketing_opt_in, u.terms_agreed_at, 'legacy'
+FROM users u
+WHERE NOT EXISTS (
+    SELECT 1 FROM user_agreements a WHERE a.user_id = u.id AND a.type = 'MARKETING'
+);
+
+-- 3) 신버전 엔티티는 terms_agreed_at을 매핑하지 않으므로 INSERT에 값을 넣지 않는다.
+--    NOT NULL을 풀지 않으면 신버전 배포 직후부터 V4를 돌릴 때까지 회원가입이 제약 위반으로 실패한다.
+--    (marketing_opt_in은 DEFAULT FALSE가 있어 그대로 둬도 무방하다.)
+ALTER TABLE users ALTER COLUMN terms_agreed_at DROP NOT NULL;
+
+COMMIT;

--- a/Pokade/src/main/resources/db/migration/V8__drop_user_consent_columns.sql
+++ b/Pokade/src/main/resources/db/migration/V8__drop_user_consent_columns.sql
@@ -1,0 +1,24 @@
+-- V3에서 user_agreements로 이관을 마친 뒤, users에 남은 옛 동의 컬럼을 제거한다.
+--
+-- 실행 시점: 신버전 배포가 안정화된 "뒤" 아무 때나. 서두를 이유가 없다.
+--   V3가 NOT NULL을 풀어둬서 두 컬럼은 이미 아무도 쓰지 않는 잔재이고, 신버전은 정상 동작한다.
+--
+-- V3와 달리 이 스크립트는 파괴적이며, 실행하는 순간 구버전으로의 롤백이 막힌다.
+--   - 신버전 엔티티는 두 컬럼을 매핑하지 않고, Hibernate validate는 엔티티가 모르는
+--     여분 컬럼을 문제 삼지 않으므로 신버전에는 영향이 없다.
+--   - 반대로 구버전 앱은 그 컬럼을 요구하므로, 지운 뒤에는 옛 이미지로 되돌릴 수 없다.
+--     배포에 문제가 없다고 확신한 다음에 실행한다.
+--
+-- 이관 확인은 V3를 실행한 "직후"에 아래 쿼리로 한다. 두 값이 같아야 한다.
+--   SELECT (SELECT count(*) FROM user_agreements) AS 동의행,
+--          (SELECT count(*) * 4 FROM users) AS 기대치;
+--   배포 후에는 신규 가입자가 앱을 통해 동의를 기록하므로 이 등식으로는 이관 여부를 판별할 수 없다.
+--   V3의 이관이 누락된 채 이 스크립트를 돌리면 동의 이력이 복구 불가능하게 사라진다.
+
+-- IF EXISTS라 재실행해도 안전하다. 한 트랜잭션으로 묶어 둘 중 하나만 지워지는 상태를 막는다.
+BEGIN;
+
+ALTER TABLE users DROP COLUMN IF EXISTS terms_agreed_at;
+ALTER TABLE users DROP COLUMN IF EXISTS marketing_opt_in;
+
+COMMIT;

--- a/Pokade/src/main/resources/db/migration/V9__add_grade_result_id_to_portfolio_items.sql
+++ b/Pokade/src/main/resources/db/migration/V9__add_grade_result_id_to_portfolio_items.sql
@@ -1,0 +1,3 @@
+-- AI 등급 진단 결과에서 바로 도감(portfolio)에 등록할 수 있게 되어(#193),
+-- 어떤 진단 결과로부터 등록된 항목인지 추적하기 위한 컬럼. UNIQUE로 동일 진단 결과의 중복 등록을 막는다.
+ALTER TABLE portfolio_items ADD COLUMN IF NOT EXISTS grade_result_id BIGINT UNIQUE REFERENCES grade_results(id);

--- a/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
@@ -25,6 +25,7 @@ import com.pokade.domain.ai.entity.GradeResult;
 import com.pokade.domain.ai.entity.GradeStatus;
 import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
+import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
@@ -46,6 +47,9 @@ class AiGradeServiceTest {
 
     @Mock
     private GradeResultImageRepository gradeResultImageRepository;
+
+    @Mock
+    private CardRepository cardRepository;
 
     @InjectMocks
     private AiGradeService aiGradeService;

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -1,5 +1,8 @@
 package com.pokade.domain.portfolio.service;
 
+import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.ai.entity.GradeStatus;
+import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
@@ -45,6 +48,7 @@ class PortfolioServiceTest {
     @Mock CardRepository cardRepository;
     @Mock CardVariantRepository cardVariantRepository;
     @Mock CardPriceRepository cardPriceRepository;
+    @Mock GradeResultRepository gradeResultRepository;
     @Mock UserAccessChecker userAccessChecker;
 
     @InjectMocks PortfolioService portfolioService;
@@ -522,5 +526,95 @@ class PortfolioServiceTest {
         // 레어도는 둘 다 "레어도R"로 합산되어 100%
         assertThat(result.byRarity()).containsExactly(
                 new PortfolioAnalyticsItemResponse("레어도R", new BigDecimal("40000"), new BigDecimal("100.00")));
+    }
+
+    // ===== addFromGradeResult =====
+
+    private GradeResult stubGradeResult(Long userId, GradeStatus status, String grade, String visionCardId) {
+        return GradeResult.builder()
+                .userId(userId)
+                .status(status)
+                .grade(grade)
+                .visionCardId(visionCardId)
+                .isFree(true)
+                .pointUsed(0)
+                .retryAllowed(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 존재하지 않는 결과면 GRADE_RESULT_NOT_FOUND")
+    void addFromGradeResult_notFound() {
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 본인 결과가 아니면 ACCESS_DENIED")
+    void addFromGradeResult_accessDenied() {
+        GradeResult gradeResult = stubGradeResult(99L, GradeStatus.SUCCESS, "S", "base1-4");
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 품질 실패(QUALITY_FAIL) 결과면 GRADE_RESULT_NOT_REGISTRABLE")
+    void addFromGradeResult_notRegistrable() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.QUALITY_FAIL, null, null);
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_NOT_REGISTRABLE);
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 이미 등록된 결과면 GRADE_RESULT_ALREADY_REGISTERED")
+    void addFromGradeResult_alreadyRegistered() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "S", "base1-4");
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(true);
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_ALREADY_REGISTERED);
+        then(portfolioItemRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): vision_card_id로 카드를 못 찾으면 CARD_NOT_FOUND")
+    void addFromGradeResult_cardNotFound() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "S", "base1-4");
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
+        given(cardRepository.findByExternalId("base1-4")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 정상 케이스면 vision_card_id로 카드를 해석해 등록한다")
+    void addFromGradeResult_success() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "S", "base1-4");
+        Card card = stubCard(10L);
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
+        given(cardRepository.findByExternalId("base1-4")).willReturn(Optional.of(card));
+        given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+
+        PortfolioItemResponse response = portfolioService.addFromGradeResult(1L, 1L);
+
+        assertThat(response.cardId()).isEqualTo(10L);
+        assertThat(response.quantity()).isEqualTo(1);
+        then(portfolioItemRepository).should().save(any(PortfolioItem.class));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -1,0 +1,235 @@
+package com.pokade.domain.portfolio.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardPriceRepository;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
+import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.entity.PortfolioItem;
+import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.port.UserAccessChecker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class PortfolioServiceTest {
+
+    @Mock PortfolioItemRepository portfolioItemRepository;
+    @Mock CardRepository cardRepository;
+    @Mock CardVariantRepository cardVariantRepository;
+    @Mock CardPriceRepository cardPriceRepository;
+    @Mock UserAccessChecker userAccessChecker;
+
+    @InjectMocks PortfolioService portfolioService;
+
+    // id 필드 포함 — enrich 내부 Collectors.toMap(Card::getId, ...) 정상 동작을 위해 필수
+    private Card stubCard(Long id) {
+        return Card.builder()
+                .id(id)
+                .externalId("ext-" + id)
+                .name("리자몽")
+                .build();
+    }
+
+    private PortfolioItem stubItem(Long userId, Long cardId, Long variantId) {
+        return PortfolioItem.builder()
+                .userId(userId)
+                .cardId(cardId)
+                .variantId(variantId)
+                .quantity(1)
+                .acquiredPrice(50000)
+                .acquiredAt(LocalDateTime.now())
+                .build();
+    }
+
+    // ===== addItem =====
+
+    @Test
+    @DisplayName("추가: 존재하지 않는 카드면 CARD_NOT_FOUND")
+    void addItem_cardNotFound() {
+        PortfolioItemAddRequest request = new PortfolioItemAddRequest(999L, null, 1, null, null);
+        given(cardRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.addItem(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        then(portfolioItemRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("추가: 존재하지 않는 variantId면 CARD_NOT_FOUND")
+    void addItem_variantNotFound() {
+        PortfolioItemAddRequest request = new PortfolioItemAddRequest(1L, 999L, 1, null, null);
+        given(cardRepository.findById(1L)).willReturn(Optional.of(stubCard(1L)));
+        given(cardVariantRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.addItem(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        then(portfolioItemRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("추가: variantId null이고 대표 변형도 없으면 시세 없이 정상 추가된다")
+    void addItem_variantIdNull_success() {
+        PortfolioItemAddRequest request = new PortfolioItemAddRequest(1L, null, 2, 30000, null);
+        Card card = stubCard(1L);
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+        // 대표 변형 없으면 resolvedVariantId = null → cardPriceRepository 호출 안 됨
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
+
+        PortfolioItemResponse response = portfolioService.addItem(1L, request);
+
+        then(portfolioItemRepository).should().save(any(PortfolioItem.class));
+        assertThat(response.cardId()).isEqualTo(1L);
+        assertThat(response.variantId()).isNull();
+        assertThat(response.quantity()).isEqualTo(2);
+        assertThat(response.currentMarketPrice()).isNull();
+    }
+
+    @Test
+    @DisplayName("추가: 같은 카드를 여러 번 추가해도 에러 없이 별도 행으로 저장된다")
+    void addItem_duplicateAllowed() {
+        PortfolioItemAddRequest request = new PortfolioItemAddRequest(1L, null, 1, null, null);
+        Card card = stubCard(1L);
+        given(cardRepository.findById(1L)).willReturn(Optional.of(card));
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+        given(cardVariantRepository.findPrimaryVariantId(1L)).willReturn(Optional.empty());
+
+        portfolioService.addItem(1L, request);
+        portfolioService.addItem(1L, request);
+
+        then(portfolioItemRepository).should(org.mockito.Mockito.times(2)).save(any(PortfolioItem.class));
+    }
+
+    // ===== getMyPortfolio =====
+
+    @Test
+    @DisplayName("조회: 포트폴리오가 비어 있으면 빈 리스트 반환")
+    void getMyPortfolio_empty() {
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of());
+
+        List<PortfolioItemResponse> result = portfolioService.getMyPortfolio(1L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조회: variantId 있는 항목의 시세를 포함해 항목 수만큼 반환")
+    void getMyPortfolio_success() {
+        // item1: variantId null (대표 변형도 없음), item2: variantId=5
+        PortfolioItem item1 = stubItem(1L, 10L, null);
+        PortfolioItem item2 = stubItem(1L, 20L, 5L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item1, item2));
+        given(cardRepository.findAllById(any())).willReturn(List.of(stubCard(10L), stubCard(20L)));
+        // item1의 cardId=10은 대표 변형 없음
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(anyList())).willReturn(List.of());
+        // item2의 variantId=5 → findAllById({5}) 호출
+        given(cardVariantRepository.findAllById(any())).willReturn(List.of());
+        // 시세 조회 (variantId=5 기준)
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of());
+
+        List<PortfolioItemResponse> result = portfolioService.getMyPortfolio(1L);
+
+        assertThat(result).hasSize(2);
+    }
+
+    // ===== updateItem =====
+
+    @Test
+    @DisplayName("수정: 본인 항목이 아니면 PORTFOLIO_ITEM_NOT_FOUND")
+    void updateItem_notFound() {
+        given(portfolioItemRepository.findByIdAndUserId(1L, 99L)).willReturn(Optional.empty());
+        PortfolioItemUpdateRequest request = new PortfolioItemUpdateRequest(3, null, null);
+
+        assertThatThrownBy(() -> portfolioService.updateItem(99L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("수정: 수량만 변경하면 나머지 필드는 유지된다")
+    void updateItem_quantityOnly() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardRepository.findById(10L)).willReturn(Optional.of(stubCard(10L)));
+        // variantId null + 대표 변형 없음 → cardPriceRepository 호출 안 됨
+        given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
+
+        PortfolioItemUpdateRequest request = new PortfolioItemUpdateRequest(5, null, null);
+        PortfolioItemResponse response = portfolioService.updateItem(1L, 1L, request);
+
+        assertThat(response.quantity()).isEqualTo(5);
+        assertThat(response.acquiredPrice()).isEqualTo(50000); // 원래 값 유지
+    }
+
+    // ===== deleteItem =====
+
+    @Test
+    @DisplayName("삭제: 본인 항목이 아니면 PORTFOLIO_ITEM_NOT_FOUND")
+    void deleteItem_notFound() {
+        given(portfolioItemRepository.findByIdAndUserId(1L, 99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.deleteItem(99L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND);
+        then(portfolioItemRepository).should(never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("삭제: 정상 케이스면 repository.delete() 호출")
+    void deleteItem_success() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+
+        portfolioService.deleteItem(1L, 1L);
+
+        then(portfolioItemRepository).should().delete(item);
+    }
+
+    // ===== addFromCompletedTrade =====
+
+    @Test
+    @DisplayName("거래 연동: 이미 동일 tradeId로 등록된 경우 중복 저장하지 않는다")
+    void addFromCompletedTrade_idempotent() {
+        given(portfolioItemRepository.existsByTradeId(1L)).willReturn(true);
+
+        portfolioService.addFromCompletedTrade(1L, 1L, 10L, null, 50000);
+
+        then(portfolioItemRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("거래 연동: 신규 tradeId면 포트폴리오 항목 저장")
+    void addFromCompletedTrade_success() {
+        given(portfolioItemRepository.existsByTradeId(1L)).willReturn(false);
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+
+        portfolioService.addFromCompletedTrade(1L, 1L, 10L, 5L, 50000);
+
+        then(portfolioItemRepository).should().save(any(PortfolioItem.class));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
+import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
 import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
@@ -326,5 +327,107 @@ class PortfolioServiceTest {
         // changeAmount=4000, changeRate=4000/16000*100=25.00
         assertThat(result).isEqualTo(new PortfolioSummaryResponse(
                 new BigDecimal("20000"), new BigDecimal("4000"), new BigDecimal("25.00"), "KRW"));
+    }
+
+    // ===== getPnl =====
+
+    @Test
+    @DisplayName("손익: 본인 항목이 아니면 PORTFOLIO_ITEM_NOT_FOUND")
+    void getPnl_notFound() {
+        given(portfolioItemRepository.findByIdAndUserId(1L, 99L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.getPnl(99L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("손익: 취득가가 없으면 PORTFOLIO_ACQUIRED_PRICE_REQUIRED")
+    void getPnl_acquiredPriceMissing() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L)
+                .cardId(10L)
+                .variantId(5L)
+                .quantity(1)
+                .acquiredPrice(null)
+                .build();
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+
+        assertThatThrownBy(() -> portfolioService.getPnl(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_ACQUIRED_PRICE_REQUIRED);
+        then(cardPriceRepository).should(never()).findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("손익: 시세 정보가 없으면 PORTFOLIO_PRICE_NOT_FOUND")
+    void getPnl_priceNotFound() {
+        PortfolioItem item = stubItem(1L, 10L, 5L);
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of());
+
+        assertThatThrownBy(() -> portfolioService.getPnl(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("손익: variantId가 null이고 대표 변형도 없으면 PORTFOLIO_PRICE_NOT_FOUND")
+    void getPnl_noVariant_priceNotFound() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.getPnl(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
+        then(cardPriceRepository).should(never()).findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("손익: 현재 시세가 취득가보다 높으면 이익(+)으로 계산")
+    void getPnl_profit() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L)
+                .cardId(10L)
+                .variantId(5L)
+                .quantity(2)
+                .acquiredPrice(8000)
+                .acquiredAt(LocalDateTime.now())
+                .build();
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null)));
+
+        PortfolioItemPnlResponse result = portfolioService.getPnl(1L, 1L);
+
+        // 취득총액=8000*2=16000, 현재총액=10000*2=20000 → pnlAmount=4000, pnlRate=4000/16000*100=25.00
+        assertThat(result).isEqualTo(new PortfolioItemPnlResponse(
+                null, 10L, 2, 8000, new BigDecimal("10000"), "KRW",
+                new BigDecimal("4000"), new BigDecimal("25.00")));
+    }
+
+    @Test
+    @DisplayName("손익: 현재 시세가 취득가보다 낮으면 손실(-)로 계산")
+    void getPnl_loss() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L)
+                .cardId(10L)
+                .variantId(5L)
+                .quantity(1)
+                .acquiredPrice(10000)
+                .acquiredAt(LocalDateTime.now())
+                .build();
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("7500"), "KRW", null)));
+
+        PortfolioItemPnlResponse result = portfolioService.getPnl(1L, 1L);
+
+        // pnlAmount=7500-10000=-2500, pnlRate=-2500/10000*100=-25.00
+        assertThat(result).isEqualTo(new PortfolioItemPnlResponse(
+                null, 10L, 1, 10000, new BigDecimal("7500"), "KRW",
+                new BigDecimal("-2500"), new BigDecimal("-25.00")));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -4,6 +4,8 @@ import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.portfolio.dto.PortfolioAnalyticsItemResponse;
+import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
@@ -429,5 +431,96 @@ class PortfolioServiceTest {
         assertThat(result).isEqualTo(new PortfolioItemPnlResponse(
                 null, 10L, 1, 10000, new BigDecimal("7500"), "KRW",
                 new BigDecimal("-2500"), new BigDecimal("-25.00")));
+    }
+
+    // ===== getAnalytics =====
+
+    private Card stubCard(Long id, String setName, String rarity) {
+        return Card.builder()
+                .id(id)
+                .externalId("ext-" + id)
+                .name("리자몽")
+                .setName(setName)
+                .rarity(rarity)
+                .build();
+    }
+
+    @Test
+    @DisplayName("구성비율: 보유 카드가 없으면 빈 목록 반환")
+    void getAnalytics_empty() {
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of());
+
+        PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
+
+        assertThat(result.bySet()).isEmpty();
+        assertThat(result.byRarity()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("구성비율: 모든 항목의 시세가 없으면 빈 목록 반환")
+    void getAnalytics_noPriceData() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(anyList())).willReturn(List.of());
+
+        PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
+
+        assertThat(result.bySet()).isEmpty();
+        assertThat(result.byRarity()).isEmpty();
+        then(cardRepository).should(never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("구성비율: 세트·레어도 정보가 없는 카드는 '미분류'로 집계된다")
+    void getAnalytics_unclassified() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L)
+                .cardId(10L)
+                .variantId(5L)
+                .quantity(1)
+                .build();
+        ReflectionTestUtils.setField(item, "id", 100L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null)));
+        given(cardRepository.findAllById(any())).willReturn(List.of(stubCard(10L, null, null)));
+
+        PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
+
+        assertThat(result.bySet()).containsExactly(
+                new PortfolioAnalyticsItemResponse("미분류", new BigDecimal("10000"), new BigDecimal("100.00")));
+        assertThat(result.byRarity()).containsExactly(
+                new PortfolioAnalyticsItemResponse("미분류", new BigDecimal("10000"), new BigDecimal("100.00")));
+    }
+
+    @Test
+    @DisplayName("구성비율: 세트별·레어도별 평가액 비중을 내림차순으로 반환한다")
+    void getAnalytics_success() {
+        // item1: 세트 A / 레어도 R, 평가액 30000(qty3*10000) / item2: 세트 B / 레어도 R, 평가액 10000
+        PortfolioItem item1 = PortfolioItem.builder()
+                .userId(1L).cardId(10L).variantId(5L).quantity(3).build();
+        ReflectionTestUtils.setField(item1, "id", 100L);
+        PortfolioItem item2 = PortfolioItem.builder()
+                .userId(1L).cardId(20L).variantId(6L).quantity(1).build();
+        ReflectionTestUtils.setField(item2, "id", 200L);
+
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item1, item2));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(
+                        variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null),
+                        variantMarketPriceView(6L, new BigDecimal("10000"), "KRW", null)));
+        given(cardRepository.findAllById(any())).willReturn(List.of(
+                stubCard(10L, "세트A", "레어도R"),
+                stubCard(20L, "세트B", "레어도R")));
+
+        PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
+
+        // 총 평가액=40000, 세트A=30000(75%), 세트B=10000(25%) → 내림차순
+        assertThat(result.bySet()).containsExactly(
+                new PortfolioAnalyticsItemResponse("세트A", new BigDecimal("30000"), new BigDecimal("75.00")),
+                new PortfolioAnalyticsItemResponse("세트B", new BigDecimal("10000"), new BigDecimal("25.00")));
+        // 레어도는 둘 다 "레어도R"로 합산되어 100%
+        assertThat(result.byRarity()).containsExactly(
+                new PortfolioAnalyticsItemResponse("레어도R", new BigDecimal("40000"), new BigDecimal("100.00")));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -461,17 +461,18 @@ class PortfolioServiceTest {
     }
 
     @Test
-    @DisplayName("구성비율: 모든 항목의 시세가 없으면 빈 목록 반환")
-    void getAnalytics_noPriceData() {
+    @DisplayName("구성비율: 카드 정보를 찾을 수 없으면 '미분류' 수량으로 집계된다")
+    void getAnalytics_cardNotFound() {
         PortfolioItem item = stubItem(1L, 10L, null);
         given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
-        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(anyList())).willReturn(List.of());
+        given(cardRepository.findAllById(any())).willReturn(List.of());
 
         PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
 
-        assertThat(result.bySet()).isEmpty();
-        assertThat(result.byRarity()).isEmpty();
-        then(cardRepository).should(never()).findAllById(any());
+        assertThat(result.bySet()).containsExactly(
+                new PortfolioAnalyticsItemResponse("미분류", BigDecimal.ONE, new BigDecimal("100.00")));
+        assertThat(result.byRarity()).containsExactly(
+                new PortfolioAnalyticsItemResponse("미분류", BigDecimal.ONE, new BigDecimal("100.00")));
     }
 
     @Test
@@ -485,22 +486,20 @@ class PortfolioServiceTest {
                 .build();
         ReflectionTestUtils.setField(item, "id", 100L);
         given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
-        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
-                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null)));
         given(cardRepository.findAllById(any())).willReturn(List.of(stubCard(10L, null, null)));
 
         PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
 
         assertThat(result.bySet()).containsExactly(
-                new PortfolioAnalyticsItemResponse("미분류", new BigDecimal("10000"), new BigDecimal("100.00")));
+                new PortfolioAnalyticsItemResponse("미분류", BigDecimal.ONE, new BigDecimal("100.00")));
         assertThat(result.byRarity()).containsExactly(
-                new PortfolioAnalyticsItemResponse("미분류", new BigDecimal("10000"), new BigDecimal("100.00")));
+                new PortfolioAnalyticsItemResponse("미분류", BigDecimal.ONE, new BigDecimal("100.00")));
     }
 
     @Test
-    @DisplayName("구성비율: 세트별·레어도별 평가액 비중을 내림차순으로 반환한다")
+    @DisplayName("구성비율: 세트별·레어도별 보유 수량 비중을 내림차순으로 반환한다")
     void getAnalytics_success() {
-        // item1: 세트 A / 레어도 R, 평가액 30000(qty3*10000) / item2: 세트 B / 레어도 R, 평가액 10000
+        // item1: 세트 A / 레어도 R, 수량 3 / item2: 세트 B / 레어도 R, 수량 1
         PortfolioItem item1 = PortfolioItem.builder()
                 .userId(1L).cardId(10L).variantId(5L).quantity(3).build();
         ReflectionTestUtils.setField(item1, "id", 100L);
@@ -509,23 +508,19 @@ class PortfolioServiceTest {
         ReflectionTestUtils.setField(item2, "id", 200L);
 
         given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item1, item2));
-        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
-                .willReturn(List.of(
-                        variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null),
-                        variantMarketPriceView(6L, new BigDecimal("10000"), "KRW", null)));
         given(cardRepository.findAllById(any())).willReturn(List.of(
                 stubCard(10L, "세트A", "레어도R"),
                 stubCard(20L, "세트B", "레어도R")));
 
         PortfolioAnalyticsResponse result = portfolioService.getAnalytics(1L);
 
-        // 총 평가액=40000, 세트A=30000(75%), 세트B=10000(25%) → 내림차순
+        // 총 수량=4, 세트A=3(75%), 세트B=1(25%) → 내림차순
         assertThat(result.bySet()).containsExactly(
-                new PortfolioAnalyticsItemResponse("세트A", new BigDecimal("30000"), new BigDecimal("75.00")),
-                new PortfolioAnalyticsItemResponse("세트B", new BigDecimal("10000"), new BigDecimal("25.00")));
+                new PortfolioAnalyticsItemResponse("세트A", new BigDecimal("3"), new BigDecimal("75.00")),
+                new PortfolioAnalyticsItemResponse("세트B", BigDecimal.ONE, new BigDecimal("25.00")));
         // 레어도는 둘 다 "레어도R"로 합산되어 100%
         assertThat(result.byRarity()).containsExactly(
-                new PortfolioAnalyticsItemResponse("레어도R", new BigDecimal("40000"), new BigDecimal("100.00")));
+                new PortfolioAnalyticsItemResponse("레어도R", new BigDecimal("4"), new BigDecimal("100.00")));
     }
 
     // ===== addFromGradeResult =====

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -7,6 +7,7 @@ import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemUpdateRequest;
+import com.pokade.domain.portfolio.dto.PortfolioSummaryResponse;
 import com.pokade.domain.portfolio.entity.PortfolioItem;
 import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
 import com.pokade.global.exception.BusinessException;
@@ -18,7 +19,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -231,5 +234,97 @@ class PortfolioServiceTest {
         portfolioService.addFromCompletedTrade(1L, 1L, 10L, 5L, 50000);
 
         then(portfolioItemRepository).should().save(any(PortfolioItem.class));
+    }
+
+    // ===== getSummary =====
+
+    private CardPriceRepository.VariantMarketPriceView variantMarketPriceView(
+            Long variantId, BigDecimal market, String currency, BigDecimal change1dPct) {
+        return new CardPriceRepository.VariantMarketPriceView() {
+            @Override
+            public Long getVariantId() {
+                return variantId;
+            }
+
+            @Override
+            public BigDecimal getMarket() {
+                return market;
+            }
+
+            @Override
+            public String getCurrency() {
+                return currency;
+            }
+
+            @Override
+            public BigDecimal getChange1dPct() {
+                return change1dPct;
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("총 평가액: 보유 카드가 없으면 0으로 반환")
+    void getSummary_empty() {
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of());
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        assertThat(result).isEqualTo(new PortfolioSummaryResponse(
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, null));
+    }
+
+    @Test
+    @DisplayName("총 평가액: 시세 정보가 없는 항목은 계산에서 제외되어 0으로 반환")
+    void getSummary_noPriceData() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        ReflectionTestUtils.setField(item, "id", 100L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(anyList())).willReturn(List.of());
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        assertThat(result).isEqualTo(new PortfolioSummaryResponse(
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, null));
+    }
+
+    @Test
+    @DisplayName("총 평가액: 전일 대비 등락 없이(change1dPct=null) 평가액만 정상 계산")
+    void getSummary_withoutChange() {
+        PortfolioItem item = stubItem(1L, 10L, 5L);
+        ReflectionTestUtils.setField(item, "id", 100L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", null)));
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        // 전일가도 시세와 동일(10000.00)해서 등락은 0이지만, 나눗셈을 거치는 경로라 스케일이 0.00으로 남는다.
+        assertThat(result).isEqualTo(new PortfolioSummaryResponse(
+                new BigDecimal("10000"), BigDecimal.ZERO, new BigDecimal("0.00"), "KRW"));
+    }
+
+    @Test
+    @DisplayName("총 평가액: change1dPct 반영해 전일 대비 등락액·등락률 계산")
+    void getSummary_withPositiveChange() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L)
+                .cardId(10L)
+                .variantId(5L)
+                .quantity(2)
+                .acquiredPrice(50000)
+                .acquiredAt(LocalDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(item, "id", 100L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "KRW", new BigDecimal("25"))));
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        // market=10000, qty=2 → totalValue=20000 / 전일가=10000/1.25=8000 → previousValue=16000
+        // changeAmount=4000, changeRate=4000/16000*100=25.00
+        assertThat(result).isEqualTo(new PortfolioSummaryResponse(
+                new BigDecimal("20000"), new BigDecimal("4000"), new BigDecimal("25.00"), "KRW"));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -369,6 +369,11 @@ class PriceServiceTest {
             public String getCurrency() {
                 return currency;
             }
+
+            @Override
+            public BigDecimal getChange1dPct() {
+                return null;
+            }
         };
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -3,6 +3,7 @@ package com.pokade.domain.trade.service;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.portfolio.service.PortfolioService;
 import com.pokade.domain.trade.dto.TradeCreateRequest;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Trade;
@@ -48,6 +49,9 @@ class TradeServiceTest {
 
     @Mock
     private UserAccessChecker userAccessChecker;
+
+    @Mock
+    private PortfolioService portfolioService;
 
     @InjectMocks
     private TradeService tradeService;

--- a/Pokade/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/Pokade/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## 📌 관련 이슈
- #320
- #322

## ✨ 작업 내용
- portfolio_items에 grade_result_id 컬럼 마이그레이션 추가 — 엔티티에는 필드가 있었는데 대응 마이그레이션이 누락되어 도감 조회가 500 에러 나던 문제 수정 (#320)
- 포트폴리오 세트별·레어도별 구성 비율 계산 기준을 평가액(시세) → 보유 수량(quantity)으로 전환 — 시세 없는 카드도 항상 계산되도록 함
- 세트 완성도 조회 API 신규 추가 (`GET /api/portfolio/set-completion`) — 보유한 서로 다른 카드 수 / 세트 전체 카드 수(Expansion.total)로 완성도(%) 계산 (#322)
- 회원 약관 동의 이력 컬럼/테이블 마이그레이션 추가 (V6~V8) — users 동의 컬럼 → user_agreements 이력 테이블 이관, 기존 컬럼 제거는 배포 안정화 이후로 분리

## 📸 스크린샷 / 테스트 결과
- `./gradlew compileJava` 성공 확인
- 로컬에서 카드 등록 후 `/api/portfolio/analytics`, `/api/portfolio/set-completion` 응답에 실제 세트/레어도 값 반영 확인
- ⚠️ `./gradlew test` 전체 스위트는 실행하지 않았습니다 — 머지 전에 한 번 돌려봐 주세요.

## 🔍 리뷰 포인트
- `getAnalytics()`가 이제 시세를 전혀 안 보므로, "평가액 기준 구성비"를 기대하던 기존 소비처가 있다면 확인 필요합니다.
- V6~V8 마이그레이션은 원래 단계별 배포(V7은 배포 전, V8은 배포 안정화 후)를 전제로 작성된 것으로 보입니다 — 한 번에 다 적용해도 되는 타이밍인지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드가 성공했는가? (테스트 스위트는 미실행)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 포트폴리오 카드 등록, 조회, 수정 및 삭제 기능을 추가했습니다.
  * 포트폴리오의 총 평가액, 손익, 변동률, 세트·희귀도별 분석을 제공합니다.
  * 세트별 카드 수집 완성도를 확인할 수 있습니다.
  * 거래 완료 카드와 AI 등급 진단 결과를 포트폴리오에 바로 등록할 수 있습니다.
  * AI 등급 결과에 카드 정보와 인식 신뢰도를 함께 표시합니다.

* **개선**
  * 카드 시세에 전일 대비 변동률 정보를 추가했습니다.
  * 포트폴리오 조회 시 카드 및 시세 정보가 함께 제공됩니다.

* **테스트**
  * 포트폴리오 기능과 주요 성공·오류 시나리오에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->