### PR TITLE
[fix] #329 인증 메일 발송 시각을 본문 마지막 줄로 이동

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/support/VerificationMailTemplate.java
@@ -7,9 +7,9 @@ import java.time.format.DateTimeFormatter;
 // 제거하므로 스타일을 전부 인라인 속성으로 둔다.
 public final class VerificationMailTemplate {
 
-    // 발송 시각 표기 — 재발송 시 본문이 통째로 같으면 Gmail이 뒤에 온 메일의 겹치는 부분을
-    // "..." 뒤로 접어 코드가 가려진다. 메일마다 달라지는 값을 넣어 접힐 덩어리를 없애고,
-    // 여러 통이 쌓였을 때 어느 것이 최신인지도 알 수 있게 한다.
+    // 발송 시각 표기 — Gmail은 같은 스레드에서 끝에서부터 겹치는 본문을 "..." 뒤로 접는다.
+    // 그래서 매번 달라지는 이 값을 본문 맨 마지막 줄에 두어 공통 꼬리 자체를 없앤다.
+    // 여러 통이 쌓였을 때 어느 것이 최신인지 알려주는 정보 역할도 한다.
     private static final DateTimeFormatter SENT_AT_FORMAT =
             DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
 
@@ -20,11 +20,12 @@ public final class VerificationMailTemplate {
                 <h1 style="margin:18px 0 0;font-size:20px;font-weight:800;color:#1A1A1F;">%s</h1>
                 <p style="margin:10px 0 0;font-size:14px;line-height:1.6;color:#5A5A62;">%s</p>
                 <div style="margin:24px 0;padding:18px;background-color:#FDEEF0;border-radius:11px;text-align:center;font-size:30px;font-weight:800;letter-spacing:6px;color:#C21414;">%s</div>
-                <p style="margin:0;font-size:13px;color:#8A8A92;">이 코드는 %d분 동안만 사용할 수 있습니다. (%s 발송)</p>
+                <p style="margin:0;font-size:13px;color:#8A8A92;">이 코드는 %d분 동안만 사용할 수 있습니다.</p>
                 <hr style="margin:24px 0 0;border:none;border-top:1px solid #EDEDF0;">
                 <p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#9A9AA2;">
                   본인이 요청하지 않았다면 이 메일을 무시하셔도 됩니다.<br>이 메일은 발신 전용입니다.
                 </p>
+                <p style="margin:10px 0 0;font-size:12px;color:#B4B4BC;">%s 발송</p>
               </div>
             </div>
             """;


### PR DESCRIPTION
## 📌 관련 이슈
- #329 후속 (#334 머지 이후 확인된 문제)

## ✨ 작업 내용

발송 시각을 유효시간 문구 괄호에서 본문 맨 마지막 줄로 옮긴다.

## 📸 스크린샷 / 테스트 결과

#334 머지본으로 실제 발송해 확인한 결과, 코드와 유효시간까지는 노출되지만 그 아래 안내 문구("본인이 요청하지 않았다면...", "이 메일은 발신 전용입니다")가 Gmail의 `...` 뒤로 접혔다.

Gmail은 같은 스레드에서 **끝에서부터** 겹치는 본문을 접는다. 발송 시각이 중간에 있으면 그 아래 두 줄이 모든 메일에서 동일해 공통 꼬리로 잡힌다.

시각을 마지막 줄로 내려 공통 꼬리를 없앴다. 수정 후 발송한 메일은 접힘 없이 전체가 노출된다.

`SmtpMailSenderTest` 통과, 컴파일 정상.

## 🔍 리뷰 포인트

정밀도가 아니라 위치 문제다. 발송 시각을 분 단위로 넣었는데도 접혔고, 접힌 구간은 시각 **아래** 문구였다. 초·밀리초를 추가해도 해결되지 않는다.

부수적으로 유효시간 문구에서 괄호가 빠져 읽기 쉬워졌다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 해당 없음