### PR TITLE
[Feature] #325 무중단 배포(blue-green) 도입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,26 +46,68 @@ jobs:
     needs: build-and-push
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to EC2
+      # blue-green 배포. 두 슬롯(a/b)을 번갈아 쓰고, 새 슬롯이 헬스체크를 통과한 뒤에만
+      # nginx 업스트림을 전환하고 이전 슬롯을 내린다 — 컨테이너 교체 사이의 다운타임(약
+      # 30초)이 없어진다. EC2에 사전 설정(nginx upstream include, sudoers)이 1회 돼
+      # 있어야 한다 — docs/troubleshooting/decisions/zero-downtime-blue-green-deploy.md 참고.
+      - name: Deploy to EC2 (blue-green)
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           envs: OPENAI_API_KEY
-          # GHCR 로그인·이미지 pull이 실패하면 즉시 중단 — 새 이미지 없이 기존 컨테이너만
-          # 삭제되어 서비스가 내려가는 것을 막는다(기본값 false라 명시 필요).
+          # GHCR 로그인·이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
+          # nginx 설정을 건드리지 않은 채로 배포만 실패한다(기본값 false라 명시 필요).
           script_stop: true
           script: |
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker pull ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
-            docker stop pokade-app || true
-            docker rm pokade-app || true
-            docker run -d --name pokade-app --network host --restart unless-stopped \
+            IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+            docker pull "$IMAGE"
+
+            CURRENT_SLOT=$(cat ~/pokade-active-slot 2>/dev/null || echo "")
+            if [ "$CURRENT_SLOT" = "a" ]; then TARGET=b; else TARGET=a; fi
+            if [ "$TARGET" = "a" ]; then APP_PORT=18080; MGMT_PORT=18180; else APP_PORT=18081; MGMT_PORT=18181; fi
+
+            docker rm -f "pokade-app-$TARGET" 2>/dev/null || true
+            docker run -d --name "pokade-app-$TARGET" \
+              --network pokade_pokade-net \
+              -p "${APP_PORT}:8080" \
+              -p "127.0.0.1:${MGMT_PORT}:8081" \
+              --restart unless-stopped \
               --env-file ~/AIBE6_FinalProject_Team05_BE/Pokade/.env \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e TZ=Asia/Seoul \
               -e OPENAI_API_KEY="$OPENAI_API_KEY" \
-              ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+              -e REDIS_HOST=pokade-redis \
+              "$IMAGE"
+
+            HEALTHY=false
+            for i in $(seq 1 40); do
+              if curl -fs "http://127.0.0.1:${MGMT_PORT}/actuator/health" > /dev/null; then
+                HEALTHY=true
+                break
+              fi
+              sleep 3
+            done
+
+            if [ "$HEALTHY" != "true" ]; then
+              echo "헬스체크 실패 — 신규 컨테이너(pokade-app-$TARGET) 제거, 기존 컨테이너 유지"
+              docker logs --tail 100 "pokade-app-$TARGET" || true
+              docker rm -f "pokade-app-$TARGET"
+              exit 1
+            fi
+
+            echo "upstream pokade_upstream { server 127.0.0.1:${APP_PORT}; }" | sudo tee /etc/nginx/conf.d/pokade_upstream.conf > /dev/null
+            sudo nginx -t
+            sudo systemctl reload nginx
+
+            if [ -n "$CURRENT_SLOT" ]; then
+              docker rm -f "pokade-app-$CURRENT_SLOT" 2>/dev/null || true
+            else
+              docker rm -f pokade-app 2>/dev/null || true
+            fi
+
+            echo "$TARGET" > ~/pokade-active-slot
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## 📌 관련 이슈
- #325

## ✨ 작업 내용
- 기존 `docker stop → rm → run`(host 네트워크, 포트 고정) 배포 방식은 새 컨테이너가 뜨는 동안(측정값 약 28~35초) 서비스가 완전히 끊김
- 슬롯 두 개(a/b)를 번갈아 사용하는 blue-green 배포로 전환 — 새 컨테이너를 먼저 띄우고 헬스체크(`/actuator/health`, 관리 포트 8081, `127.0.0.1` 전용) 통과 후에만 nginx 업스트림 전환 + 이전 슬롯 종료
- `--network host` → 커스텀 브리지(`pokade_pokade-net`)로 전환 — 신/구 컨테이너를 동시에 띄우려면 포트가 겹치면 안 되는데 host 네트워크는 포트 공유가 불가능해서 필요
- `REDIS_HOST=pokade-redis`로 덮어씀 — host 네트워크를 버리면 컨테이너 안 `localhost`가 더 이상 EC2 호스트를 가리키지 않으므로 Docker 내장 DNS(컨테이너 이름)로 해석
- 헬스체크 40회(3초 간격, 최대 120초) 실패 시 신규 컨테이너만 `docker rm -f`로 제거하고 `exit 1` — nginx는 그대로 이전 슬롯을 보고 있어 아무 것도 안 바뀐 상태가 됨. `script_stop: true`라 중간 실패해도 기존 컨테이너는 안전

## ⚠️ 사전 준비 (배포 전 1회, EC2에서 수동)
nginx 설정과 sudoers는 저장소 밖(EC2에만 존재)이라 CI로 배포할 수 없습니다. **이 PR을 머지해 배포가 돌기 전에 아래를 먼저 끝내야 합니다** (안 해두면 `sudo tee`/`nginx -t`/`systemctl reload nginx`에서 막히지만, `script_stop: true`라 실패해도 기존 컨테이너는 안전하게 남습니다):

\`\`\`bash
# 1) upstream include 파일 생성 — 처음엔 기존 8080을 그대로 가리키게 해서 반영 시점에 다운타임 없음
echo "upstream pokade_upstream { server 127.0.0.1:8080; }" | sudo tee /etc/nginx/conf.d/pokade_upstream.conf

# 2) 실제 활성 파일의 proxy_pass를 업스트림 이름으로 변경
sudo sed -i 's#proxy_pass http://127.0.0.1:8080;#proxy_pass http://pokade_upstream;#' /etc/nginx/sites-available/pokade

# 3) 문법 확인 후 리로드 (기존 연결 유지한 채 반영됨)
sudo nginx -t && sudo systemctl reload nginx

# 4) 배포 스크립트가 비밀번호 없이 실행할 수 있도록 딱 이 세 명령만 허용 (최소 권한)
echo 'ubuntu ALL=(root) NOPASSWD: /usr/bin/tee /etc/nginx/conf.d/pokade_upstream.conf, /usr/sbin/nginx -t, /usr/bin/systemctl reload nginx' | sudo tee /etc/sudoers.d/pokade-deploy
sudo visudo -c   # 문법 검증 필수 — sudoers 파일 문법이 깨지면 이후 sudo 자체가 전부 막힘
\`\`\`

## 📸 스크린샷 / 테스트 결과
- 실제 배포 트리거 전 로컬에서는 워크플로 문법만 확인했습니다(`.github/workflows/deploy.yml` YAML 유효성).
- 실제 검증은 머지 후 다음 절차로 진행 예정입니다:
  1. 배포 중 `curl -w "%{http_code} " -o /dev/null -s https://api.pokade.store/api/cards`를 1초 간격으로 반복 실행해 응답이 끊기지 않는지 확인
  2. GitHub Actions 로그와 `docker logs pokade-app-a`(또는 `-b`)에서 헬스체크 통과 및 `Started PokadeApplication` 로그 확인
  3. 두 번째 배포부터 슬롯이 a↔b로 정상적으로 번갈아 가는지(`cat ~/pokade-active-slot`) 확인
  4. (선택) 존재하지 않는 이미지 태그로 일부러 실패시켜 기존 컨테이너가 안 죽고 워크플로만 실패하는지 리허설

## 🔍 리뷰 포인트
- EC2 사전 준비(위 항목)를 트래픽 적은 시간대에 먼저 끝내는 게 안전합니다.
- 여전히 `:latest` 단일 태그만 사용합니다(SHA 태그 병행은 후속 과제) — 검증 안 된 이미지가 트래픽을 받은 적이 없는 구조라 롤백 관점에서 문제는 없지만, 명확한 롤백 대상 확보 차원에서 개선 여지가 있습니다.
- nginx 설정 자체는 여전히 EC2에만 존재해 형상관리가 안 되고 있습니다 — 별도 과제로 남겨둡니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 로컬에서 빌드 및 테스트가 성공했는가? — 워크플로 파일이라 로컬 빌드 대상이 아니며, 실제 동작은 머지 후 배포로만 검증 가능합니다.
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 상세 설계/트러블슈팅 메모는 `docs/troubleshooting/`(리포지토리 정책상 push 대상 아님)에 개인 기록으로 남겨뒀습니다.