### PR TITLE
[refactor] #329 인증 메일을 HTML 템플릿으로 전환

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailSender.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailSender.java
@@ -9,23 +9,38 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class VerificationMailSender {
 
+    // 메일 문구에 노출하는 코드 유효시간 - 실제 만료는 각  CodeStore의 CODE_TTL에 의해 결정된다.
+    private static final int CODE_TTL_MINUTES = 5;
+
     private final MailSender mailSender;
 
     // 인증 코드 메일을 비동기로 발송한다.
     @Async
     public void sendCode(String email, String code) {
-        mailSender.send(email, "[Pokade] 이메일 인증 코드", "인증 코드: " + code + "\n5분 이내 입력");
+        mailSender.send(email, "[Pokade] 이메일 인증 코드",
+                VerificationMailTemplate.codeMail(
+                        "이메일 인증 코드",
+                        "아래 코드를 입력하시면 이메일 인증이 완료됩니다.",
+                        code, CODE_TTL_MINUTES));
     }
 
     // 비밀번호 재설정 코드 메일을 비동기로 발송한다.
     @Async
     public void sendResetCode(String email, String code) {
-        mailSender.send(email, "[Pokade] 비밀번호 재설정 코드", "재설정 코드: " + code + "\n5분 이내 입력");
+        mailSender.send(email, "[Pokade] 비밀번호 재설정 코드",
+                VerificationMailTemplate.codeMail(
+                        "비밀번호 재설정 코드",
+                        "아래 코드를 입력하시면 새 비밀번호를 설정할 수 있습니다.",
+                        code, CODE_TTL_MINUTES));
     }
 
     // 탈퇴 인증 코드 메일을 보낸다
     @Async
     public void sendWithdrawalCode(String email, String code) {
-        mailSender.send(email, "[Pokade] 회원 탈퇴 인증 코드", "탈퇴 인증 코드: " + code + "\n5분 이내 입력");
+        mailSender.send(email, "[Pokade] 회원 탈퇴 인증 코드",
+                VerificationMailTemplate.codeMail(
+                        "회원 탈퇴 인증 코드",
+                        "아래 코드를 입력하시면 탈퇴 절차가 진행됩니다. 탈퇴 후에는 되돌릴 수 없습니다.",
+                        code, CODE_TTL_MINUTES));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
@@ -1,8 +1,17 @@
 package com.pokade.domain.auth.support;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 // 인증 코드 메일의 HTML 본문을 만든다. 메일 클라이언트가 <style> 블록과 외부 CSS를 자주
 // 제거하므로 스타일을 전부 인라인 속성으로 둔다.
 public final class VerificationMailTemplate {
+
+    // 발송 시각 표기 — 재발송 시 본문이 통째로 같으면 Gmail이 뒤에 온 메일의 겹치는 부분을
+    // "..." 뒤로 접어 코드가 가려진다. 메일마다 달라지는 값을 넣어 접힐 덩어리를 없애고,
+    // 여러 통이 쌓였을 때 어느 것이 최신인지도 알 수 있게 한다.
+    private static final DateTimeFormatter SENT_AT_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
 
     private static final String LAYOUT = """
             <div style="margin:0;padding:32px 16px;background-color:#F6F6F8;font-family:'Apple SD Gothic Neo',-apple-system,'Malgun Gothic',sans-serif;">
@@ -11,7 +20,7 @@ public final class VerificationMailTemplate {
                 <h1 style="margin:18px 0 0;font-size:20px;font-weight:800;color:#1A1A1F;">%s</h1>
                 <p style="margin:10px 0 0;font-size:14px;line-height:1.6;color:#5A5A62;">%s</p>
                 <div style="margin:24px 0;padding:18px;background-color:#FDEEF0;border-radius:11px;text-align:center;font-size:30px;font-weight:800;letter-spacing:6px;color:#C21414;">%s</div>
-                <p style="margin:0;font-size:13px;color:#8A8A92;">이 코드는 %d분 동안만 사용할 수 있습니다.</p>
+                <p style="margin:0;font-size:13px;color:#8A8A92;">이 코드는 %d분 동안만 사용할 수 있습니다. (%s 발송)</p>
                 <hr style="margin:24px 0 0;border:none;border-top:1px solid #EDEDF0;">
                 <p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#9A9AA2;">
                   본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.<br>이 메일은 발신 전용입니다.
@@ -25,6 +34,7 @@ public final class VerificationMailTemplate {
 
     // 코드 안내 메일의 HTML 본문을 만든다.
     public static String codeMail(String heading, String description, String code, int minutes) {
-        return LAYOUT.formatted(heading, description, code, minutes);
+        return LAYOUT.formatted(heading, description, code, minutes,
+                LocalDateTime.now().format(SENT_AT_FORMAT));
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
@@ -7,7 +7,7 @@ public final class VerificationMailTemplate {
     private static final String LAYOUT = """
             <div style="margin:0;padding:32px 16px;background-color:#F6F6F8;font-family:'Apple SD Gothic Neo',-apple-system,'Malgun Gothic',sans-serif;">
               <div style="max-width:480px;margin:0 auto;padding:32px;background-color:#FFFFFF;border:1px solid #EDEDF0;border-radius:14px;">
-                <div style="font-size:15px;font-weight:800;letter-spacing:-0.3px;color:#EE1515;">POCKET TRADE</div>
+                <div style="font-size:15px;font-weight:800;letter-spacing:-0.3px;color:#EE1515;">POKADE</div>
                 <h1 style="margin:18px 0 0;font-size:20px;font-weight:800;color:#1A1A1F;">%s</h1>
                 <p style="margin:10px 0 0;font-size:14px;line-height:1.6;color:#5A5A62;">%s</p>
                 <div style="margin:24px 0;padding:18px;background-color:#FDEEF0;border-radius:11px;text-align:center;font-size:30px;font-weight:800;letter-spacing:6px;color:#C21414;">%s</div>

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
@@ -1,0 +1,4 @@
+package com.pokade.domain.auth.support;
+
+public class VerificationMailTemplate {
+}

--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
@@ -1,4 +1,30 @@
 package com.pokade.domain.auth.support;
 
-public class VerificationMailTemplate {
+// 인증 코드 메일의 HTML 본문을 만든다. 메일 클라이언트가 <style> 블록과 외부 CSS를 자주
+// 제거하므로 스타일을 전부 인라인 속성으로 둔다.
+public final class VerificationMailTemplate {
+
+    private static final String LAYOUT = """
+            <div style="margin:0;padding:32px 16px;background-color:#F6F6F8;font-family:'Apple SD Gothic Neo',-apple-system,'Malgun Gothic',sans-serif;">
+              <div style="max-width:480px;margin:0 auto;padding:32px;background-color:#FFFFFF;border:1px solid #EDEDF0;border-radius:14px;">
+                <div style="font-size:15px;font-weight:800;letter-spacing:-0.3px;color:#EE1515;">POCKET TRADE</div>
+                <h1 style="margin:18px 0 0;font-size:20px;font-weight:800;color:#1A1A1F;">%s</h1>
+                <p style="margin:10px 0 0;font-size:14px;line-height:1.6;color:#5A5A62;">%s</p>
+                <div style="margin:24px 0;padding:18px;background-color:#FDEEF0;border-radius:11px;text-align:center;font-size:30px;font-weight:800;letter-spacing:6px;color:#C21414;">%s</div>
+                <p style="margin:0;font-size:13px;color:#8A8A92;">이 코드는 %d분 동안만 사용할 수 있습니다.</p>
+                <hr style="margin:24px 0 0;border:none;border-top:1px solid #EDEDF0;">
+                <p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#9A9AA2;">
+                  본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.<br>이 메일은 발신 전용입니다.
+                </p>
+              </div>
+            </div>
+            """;
+
+    private VerificationMailTemplate() {
+    }
+
+    // 코드 안내 메일의 HTML 본문을 만든다.
+    public static String codeMail(String heading, String description, String code, int minutes) {
+        return LAYOUT.formatted(heading, description, code, minutes);
+    }
 }

--- a/Pokade/src/main/java/com/pokade/global/infra/mail/SmtpMailSender.java
+++ b/Pokade/src/main/java/com/pokade/global/infra/mail/SmtpMailSender.java
@@ -2,10 +2,12 @@ package com.pokade.global.infra.mail;
 
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,13 +18,14 @@ public class SmtpMailSender implements MailSender {
 
     @Override
     public void send(String to, String subject, String body) {
-        try{
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(to);
-            message.setSubject(subject);
-            message.setText(body);
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(body, true); // true indicates HTML content
             javaMailSender.send(message);
-        } catch (MailException e) {
+        } catch (MailException | MessagingException e) {
             throw new BusinessException(ErrorCode.EMAIL_SEND_FAILED);
         }
     }

--- a/Pokade/src/test/java/com/pokade/global/infra/mail/SmtpMailSenderTest.java
+++ b/Pokade/src/test/java/com/pokade/global/infra/mail/SmtpMailSenderTest.java
@@ -2,6 +2,7 @@ package com.pokade.global.infra.mail;
 
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,12 +11,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.MailSendException;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willThrow;
 
@@ -27,27 +29,42 @@ public class SmtpMailSenderTest {
     @InjectMocks
     SmtpMailSender smtpMailSender;
 
-    @Test
-    @DisplayName("수신자·제목·본문을 담은 메일을 전송한다")
-    void send_deliversMessage() {
-        smtpMailSender.send("user@pokade.com", "제목", "본문");
+    // mock은 createMimeMessage()에 null을 돌려주므로, 실제로 채워 넣을 수 있는 빈 MimeMessage를 만들어 준다.
+    private MimeMessage emptyMimeMessage() {
+        return new JavaMailSenderImpl().createMimeMessage();
+    }
 
-        ArgumentCaptor<SimpleMailMessage> captor = ArgumentCaptor.forClass(SimpleMailMessage.class);
+    @Test
+    @DisplayName("수신자·제목·HTML 본문을 담은 메일을 전송한다")
+    void send_deliversMessage() throws Exception {
+        given(javaMailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+
+        smtpMailSender.send("user@pokade.com", "제목", "<p>본문</p>");
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
         then(javaMailSender).should().send(captor.capture());
 
-        SimpleMailMessage sent = captor.getValue();
-        assertThat(sent.getTo()).containsExactly("user@pokade.com");
+        MimeMessage sent = captor.getValue();
+        // Content-Type 헤더는 saveChanges() 시점에 기록된다 — 실제 발송에서는 JavaMailSenderImpl이
+        // 호출하지만 여기서는 send를 mock으로 잡아 그 단계를 거치지 않으므로 직접 확정시킨다.
+        sent.saveChanges();
+
+        assertThat(sent.getAllRecipients()).hasSize(1);
+        assertThat(sent.getAllRecipients()[0].toString()).isEqualTo("user@pokade.com");
         assertThat(sent.getSubject()).isEqualTo("제목");
-        assertThat(sent.getText()).isEqualTo("본문");
+        assertThat(sent.getContent().toString()).contains("<p>본문</p>");
+        assertThat(sent.getContentType()).contains("text/html");
+        assertThat(sent.getContentType()).contains("UTF-8");
     }
 
     @Test
     @DisplayName("메일 서버 전송 실패 시 EMAIL_SEND_FAILED 예외를 던진다")
     void send_throwsWhenMailFails() {
+        given(javaMailSender.createMimeMessage()).willReturn(emptyMimeMessage());
         willThrow(new MailSendException("smtp down"))
-                .given(javaMailSender).send(any(SimpleMailMessage.class));
+                .given(javaMailSender).send(any(MimeMessage.class));
 
-        assertThatThrownBy(() -> smtpMailSender.send("user@pokade.com", "제목", "본문"))
+        assertThatThrownBy(() -> smtpMailSender.send("user@pokade.com", "제목", "<p>본문</p>"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.EMAIL_SEND_FAILED);
     }


### PR DESCRIPTION
## 📌 관련 이슈
- #329

## ✨ 작업 내용

인증 메일이 평문으로 나가던 것을 HTML로 전환한다.

| 커밋 | 내용 |
|---|---|
| `5976094` | `SmtpMailSender`를 `SimpleMailMessage`에서 `MimeMessageHelper` 기반으로 교체 |
| `a57cc6d` | 인증 메일 본문을 `VerificationMailTemplate`으로 분리 |
| `896027f` | `SmtpMailSenderTest`를 `MimeMessage` 기준으로 수정 |
| `947cdaa` | 메일 발신 주체 표기를 POKADE로 변경 |
| `52f04fd` | 재발송 시 본문이 접히지 않도록 발송 시각 표기 추가 |

대상 메일은 이메일 인증 코드, 비밀번호 재설정 코드, 회원 탈퇴 인증 코드 세 종이다. 기존에는 `"인증 코드: " + code + "\n5분 이내 입력"` 형태의 문자열 연결이었다.

## 📸 스크린샷 / 테스트 결과

로컬 dev 프로파일에서 실제 SMTP로 발송해 확인했다.

```
POST /api/auth/email/send
200 {"code":"OK","msg":"이메일 인증 코드가 발송되었습니다."}
발송 이후 EMAIL_SEND_FAILED · MessagingException 로그 없음
```

단위 테스트

```
SmtpMailSenderTest 2/2 통과
EmailVerificationServiceTest · PasswordResetServiceTest ·
WithdrawalCodeServiceTest · ListingStaleNoticeServiceTest 통과
```

렌더링은 데스크톱(1280px)과 모바일(375px) 모두 가로 넘침이 없고 한글도 정상 출력된다.

## 🔍 리뷰 포인트

**`MailSender` 인터페이스 시그니처를 그대로 뒀다.** `send(String to, String subject, String body)` 호출부가 5곳이고 그중 `ListingStaleNoticeService`는 상품 도메인 소유라, 인터페이스를 바꾸면 범위가 그쪽까지 번진다. 구현체만 교체했다.

**다만 이 선택에는 부작용이 하나 있다.** `setText(body, true)`로 바꾸면서 모든 발신이 HTML로 해석된다. 현재 `ListingStaleNoticeService`의 본문은 줄바꿈 없는 한 줄이고 `<`나 `&`도 없어 문제가 없지만, 앞으로 `\n`이 포함된 평문을 넘기면 줄바꿈이 무시된 채 한 줄로 붙는다.

**테스트에서 `saveChanges()`를 직접 호출한다.** `MimeMessage`의 Content-Type 헤더는 `saveChanges()` 시점에 기록되는데, 실제 발송에서는 `JavaMailSenderImpl`이 호출하지만 테스트는 `send`를 목으로 잡아 그 단계를 거치지 않는다. 호출하지 않으면 `getContentType()`이 `text/plain`으로 나온다.

**발송 시각을 본문에 넣었다.** Gmail은 같은 스레드에서 앞 메일과 겹치는 본문을 접는다. 템플릿이 고정이라 코드 숫자를 빼면 본문이 동일했고, 재발송 시 뒤에 온 메일의 코드가 접힌 영역으로 들어가 보이지 않았다. 매번 달라지는 값을 넣어 접힐 덩어리를 없앴다. 여러 통이 쌓였을 때 어느 것이 최신인지 구분하는 단서도 된다.

**스타일은 전부 인라인 속성이다.** 메일 클라이언트가 `<style>` 블록과 외부 CSS를 자주 제거한다. 같은 이유로 레이아웃 폭도 퍼센트가 아닌 px로 고정했다. `LAYOUT`은 `formatted()`로 값을 채우므로 HTML 안에 `%` 문자를 새로 넣을 경우 `%%`로 이스케이프해야 한다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 메일 관련 기술노트가 없어 해당 없음

## 참고

`VerificationMailSender`의 `CODE_TTL_MINUTES`는 메일 문구에 노출하는 값일 뿐이고, 실제 만료는 각 CodeStore의 `CODE_TTL`이 정한다. 현재는 둘 다 5분으로 일치한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 인증, 비밀번호 재설정, 회원 탈퇴 메일이 보기 쉬운 HTML 형식으로 제공됩니다.
  * 메일에 제목, 안내 문구, 인증 코드, 유효 시간(5분), 발송 시각이 표시됩니다.

* **개선**
  * UTF-8 인코딩을 지원해 다양한 언어의 메일 내용이 올바르게 표시됩니다.
  * 인증 코드 메일의 수신자와 제목 처리가 안정적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->