### PR TITLE
[Feature] #338 알림 문의 식별자 추가 및 워치리스트 등록 검증 강화

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminInquiryService.java
@@ -56,7 +56,7 @@ public class AdminInquiryService {
         InquiryStatus previousStatus = inquiry.getStatus();
         inquiry.changeStatus(status);
         if (previousStatus != InquiryStatus.HANDLED && status == InquiryStatus.HANDLED) {
-            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
+            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getId(), inquiry.getTitle());
         }
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
@@ -71,7 +71,7 @@ public class AdminInquiryService {
         boolean isFirstAnswer = inquiry.getAnswerContent() == null;
         inquiry.answer(content);
         if (isFirstAnswer) {
-            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getTitle());
+            notificationService.createInquiryHandledNotification(inquiry.getUserId(), inquiry.getId(), inquiry.getTitle());
         }
         List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(id).stream()
                 .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardVariantRepository.java
@@ -14,6 +14,13 @@ public interface CardVariantRepository extends JpaRepository<CardVariant, Long> 
     List<CardVariant> findByCardIdOrderByPrimaryDescVariantNameAsc(Long cardId);
 
     /**
+     * 요청으로 받은 variantId가 "그 카드에 실제로 속한" 변형인지 확인한다.
+     * existsById만으로는 부족하다 - watchlist.variant_id FK는 card_variants(id)만 참조하므로,
+     * 다른 카드의 변형 id를 보내도 DB 제약에 걸리지 않고 그대로 저장돼 버린다.
+     */
+    boolean existsByIdAndCardId(Long id, Long cardId);
+
+    /**
      * Scrydex 동기화 배치가 대표 판본 1개를 upsert할 때 쓰는 조회 - 현재 배치 스코프에서는 카드당
      * card_variants 행이 최대 1개뿐이므로 findByCardId 하나로 충분하다.
      */

--- a/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/dto/NotificationResponse.java
@@ -12,6 +12,7 @@ public record NotificationResponse(
         String message,
         Long cardId,
         String cardImageUrl,
+        Long inquiryId,
         boolean isRead,
         LocalDateTime createdAt
 ) {
@@ -25,6 +26,7 @@ public record NotificationResponse(
                 notification.getMessage(),
                 notification.getCardId(),
                 resolveImageUrl(card),
+                notification.getInquiryId(),
                 notification.isRead(),
                 notification.getCreatedAt()
         );

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/Notification.java
@@ -41,6 +41,11 @@ public class Notification {
     @Column(name = "card_id")
     private Long cardId;
 
+    // #338: 문의 처리 완료 알림에서 FE가 해당 문의로 바로 이동할 수 있도록 하는 참조 ID.
+    // cardId와 마찬가지로 관련 없는 알림 타입에서는 null이다.
+    @Column(name = "inquiry_id")
+    private Long inquiryId;
+
     @Column(name = "is_read", nullable = false)
     private boolean isRead;
 
@@ -49,11 +54,12 @@ public class Notification {
     private LocalDateTime createdAt;
 
     @Builder
-    public Notification(Long userId, NotificationType type, String message, Long cardId) {
+    public Notification(Long userId, NotificationType type, String message, Long cardId, Long inquiryId) {
         this.userId = userId;
         this.type = type;
         this.message = message;
         this.cardId = cardId;
+        this.inquiryId = inquiryId;
         this.isRead = false;
     }
 

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -150,11 +150,12 @@ public class NotificationService {
     // 커밋 전에 푸시하면 이후 같은 트랜잭션 안에서 다른 작업이 실패해 롤백되는 경우, 유저는 이미 알림을
     // 받았는데 문의 상태/알림 레코드는 존재하지 않는 불일치가 생긴다.
     @Transactional
-    public void createInquiryHandledNotification(Long userId, String inquiryTitle) {
+    public void createInquiryHandledNotification(Long userId, Long inquiryId, String inquiryTitle) {
         Notification notification = Notification.builder()
                 .userId(userId)
                 .type(NotificationType.INQUIRY_HANDLED)
                 .message(String.format("'%s' 문의가 처리 완료되었습니다.", inquiryTitle))
+                .inquiryId(inquiryId)
                 .build();
 
         notificationRepository.save(notification);

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistCreateRequest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.watchlist.dto;
 
+import com.pokade.domain.watchlist.entity.Watchlist;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
@@ -10,9 +12,11 @@ public record WatchlistCreateRequest(
         Long variantId,
 
         @Positive(message = "targetBuyPrice는 0보다 커야 합니다.")
+        @Max(value = Watchlist.MAX_TARGET_PRICE, message = "목표가는 1억원을 초과할 수 없습니다.")
         Integer targetBuyPrice,
 
         @Positive(message = "targetSellPrice는 0보다 커야 합니다.")
+        @Max(value = Watchlist.MAX_TARGET_PRICE, message = "목표가는 1억원을 초과할 수 없습니다.")
         Integer targetSellPrice
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/dto/WatchlistUpdateRequest.java
@@ -1,12 +1,16 @@
 package com.pokade.domain.watchlist.dto;
 
+import com.pokade.domain.watchlist.entity.Watchlist;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Positive;
 
 public record WatchlistUpdateRequest(
         @Positive(message = "targetBuyPrice는 0보다 커야 합니다.")
+        @Max(value = Watchlist.MAX_TARGET_PRICE, message = "목표가는 1억원을 초과할 수 없습니다.")
         Integer targetBuyPrice,
 
         @Positive(message = "targetSellPrice는 0보다 커야 합니다.")
+        @Max(value = Watchlist.MAX_TARGET_PRICE, message = "목표가는 1억원을 초과할 수 없습니다.")
         Integer targetSellPrice,
 
         // null/false 둘 다 "재알림 요청 없음"으로 취급 - Boolean.TRUE.equals()로 체크할 것(원시 boolean 언박싱 NPE 방지)

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Watchlist {
 
+    // #238: 목표가 상한. DTO의 @Max와 같은 값을 두 군데 적지 않도록 도메인 엔티티에 단일 정의한다.
+    public static final int MAX_TARGET_PRICE = 100_000_000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -94,8 +97,8 @@ public class Watchlist {
     // null로 온 필드는 "값을 지운다"가 아니라 "기존 값 유지"로 해석한다 - 부분 업데이트를 지원하기
     // 위함. 두 필드를 한꺼번에 지우는 기능은 없음(전체 삭제는 DELETE로만 가능).
     public void updateTargetPrices(Integer targetBuyPrice, Integer targetSellPrice) {
-        Integer resolvedBuyPrice = targetBuyPrice != null ? targetBuyPrice : this.targetBuyPrice;
-        Integer resolvedSellPrice = targetSellPrice != null ? targetSellPrice : this.targetSellPrice;
+        Integer resolvedBuyPrice = resolveUpdatedPrice(targetBuyPrice, this.targetBuyPrice);
+        Integer resolvedSellPrice = resolveUpdatedPrice(targetSellPrice, this.targetSellPrice);
         // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
         // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
         boolean changed = !Objects.equals(this.targetBuyPrice, resolvedBuyPrice)
@@ -105,5 +108,12 @@ public class Watchlist {
         if (changed) {
             resetNotification();
         }
+    }
+
+    // 위 "null = 기존 값 유지" 규칙을 밖에서도 쓸 수 있게 노출한다(#238) - WatchlistService가 수정 요청을
+    // 반영하기 "전에" 최종 목표가 조합을 미리 계산해 역전 여부를 검증하는데, 그 계산이 여기 규칙과
+    // 어긋나면 검증을 통과한 값과 실제 저장되는 값이 달라진다.
+    public static Integer resolveUpdatedPrice(Integer requested, Integer current) {
+        return requested != null ? requested : current;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/entity/Watchlist.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.watchlist.entity;
 
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -94,26 +96,45 @@ public class Watchlist {
         this.isNotified = false;
     }
 
-    // null로 온 필드는 "값을 지운다"가 아니라 "기존 값 유지"로 해석한다 - 부분 업데이트를 지원하기
-    // 위함. 두 필드를 한꺼번에 지우는 기능은 없음(전체 삭제는 DELETE로만 가능).
+    // 안 보낸 필드(null)는 "기존 값 유지"로 해석한다. 목표가를 "지우는" 기능은 없다 - 한쪽만 지우는 것도,
+    // 두 필드를 한꺼번에 지우는 것도 지원하지 않는다(관심 자체를 없애려면 DELETE). 그래서 null은 언제나
+    // "변경 없음"이지 "삭제"가 아니다.
     public void updateTargetPrices(Integer targetBuyPrice, Integer targetSellPrice) {
         Integer resolvedBuyPrice = resolveUpdatedPrice(targetBuyPrice, this.targetBuyPrice);
         Integer resolvedSellPrice = resolveUpdatedPrice(targetSellPrice, this.targetSellPrice);
-        // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
-        // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
         boolean changed = !Objects.equals(this.targetBuyPrice, resolvedBuyPrice)
                 || !Objects.equals(this.targetSellPrice, resolvedSellPrice);
+
+        // 역전 검증은 "값이 실제로 바뀔 때"만 한다. 요청에 가격 필드가 왔는지로 판정하면, 기존과 똑같은
+        // 값을 되보내는 no-op 수정이 검증에 걸려서 - 이 검증이 생기기 전에 저장된 역전 데이터를 가진
+        // 사용자가 재알림조차 못 받게 된다(가격을 안 보내면 통과, 같은 값을 보내면 차단이라는 불일치).
+        if (changed) {
+            validateTargetPriceOrder(resolvedBuyPrice, resolvedSellPrice);
+        }
+
         this.targetBuyPrice = resolvedBuyPrice;
         this.targetSellPrice = resolvedSellPrice;
+        // 목표가가 실제로 바뀐 경우에만 isNotified를 리셋한다 - 이미 알림이 간 목표가를 그대로 재저장하는
+        // no-op 수정에서는 배치가 불필요하게 재알림을 보내지 않도록 한다.
         if (changed) {
             resetNotification();
         }
     }
 
-    // 위 "null = 기존 값 유지" 규칙을 밖에서도 쓸 수 있게 노출한다(#238) - WatchlistService가 수정 요청을
-    // 반영하기 "전에" 최종 목표가 조합을 미리 계산해 역전 여부를 검증하는데, 그 계산이 여기 규칙과
-    // 어긋나면 검증을 통과한 값과 실제 저장되는 값이 달라진다.
-    public static Integer resolveUpdatedPrice(Integer requested, Integer current) {
+    // #238: 목표 구매가가 판매가 이상이면 두 목표가가 한 체결가에 동시에 걸려 알림이 의미를 잃는다.
+    // 한쪽만 설정된 경우는 애초에 역전이 성립하지 않으므로 통과시킨다.
+    // 등록 경로(WatchlistService.addWatchlist)는 빌더로 새 인스턴스를 만들어 updateTargetPrices()를
+    // 거치지 않으므로, 같은 규칙을 쓰도록 이 메서드를 직접 호출한다.
+    public static void validateTargetPriceOrder(Integer targetBuyPrice, Integer targetSellPrice) {
+        if (targetBuyPrice == null || targetSellPrice == null) {
+            return;
+        }
+        if (targetBuyPrice >= targetSellPrice) {
+            throw new BusinessException(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+        }
+    }
+
+    private static Integer resolveUpdatedPrice(Integer requested, Integer current) {
         return requested != null ? requested : current;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -90,28 +90,35 @@ public class WatchlistService {
                 .targetSellPrice(request.targetSellPrice())
                 .build();
 
+        // catch 범위는 저장 한 줄로 좁혀 둔다. 예전에는 아래 시세 조회·알림 생성까지 같은 try 안에 있어서,
+        // 알림 쪽에서 난 무결성 오류까지 "이미 등록된 카드입니다"로 뒤집어씌워졌다(워치리스트는 이미
+        // 저장에 성공했는데도) - 오분류를 막으려면 변환 대상 구간이 딱 저장이어야 한다.
         // 위 잠금으로 정상 경로에서는 걸릴 일이 없지만, 방어적으로 DB UNIQUE 제약 위반도 안전하게 변환한다.
         // 카드/변형 존재 여부는 위에서 먼저 검증하므로 여기 남는 건 사실상 UNIQUE(user_id, card_id) 위반이다.
+        // save()만으로 충분한 이유: id가 IDENTITY라 Hibernate가 키를 받으려고 INSERT를 즉시 실행하고,
+        // UNIQUE 제약도 DEFERRABLE이 아니라 그 문장에서 바로 검사된다(커밋까지 미뤄지지 않는다).
+        // 생성 전략을 SEQUENCE로 바꾸면 위반이 커밋 시점으로 밀려 이 catch를 빠져나가므로 saveAndFlush가 필요해진다.
+        Watchlist saved;
         try {
-            Watchlist saved = watchlistRepository.save(watchlist);
-
-            // TODO(#275): updateWatchlist()/getWatchlist()와 같은 원인(전체 기간 range 사용)을 공유하지만,
-            // "등록 시점에 이미 도달이면 배치를 기다리지 않고 즉시 알림"이라는 의도된 최적화(아래 주석)와
-            // 상충할 수 있어 이번엔 범위에서 제외함 - 등록 이후 스코프로 바꿀지는 별도 논의 필요.
-            PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
-                    .findPriceRangesByCardIds(List.of(saved.getCardId()), null, TradeStatus.COMPLETED)
-                    .stream()
-                    .findFirst()
-                    .orElse(null);
-            Integer reachedTargetPrice = watchlistTargetPriceEvaluator.resolveReachedTargetPrice(saved, range);
-            boolean targetReached = reachedTargetPrice != null;
-            // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
-            // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
-            watchlistTargetPriceEvaluator.notifyIfNewlyReached(saved, reachedTargetPrice);
-            return WatchlistResponse.of(saved, targetReached);
+            saved = watchlistRepository.save(watchlist);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
+
+        // TODO(#275): updateWatchlist()/getWatchlist()와 같은 원인(전체 기간 range 사용)을 공유하지만,
+        // "등록 시점에 이미 도달이면 배치를 기다리지 않고 즉시 알림"이라는 의도된 최적화(아래 주석)와
+        // 상충할 수 있어 이번엔 범위에서 제외함 - 등록 이후 스코프로 바꿀지는 별도 논의 필요.
+        PriceTradeStatsRepository.CardPriceRangeView range = priceTradeStatsRepository
+                .findPriceRangesByCardIds(List.of(saved.getCardId()), null, TradeStatus.COMPLETED)
+                .stream()
+                .findFirst()
+                .orElse(null);
+        Integer reachedTargetPrice = watchlistTargetPriceEvaluator.resolveReachedTargetPrice(saved, range);
+        boolean targetReached = reachedTargetPrice != null;
+        // 등록 시점에 이미 목표가 범위 안이면 배치(최대 1시간 지연)를 기다리지 않고 바로 알림 처리한다 -
+        // 화면은 "도달"인데 실제 알림은 한참 뒤에 오는 시차, 그리고 알림 자체가 생성 안 되는 누락을 없애기 위함.
+        watchlistTargetPriceEvaluator.notifyIfNewlyReached(saved, reachedTargetPrice);
+        return WatchlistResponse.of(saved, targetReached);
     }
 
     public List<WatchlistResponse> getWatchlist(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -54,6 +54,13 @@ public class WatchlistService {
         // 트랜잭션 종료까지 직렬화한다(다른 유저는 영향 없음).
         watchlistRepository.acquireUserLock(userId);
 
+        // SEC-B1: 존재하지 않는 카드는 여기서 걸러낸다. 이 검증이 없으면 저장 시점에 card_id FK 위반으로
+        // DataIntegrityViolationException이 나고, 아래 catch가 그걸 UNIQUE 위반과 구분하지 못해
+        // "이미 등록된 카드입니다"라는 엉뚱한 원인을 안내하게 된다(ListingService.getOrderbook()과 동일한 패턴).
+        if (!cardRepository.existsById(request.cardId())) {
+            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+        }
+
         if (watchlistRepository.existsByUserIdAndCardId(userId, request.cardId())) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
@@ -73,6 +80,8 @@ public class WatchlistService {
                 .build();
 
         // 위 잠금으로 정상 경로에서는 걸릴 일이 없지만, 방어적으로 DB UNIQUE 제약 위반도 안전하게 변환한다.
+        // 카드 존재 여부는 위에서 먼저 검증하므로 여기 남는 건 사실상 UNIQUE(user_id, card_id) 위반이다.
+        // (variant_id FK 위반은 아직 이 catch로 흡수되어 DUPLICATE_WATCHLIST로 보고된다 - 별도 이슈)
         try {
             Watchlist saved = watchlistRepository.save(watchlist);
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -62,6 +62,8 @@ public class WatchlistService {
             throw new BusinessException(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
         }
 
+        validateTargetPriceOrder(request.targetBuyPrice(), request.targetSellPrice());
+
         Watchlist watchlist = Watchlist.builder()
                 .userId(userId)
                 .cardId(request.cardId())
@@ -152,6 +154,16 @@ public class WatchlistService {
         Watchlist watchlist = watchlistRepository.findByIdAndUserId(watchlistId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
 
+        // 부분 수정이라 요청 값만 봐서는 역전을 못 잡는다 - 구매가만 올려 보내도 "기존 판매가"와 엮여
+        // 역전될 수 있으므로, updateTargetPrices()와 같은 규칙으로 최종 조합을 먼저 계산해 검증한다.
+        // 가격을 하나도 안 보낸 요청(재알림 전용)은 건드리지 않고 넘긴다 - 이번 검증이 생기기 전에
+        // 저장된 역전 데이터가 있어도 재알림 요청까지 막히지는 않게 한다.
+        if (request.targetBuyPrice() != null || request.targetSellPrice() != null) {
+            validateTargetPriceOrder(
+                    Watchlist.resolveUpdatedPrice(request.targetBuyPrice(), watchlist.getTargetBuyPrice()),
+                    Watchlist.resolveUpdatedPrice(request.targetSellPrice(), watchlist.getTargetSellPrice()));
+        }
+
         watchlist.updateTargetPrices(request.targetBuyPrice(), request.targetSellPrice());
         if (resend) {
             watchlist.requestNotificationAgain();
@@ -170,6 +182,17 @@ public class WatchlistService {
         boolean targetReached = reachedTargetPrice != null;
         watchlistTargetPriceEvaluator.notifyIfNewlyReached(watchlist, reachedTargetPrice);
         return WatchlistResponse.of(watchlist, targetReached);
+    }
+
+    // #238: 목표 구매가가 판매가 이상이면 두 목표가가 한 체결가에 동시에 걸려 알림이 의미를 잃는다.
+    // 한쪽만 설정된 경우는 애초에 역전이 성립하지 않으므로 통과시킨다.
+    private void validateTargetPriceOrder(Integer targetBuyPrice, Integer targetSellPrice) {
+        if (targetBuyPrice == null || targetSellPrice == null) {
+            return;
+        }
+        if (targetBuyPrice >= targetSellPrice) {
+            throw new BusinessException(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+        }
     }
 
     private void validateAtLeastOneTargetPrice(Integer targetBuyPrice, Integer targetSellPrice) {

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -65,7 +65,10 @@ public class WatchlistService {
 
         // card_id와 같은 이유로 variant_id FK 위반도 미리 걸러낸다. variantId가 null인 건 "대표 변형 기준"이라는
         // 정상 입력이므로(WatchlistVariantResolver 참고) 값이 있을 때만 검증한다.
-        if (request.variantId() != null && !cardVariantRepository.existsById(request.variantId())) {
+        // 존재 여부만이 아니라 "이 카드의 변형인지"까지 본다 - FK는 card_variants(id)만 참조해서 다른 카드의
+        // 변형 id를 보내면 제약에 걸리지 않고 그대로 저장되기 때문이다(오분류가 아니라 잘못된 데이터가 남는 문제).
+        if (request.variantId() != null
+                && !cardVariantRepository.existsByIdAndCardId(request.variantId(), request.cardId())) {
             throw new BusinessException(ErrorCode.VARIANT_NOT_FOUND);
         }
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
@@ -40,6 +41,7 @@ public class WatchlistService {
     private final WatchlistRepository watchlistRepository;
     private final PriceService priceService;
     private final CardRepository cardRepository;
+    private final CardVariantRepository cardVariantRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
     private final CardNameKoResolver cardNameKoResolver;
     private final WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator;
@@ -61,6 +63,12 @@ public class WatchlistService {
             throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
         }
 
+        // card_id와 같은 이유로 variant_id FK 위반도 미리 걸러낸다. variantId가 null인 건 "대표 변형 기준"이라는
+        // 정상 입력이므로(WatchlistVariantResolver 참고) 값이 있을 때만 검증한다.
+        if (request.variantId() != null && !cardVariantRepository.existsById(request.variantId())) {
+            throw new BusinessException(ErrorCode.VARIANT_NOT_FOUND);
+        }
+
         if (watchlistRepository.existsByUserIdAndCardId(userId, request.cardId())) {
             throw new BusinessException(ErrorCode.DUPLICATE_WATCHLIST);
         }
@@ -80,8 +88,7 @@ public class WatchlistService {
                 .build();
 
         // 위 잠금으로 정상 경로에서는 걸릴 일이 없지만, 방어적으로 DB UNIQUE 제약 위반도 안전하게 변환한다.
-        // 카드 존재 여부는 위에서 먼저 검증하므로 여기 남는 건 사실상 UNIQUE(user_id, card_id) 위반이다.
-        // (variant_id FK 위반은 아직 이 catch로 흡수되어 DUPLICATE_WATCHLIST로 보고된다 - 별도 이슈)
+        // 카드/변형 존재 여부는 위에서 먼저 검증하므로 여기 남는 건 사실상 UNIQUE(user_id, card_id) 위반이다.
         try {
             Watchlist saved = watchlistRepository.save(watchlist);
 

--- a/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
+++ b/Pokade/src/main/java/com/pokade/domain/watchlist/service/WatchlistService.java
@@ -80,7 +80,7 @@ public class WatchlistService {
             throw new BusinessException(ErrorCode.WATCHLIST_LIMIT_EXCEEDED);
         }
 
-        validateTargetPriceOrder(request.targetBuyPrice(), request.targetSellPrice());
+        Watchlist.validateTargetPriceOrder(request.targetBuyPrice(), request.targetSellPrice());
 
         Watchlist watchlist = Watchlist.builder()
                 .userId(userId)
@@ -173,16 +173,9 @@ public class WatchlistService {
         Watchlist watchlist = watchlistRepository.findByIdAndUserId(watchlistId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.WATCHLIST_NOT_FOUND));
 
-        // 부분 수정이라 요청 값만 봐서는 역전을 못 잡는다 - 구매가만 올려 보내도 "기존 판매가"와 엮여
-        // 역전될 수 있으므로, updateTargetPrices()와 같은 규칙으로 최종 조합을 먼저 계산해 검증한다.
-        // 가격을 하나도 안 보낸 요청(재알림 전용)은 건드리지 않고 넘긴다 - 이번 검증이 생기기 전에
-        // 저장된 역전 데이터가 있어도 재알림 요청까지 막히지는 않게 한다.
-        if (request.targetBuyPrice() != null || request.targetSellPrice() != null) {
-            validateTargetPriceOrder(
-                    Watchlist.resolveUpdatedPrice(request.targetBuyPrice(), watchlist.getTargetBuyPrice()),
-                    Watchlist.resolveUpdatedPrice(request.targetSellPrice(), watchlist.getTargetSellPrice()));
-        }
-
+        // 역전 검증은 updateTargetPrices() 안에서 "값이 실제로 바뀔 때"만 수행된다 - 부분 수정이라
+        // 요청 값만 봐서는 역전을 못 잡고(구매가만 올려 보내도 기존 판매가와 엮여 역전될 수 있다),
+        // 최종 조합과 변경 여부를 아는 곳이 엔티티뿐이라 판정을 그쪽으로 합쳤다.
         watchlist.updateTargetPrices(request.targetBuyPrice(), request.targetSellPrice());
         if (resend) {
             watchlist.requestNotificationAgain();
@@ -201,17 +194,6 @@ public class WatchlistService {
         boolean targetReached = reachedTargetPrice != null;
         watchlistTargetPriceEvaluator.notifyIfNewlyReached(watchlist, reachedTargetPrice);
         return WatchlistResponse.of(watchlist, targetReached);
-    }
-
-    // #238: 목표 구매가가 판매가 이상이면 두 목표가가 한 체결가에 동시에 걸려 알림이 의미를 잃는다.
-    // 한쪽만 설정된 경우는 애초에 역전이 성립하지 않으므로 통과시킨다.
-    private void validateTargetPriceOrder(Integer targetBuyPrice, Integer targetSellPrice) {
-        if (targetBuyPrice == null || targetSellPrice == null) {
-            return;
-        }
-        if (targetBuyPrice >= targetSellPrice) {
-            throw new BusinessException(ErrorCode.INVALID_TARGET_PRICE_RANGE);
-        }
     }
 
     private void validateAtLeastOneTargetPrice(Integer targetBuyPrice, Integer targetSellPrice) {

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -90,6 +90,7 @@ public enum ErrorCode {
     DUPLICATE_WATCHLIST(HttpStatus.CONFLICT, "이미 등록된 카드입니다."),
     TARGET_PRICE_REQUIRED(HttpStatus.BAD_REQUEST, "목표 구매가 또는 판매가 중 하나는 입력해야 합니다."),
     WATCHLIST_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "워치리스트는 최대 20개까지 등록할 수 있습니다."),
+    INVALID_TARGET_PRICE_RANGE(HttpStatus.BAD_REQUEST, "목표 구매가는 목표 판매가보다 낮아야 합니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "이미 읽음 처리된 알림입니다."),
 
     // ===== 포트폴리오 =====

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "카드를 찾을 수 없습니다."),
     GRADE_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "진단 결과를 찾을 수 없습니다."),
     PRIMARY_VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 변형이 지정되지 않은 카드입니다."),
+    VARIANT_NOT_FOUND(HttpStatus.NOT_FOUND, "카드 변형을 찾을 수 없습니다."),
     WATCHLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "워치리스트 항목을 찾을 수 없습니다."),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),

--- a/Pokade/src/main/resources/db/migration/V12__add_inquiry_id_to_notifications.sql
+++ b/Pokade/src/main/resources/db/migration/V12__add_inquiry_id_to_notifications.sql
@@ -1,0 +1,4 @@
+-- 문의 처리 완료 알림(INQUIRY_HANDLED)을 클릭했을 때 "내 문의 목록"이 아니라 해당 문의로 바로
+-- 앵커할 수 있도록 참조 문의 ID를 보관한다(#338).
+-- card_id와 동일한 성격의 "알림 클릭 시 이동 대상" 선택 컬럼으로, 문의와 무관한 알림은 NULL이다.
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS inquiry_id BIGINT REFERENCES inquiries(id);

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminInquiryServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -109,6 +110,7 @@ class AdminInquiryServiceTest {
     @DisplayName("상태를 변경하면 엔티티에 반영되고 변경된 상태로 응답한다")
     void updateStatus_changesStatus() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        ReflectionTestUtils.setField(inquiry, "id", 7L);
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
         given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
 
@@ -116,7 +118,7 @@ class AdminInquiryServiceTest {
 
         assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
         assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
-        then(notificationService).should().createInquiryHandledNotification(1L, "제목");
+        then(notificationService).should().createInquiryHandledNotification(1L, 7L, "제목");
     }
 
     @Test
@@ -129,7 +131,7 @@ class AdminInquiryServiceTest {
 
         adminInquiryService.updateStatus(1L, InquiryStatus.HANDLED);
 
-        then(notificationService).should(never()).createInquiryHandledNotification(any(), any());
+        then(notificationService).should(never()).createInquiryHandledNotification(any(), any(), any());
     }
 
     @Test
@@ -143,7 +145,7 @@ class AdminInquiryServiceTest {
         InquiryResponse response = adminInquiryService.updateStatus(1L, InquiryStatus.UNHANDLED);
 
         assertThat(response.status()).isEqualTo(InquiryStatus.UNHANDLED);
-        then(notificationService).should(never()).createInquiryHandledNotification(any(), any());
+        then(notificationService).should(never()).createInquiryHandledNotification(any(), any(), any());
     }
 
     @Test
@@ -160,6 +162,7 @@ class AdminInquiryServiceTest {
     @DisplayName("답변을 등록하면 답변 내용/시각이 저장되고 상태가 HANDLED로 전환된다")
     void answerInquiry_savesAnswerAndMarksHandled() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        ReflectionTestUtils.setField(inquiry, "id", 7L);
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
         given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
 
@@ -169,13 +172,14 @@ class AdminInquiryServiceTest {
         assertThat(response.answeredAt()).isNotNull();
         assertThat(response.status()).isEqualTo(InquiryStatus.HANDLED);
         assertThat(inquiry.getStatus()).isEqualTo(InquiryStatus.HANDLED);
-        then(notificationService).should().createInquiryHandledNotification(1L, "제목");
+        then(notificationService).should().createInquiryHandledNotification(1L, 7L, "제목");
     }
 
     @Test
     @DisplayName("이미 답변한 문의를 다시 답변(수정)해도 답변 내용/시각만 갱신되고 알림은 최초 1회만 보낸다")
     void answerInquiry_updatesExistingAnswer() {
         Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        ReflectionTestUtils.setField(inquiry, "id", 7L);
         given(inquiryRepository.findById(1L)).willReturn(Optional.of(inquiry));
         given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(1L)).willReturn(List.of());
         adminInquiryService.answerInquiry(1L, "첫 답변");
@@ -183,7 +187,7 @@ class AdminInquiryServiceTest {
         InquiryResponse response = adminInquiryService.answerInquiry(1L, "수정된 답변");
 
         assertThat(response.answerContent()).isEqualTo("수정된 답변");
-        then(notificationService).should(times(1)).createInquiryHandledNotification(1L, "제목");
+        then(notificationService).should(times(1)).createInquiryHandledNotification(1L, 7L, "제목");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardVariantRepositoryTest.java
@@ -83,6 +83,26 @@ class CardVariantRepositoryTest extends AbstractIntegrationTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("t2-1 existsByIdAndCardId는 그 카드에 속한 변형만 true, 다른 카드의 변형이면 false다")
+    void t2_1() {
+        Card otherCard = Card.builder().name("Blastoise").build();
+        entityManager.persist(otherCard);
+        persistVariant(otherCard, "holofoil", true);
+        entityManager.flush();
+
+        CardVariant mine = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(multiVariantCard.getId()).get(0);
+        CardVariant others = cardVariantRepository
+                .findByCardIdOrderByPrimaryDescVariantNameAsc(otherCard.getId()).get(0);
+
+        assertThat(cardVariantRepository.existsByIdAndCardId(mine.getId(), multiVariantCard.getId())).isTrue();
+        // 존재하지만 다른 카드의 변형 - existsById였다면 true였을 조합이다.
+        assertThat(cardVariantRepository.existsByIdAndCardId(others.getId(), multiVariantCard.getId())).isFalse();
+        // 아예 존재하지 않는 변형
+        assertThat(cardVariantRepository.existsByIdAndCardId(999_999L, multiVariantCard.getId())).isFalse();
+    }
+
     private Long persistSeller(String email) {
         return ((Number) entityManager.createNativeQuery(
                         "INSERT INTO users (email, nickname, provider, role, status) "

--- a/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/controller/NotificationControllerTest.java
@@ -100,7 +100,7 @@ class NotificationControllerTest {
     @Test
     void 목록_조회에_성공하면_200과_페이지를_반환한다() throws Exception {
         NotificationResponse response = new NotificationResponse(
-                1L, NotificationType.PRICE_TARGET, "메시지", 10L, "medium.png", false, LocalDateTime.now());
+                1L, NotificationType.PRICE_TARGET, "메시지", 10L, "medium.png", null, false, LocalDateTime.now());
 
         given(notificationService.getNotifications(eq(100L), any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1));

--- a/Pokade/src/test/java/com/pokade/domain/notification/dto/NotificationResponseTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/dto/NotificationResponseTest.java
@@ -25,6 +25,17 @@ class NotificationResponseTest {
     }
 
     @Test
+    @DisplayName("of: 알림의 inquiryId를 그대로 응답에 노출하고, 없는 알림은 null이다")
+    void of_exposesInquiryId() {
+        Notification inquiryHandled = Notification.builder()
+                .userId(1L).type(NotificationType.INQUIRY_HANDLED).message("메시지").inquiryId(7L)
+                .build();
+
+        assertThat(NotificationResponse.of(inquiryHandled, null).inquiryId()).isEqualTo(7L);
+        assertThat(NotificationResponse.of(notification(), null).inquiryId()).isNull();
+    }
+
+    @Test
     @DisplayName("of: imageMedium이 있으면 imageMedium을 cardImageUrl로 쓴다")
     void of_prefersImageMedium() {
         Card card = Card.builder().id(10L).name("리자몽").imageSmall("small.png").imageMedium("medium.png").build();

--- a/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/repository/NotificationRepositoryTest.java
@@ -2,12 +2,12 @@ package com.pokade.domain.notification.repository;
 
 import com.pokade.domain.notification.entity.Notification;
 import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.support.AbstractIntegrationTest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -19,8 +19,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class NotificationRepositoryTest {
+class NotificationRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     private NotificationRepository notificationRepository;
@@ -218,6 +217,29 @@ class NotificationRepositoryTest {
         entityManager.clear();
     }
 
+    @Test
+    void 문의_처리_완료_알림은_inquiry_id_컬럼에_참조_문의를_저장하고_그대로_조회된다() {
+        Long userId = insertUser("inquiry@test.com");
+        Long inquiryId = insertInquiry(userId);
+
+        Notification saved = notificationRepository.save(
+                Notification.builder()
+                        .userId(userId)
+                        .type(NotificationType.INQUIRY_HANDLED)
+                        .message("'제목' 문의가 처리 완료되었습니다.")
+                        .inquiryId(inquiryId)
+                        .build()
+        );
+        entityManager.flush();
+        entityManager.clear();
+
+        Optional<Notification> found = notificationRepository.findById(saved.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getInquiryId()).isEqualTo(inquiryId);
+        assertThat(found.get().getCardId()).isNull();
+    }
+
     private Notification saveNotification(Long userId, NotificationType type, String message) {
         Notification saved = notificationRepository.save(
                 Notification.builder()
@@ -228,6 +250,14 @@ class NotificationRepositoryTest {
         );
         entityManager.flush();
         return saved;
+    }
+
+    private Long insertInquiry(Long userId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO inquiries (user_id, category, status, title, content) "
+                                + "VALUES (:userId, 'ETC', 'HANDLED', '제목', '내용') RETURNING id")
+                .setParameter("userId", userId)
+                .getSingleResult()).longValue();
     }
 
     private Long insertUser(String email) {

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -294,7 +294,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("문의 처리 완료 알림 생성: INQUIRY_HANDLED 타입으로 저장하고, 커밋 이후 푸시를 위한 이벤트를 발행한다")
     void createInquiryHandledNotification_savesAndPublishesEvent() {
-        notificationService.createInquiryHandledNotification(1L, "결제 문의");
+        notificationService.createInquiryHandledNotification(1L, 7L, "결제 문의");
 
         ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
         then(notificationRepository).should().save(notificationCaptor.capture());
@@ -303,11 +303,13 @@ class NotificationServiceTest {
         assertThat(saved.getType()).isEqualTo(NotificationType.INQUIRY_HANDLED);
         assertThat(saved.getMessage()).contains("결제 문의");
         assertThat(saved.getCardId()).isNull();
+        assertThat(saved.getInquiryId()).isEqualTo(7L);
 
         ArgumentCaptor<NotificationPushEvent> eventCaptor = ArgumentCaptor.forClass(NotificationPushEvent.class);
         then(eventPublisher).should().publishEvent(eventCaptor.capture());
         assertThat(eventCaptor.getValue().userId()).isEqualTo(1L);
         assertThat(eventCaptor.getValue().response().type()).isEqualTo(NotificationType.INQUIRY_HANDLED);
+        assertThat(eventCaptor.getValue().response().inquiryId()).isEqualTo(7L);
 
         // 이벤트 발행 시점엔 아직 커밋 전이므로, 이 메서드 자체는 Emitter로 직접 전송하지 않는다.
         then(sseEmitterStore).should(never()).findByUserId(any());
@@ -317,7 +319,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 있으면 notification 이벤트를 전송한다")
     void onNotificationPush_pushes_to_subscriber() throws Exception {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, 7L, false, null);
         SseEmitter emitter = mock(SseEmitter.class);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of(emitter));
 
@@ -329,7 +331,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("onNotificationPush: 구독 중인 Emitter가 없으면 예외 없이 조용히 스킵된다")
     void onNotificationPush_no_subscriber_noop() {
-        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, false, null);
+        NotificationResponse response = new NotificationResponse(1L, NotificationType.INQUIRY_HANDLED, "메시지", null, null, 7L, false, null);
         given(sseEmitterStore.findByUserId(1L)).willReturn(List.of());
 
         assertThatCode(() -> notificationService.onNotificationPush(new NotificationPushEvent(1L, response)))

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/controller/WatchlistControllerTest.java
@@ -43,6 +43,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -127,6 +129,66 @@ class WatchlistControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("TARGET_PRICE_REQUIRED"));
+    }
+
+    @Test
+    void 등록시_목표가가_상한_1억원을_넘으면_400을_반환하고_서비스를_호출하지_않는다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 100_000_001, null);
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.msg").value("targetBuyPrice: 목표가는 1억원을 초과할 수 없습니다."));
+
+        then(watchlistService).should(never()).addWatchlist(anyLong(), any(WatchlistCreateRequest.class));
+    }
+
+    @Test
+    void 등록시_목표가가_상한_1억원_정확히면_통과한다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 100_000_000, null);
+
+        given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
+                .willReturn(new WatchlistResponse(
+                        1L, 1L, null, "피카츄", null, "기본팩", "image.png", 100_000_000, null, false, LocalDateTime.now(), null, null, false));
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 수정시_목표가가_상한_1억원을_넘으면_400을_반환하고_서비스를_호출하지_않는다() throws Exception {
+        WatchlistUpdateRequest request = new WatchlistUpdateRequest(null, 100_000_001, null);
+
+        mockMvc.perform(patch("/api/watchlist/1")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.msg").value("targetSellPrice: 목표가는 1억원을 초과할 수 없습니다."));
+
+        then(watchlistService).should(never()).updateWatchlist(anyLong(), anyLong(), any(WatchlistUpdateRequest.class));
+    }
+
+    @Test
+    void 목표가_역전_조합이면_400과_INVALID_TARGET_PRICE_RANGE를_반환한다() throws Exception {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 5000, 3000);
+
+        given(watchlistService.addWatchlist(anyLong(), any(WatchlistCreateRequest.class)))
+                .willThrow(new BusinessException(ErrorCode.INVALID_TARGET_PRICE_RANGE));
+
+        mockMvc.perform(post("/api/watchlist")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_TARGET_PRICE_RANGE"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
@@ -64,7 +65,8 @@ class WatchlistConcurrencyTest {
         WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator =
                 new WatchlistTargetPriceEvaluator(watchlistRepository, cardRepository, notificationService, cardNameKoResolver);
         return new WatchlistService(watchlistRepository, mock(PriceService.class),
-                cardRepository, mock(PriceTradeStatsRepository.class), cardNameKoResolver, watchlistTargetPriceEvaluator);
+                cardRepository, mock(CardVariantRepository.class), mock(PriceTradeStatsRepository.class),
+                cardNameKoResolver, watchlistTargetPriceEvaluator);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistConcurrencyTest.java
@@ -31,11 +31,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
 // WatchlistService.addWatchlist()의 동시 등록 방어(유저 단위 잠금 + UNIQUE 위반 변환)를 실제 DB로 검증한다.
 // 여기서 검증하는 중복/제한 체크는 targetReached(체결가 조회) 결과와 무관하고, mock인 PriceTradeStatsRepository는
-// 기본값(빈 리스트)만 반환해 항상 targetReached=false로 끝나므로(CardRepository/NotificationService 호출 없음)
+// 기본값(빈 리스트)만 반환해 항상 targetReached=false로 끝나므로(NotificationService 호출 없음 - CardRepository는
+// SEC-B1 존재 검증 때문에 호출되므로 아래에서 existsById만 스텁한다)
 // WatchlistRepository만 진짜로 연결하고 나머지는 mock으로 채운 WatchlistService를 직접 생성해 사용한다.
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -52,6 +55,10 @@ class WatchlistConcurrencyTest {
 
     private WatchlistService newWatchlistService() {
         CardRepository cardRepository = mock(CardRepository.class);
+        // SEC-B1로 addWatchlist()가 카드 존재 여부를 먼저 확인하게 됐다. 이 테스트는 카드를 native SQL로
+        // 직접 넣고 CardRepository는 mock으로 두므로, 존재 검증만 통과시켜 원래 검증 대상(동시 등록 방어)에
+        // 도달하게 한다.
+        given(cardRepository.existsById(any())).willReturn(true);
         CardNameKoResolver cardNameKoResolver = mock(CardNameKoResolver.class);
         NotificationService notificationService = mock(NotificationService.class);
         WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator =

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -344,6 +344,26 @@ class WatchlistServiceTest {
     }
 
     @Test
+    @DisplayName("등록: 저장 성공 후 알림 처리에서 무결성 오류가 나면 DUPLICATE_WATCHLIST로 바꾸지 않고 그대로 전파한다")
+    void addWatchlist_notificationFailure_isNotMisreportedAsDuplicate() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 2000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+        given(priceTradeStatsRepository.findPriceRangesByCardIds(List.of(1L), null, TradeStatus.COMPLETED))
+                .willReturn(List.of(new PriceRange(1L, 1800, 2200)));
+        // 워치리스트 저장은 이미 성공한 뒤, 알림 처리(markAsNotifiedIfNotYet)에서 무결성 오류가 나는 상황.
+        given(watchlistRepository.markAsNotifiedIfNotYet(any()))
+                .willThrow(new DataIntegrityViolationException("notification constraint violation"));
+
+        // 예전에는 이 예외까지 같은 try에 잡혀 "이미 등록된 카드입니다"로 나갔다.
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(DataIntegrityViolationException.class);
+        then(watchlistRepository).should().save(any(Watchlist.class));
+    }
+
+    @Test
     @DisplayName("등록: 체결가가 목표가 구간 밖이면 targetReached/isNotified 모두 false로 유지된다")
     void addWatchlist_targetNotReached_keepsNotifiedFalse() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 9000, null);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -122,6 +122,76 @@ class WatchlistServiceTest {
         then(watchlistRepository).should(never()).save(any());
     }
 
+    // ===== #238 목표가 역전 검증 =====
+    @Test
+    @DisplayName("등록: 목표 구매가가 판매가보다 높으면 INVALID_TARGET_PRICE_RANGE")
+    void addWatchlist_invertedTargetPrices() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 5000, 3000);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 목표 구매가와 판매가가 같아도 INVALID_TARGET_PRICE_RANGE(구매가는 판매가보다 낮아야 한다)")
+    void addWatchlist_equalTargetPrices() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 3000, 3000);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+    }
+
+    @Test
+    @DisplayName("등록: 한쪽 목표가만 있으면 역전이 성립하지 않아 그대로 저장된다")
+    void addWatchlist_onlyOneTargetPrice_passes() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, 3000);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.targetSellPrice()).isEqualTo(3000);
+        then(watchlistRepository).should().save(any(Watchlist.class));
+    }
+
+    @Test
+    @DisplayName("수정: 구매가만 올려 보내도 기존 판매가와 역전되면 INVALID_TARGET_PRICE_RANGE")
+    void updateWatchlist_invertedAgainstStoredSellPrice() {
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(1000).targetSellPrice(3000)
+                .build();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(5000, null, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+        // 검증에서 막혔으므로 엔티티 값도 그대로여야 한다.
+        assertThat(target.getTargetBuyPrice()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("수정: 가격을 안 보낸 재알림 전용 요청은 기존 값이 역전 상태여도 통과한다")
+    void updateWatchlist_resendOnly_skipsOrderValidation() {
+        // 이번 검증이 생기기 전에 저장된 역전 데이터를 재현한다.
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(5000).targetSellPrice(3000)
+                .build();
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(null, null, true));
+
+        assertThat(response.isNotified()).isFalse();
+    }
+
     @Test
     @DisplayName("등록: 검증 통과하면 저장 후 WatchlistResponse 반환")
     void addWatchlist_success() {

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -118,7 +118,21 @@ class WatchlistServiceTest {
     void addWatchlist_variantNotFound() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 999L, 1000, null);
         given(cardRepository.existsById(1L)).willReturn(true);
-        given(cardVariantRepository.existsById(999L)).willReturn(false);
+        given(cardVariantRepository.existsByIdAndCardId(999L, 1L)).willReturn(false);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.VARIANT_NOT_FOUND);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 존재하지만 다른 카드에 속한 variantId면 VARIANT_NOT_FOUND (FK로는 안 걸리는 케이스)")
+    void addWatchlist_variantOfAnotherCard() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
+        // variant 2는 실제로 존재하지만 카드 1의 것이 아니다 - existsById였다면 통과했을 조합.
+        given(cardVariantRepository.existsByIdAndCardId(2L, 1L)).willReturn(false);
 
         assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
                 .isInstanceOf(BusinessException.class)
@@ -138,7 +152,7 @@ class WatchlistServiceTest {
         WatchlistResponse response = watchlistService.addWatchlist(1L, request);
 
         assertThat(response.variantId()).isNull();
-        then(cardVariantRepository).should(never()).existsById(any());
+        then(cardVariantRepository).should(never()).existsByIdAndCardId(any(), any());
     }
 
     @Test
@@ -246,7 +260,7 @@ class WatchlistServiceTest {
     void addWatchlist_success() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);
         given(cardRepository.existsById(1L)).willReturn(true);
-        given(cardVariantRepository.existsById(2L)).willReturn(true);
+        given(cardVariantRepository.existsByIdAndCardId(2L, 1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -256,6 +256,54 @@ class WatchlistServiceTest {
     }
 
     @Test
+    @DisplayName("수정: 역전 데이터에 기존과 똑같은 값을 되보내면(no-op) 차단되지 않는다")
+    void updateWatchlist_noOpOnInvertedData_passes() {
+        // 검증 도입 전에 저장된 역전 데이터. 예전에는 "가격 필드가 왔는지"로 판정해서, 값이 그대로여도
+        // 400이 났다(재알림만 보내면 200 - 같은 의도인데 요청 모양에 따라 결과가 갈리던 문제).
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(5000).targetSellPrice(3000)
+                .build();
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(5000, 3000, null));
+
+        assertThat(response.targetBuyPrice()).isEqualTo(5000);
+        assertThat(response.targetSellPrice()).isEqualTo(3000);
+        // 값이 안 바뀌었으므로 isNotified도 유지된다.
+        assertThat(response.isNotified()).isTrue();
+    }
+
+    @Test
+    @DisplayName("수정: 역전 데이터에 재알림을 함께 요청해도 값이 그대로면 통과한다(재알림 전용 요청과 동일 결과)")
+    void updateWatchlist_noOpWithResendOnInvertedData_passes() {
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(5000).targetSellPrice(3000)
+                .build();
+        target.markAsNotified();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        WatchlistResponse response = watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(5000, 3000, true));
+
+        assertThat(response.isNotified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("수정: 역전 데이터라도 값을 실제로 바꾸면 여전히 INVALID_TARGET_PRICE_RANGE로 차단된다")
+    void updateWatchlist_actualChangeOnInvertedData_stillBlocked() {
+        Watchlist target = Watchlist.builder()
+                .userId(1L).cardId(10L).targetBuyPrice(5000).targetSellPrice(3000)
+                .build();
+        given(watchlistRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(target));
+
+        assertThatThrownBy(() -> watchlistService.updateWatchlist(1L, 1L, new WatchlistUpdateRequest(7000, null, null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_TARGET_PRICE_RANGE);
+        // 검증에서 막혔으므로 엔티티 값은 그대로여야 한다.
+        assertThat(target.getTargetBuyPrice()).isEqualTo(5000);
+    }
+
+    @Test
     @DisplayName("등록: 검증 통과하면 저장 후 WatchlistResponse 반환")
     void addWatchlist_success() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.watchlist.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.price.dto.CardPriceSummaryResponse;
@@ -48,6 +49,7 @@ class WatchlistServiceTest {
     @Mock WatchlistRepository watchlistRepository;
     @Mock PriceService priceService;
     @Mock CardRepository cardRepository;
+    @Mock CardVariantRepository cardVariantRepository;
     @Mock PriceTradeStatsRepository priceTradeStatsRepository;
     @Mock CardNameKoResolver cardNameKoResolver;
     @Mock NotificationService notificationService;
@@ -61,7 +63,7 @@ class WatchlistServiceTest {
         WatchlistTargetPriceEvaluator watchlistTargetPriceEvaluator =
                 new WatchlistTargetPriceEvaluator(watchlistRepository, cardRepository, notificationService, cardNameKoResolver);
         watchlistService = new WatchlistService(
-                watchlistRepository, priceService, cardRepository, priceTradeStatsRepository, cardNameKoResolver, watchlistTargetPriceEvaluator);
+                watchlistRepository, priceService, cardRepository, cardVariantRepository, priceTradeStatsRepository, cardNameKoResolver, watchlistTargetPriceEvaluator);
     }
 
     private Watchlist watchlist(Long userId, Long cardId) {
@@ -109,6 +111,34 @@ class WatchlistServiceTest {
                 .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
         // FK 위반으로 저장까지 가지 않고 사전에 차단돼야 한다.
         then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: 존재하지 않는 variantId면 VARIANT_NOT_FOUND (DUPLICATE_WATCHLIST로 오분류되지 않는다)")
+    void addWatchlist_variantNotFound() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 999L, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(cardVariantRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.VARIANT_NOT_FOUND);
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
+    @DisplayName("등록: variantId가 null이면(대표 변형 기준) 변형 존재 검증을 하지 않는다")
+    void addWatchlist_nullVariantId_skipsVariantCheck() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
+        given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
+        given(watchlistRepository.countByUserId(1L)).willReturn(0L);
+        given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        WatchlistResponse response = watchlistService.addWatchlist(1L, request);
+
+        assertThat(response.variantId()).isNull();
+        then(cardVariantRepository).should(never()).existsById(any());
     }
 
     @Test
@@ -216,6 +246,7 @@ class WatchlistServiceTest {
     void addWatchlist_success() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);
         given(cardRepository.existsById(1L)).willReturn(true);
+        given(cardVariantRepository.existsById(2L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistServiceTest.java
@@ -83,6 +83,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: #308 목표가는 선택 입력 - 둘 다 null이어도 정상 등록된다")
     void addWatchlist_bothTargetPricesNull_success() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -98,9 +99,23 @@ class WatchlistServiceTest {
     }
 
     @Test
+    @DisplayName("등록: 존재하지 않는 카드면 CARD_NOT_FOUND (DUPLICATE_WATCHLIST로 오분류되지 않는다)")
+    void addWatchlist_cardNotFound() {
+        WatchlistCreateRequest request = new WatchlistCreateRequest(999L, null, 1000, null);
+        given(cardRepository.existsById(999L)).willReturn(false);
+
+        assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
+        // FK 위반으로 저장까지 가지 않고 사전에 차단돼야 한다.
+        then(watchlistRepository).should(never()).save(any());
+    }
+
+    @Test
     @DisplayName("등록: 이미 등록된 카드면 DUPLICATE_WATCHLIST")
     void addWatchlist_duplicate() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(true);
 
         assertThatThrownBy(() -> watchlistService.addWatchlist(1L, request))
@@ -113,6 +128,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 20개 이미 등록했으면 WATCHLIST_LIMIT_EXCEEDED")
     void addWatchlist_limitExceeded() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(20L);
 
@@ -127,6 +143,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 목표 구매가가 판매가보다 높으면 INVALID_TARGET_PRICE_RANGE")
     void addWatchlist_invertedTargetPrices() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 5000, 3000);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
 
@@ -140,6 +157,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 목표 구매가와 판매가가 같아도 INVALID_TARGET_PRICE_RANGE(구매가는 판매가보다 낮아야 한다)")
     void addWatchlist_equalTargetPrices() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 3000, 3000);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
 
@@ -152,6 +170,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 한쪽 목표가만 있으면 역전이 성립하지 않아 그대로 저장된다")
     void addWatchlist_onlyOneTargetPrice_passes() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, 3000);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -196,6 +215,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 검증 통과하면 저장 후 WatchlistResponse 반환")
     void addWatchlist_success() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, 2L, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -213,6 +233,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 등록 시점에 이미 체결가가 목표가 구간 안이면 targetReached=true와 isNotified=true가 함께 반영된다")
     void addWatchlist_targetAlreadyReached_marksAsNotified() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 2000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -233,6 +254,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 체결가가 목표가 구간 밖이면 targetReached/isNotified 모두 false로 유지된다")
     void addWatchlist_targetNotReached_keepsNotifiedFalse() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 9000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -250,6 +272,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 목표가 도달했지만 카드를 찾지 못하면 알림 생성은 스킵되고 targetReached/isNotified는 정상 반영된다")
     void addWatchlist_targetReachedButCardNotFound_skipsNotification() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 2000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -269,6 +292,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: 사전 체크를 통과했지만 저장 시점에 DB UNIQUE 제약을 위반하면(동시 등록 경합) DUPLICATE_WATCHLIST로 변환된다")
     void addWatchlist_saveThrowsDataIntegrityViolation_convertsToDuplicateWatchlist() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 1000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class)))
@@ -283,6 +307,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: variantId가 null이어도 정상 등록된다")
     void addWatchlist_success_variantIdNull() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, 10000, null);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));
@@ -297,6 +322,7 @@ class WatchlistServiceTest {
     @DisplayName("등록: targetSellPrice만 있어도 정상 등록된다")
     void addWatchlist_success_targetSellPriceOnly() {
         WatchlistCreateRequest request = new WatchlistCreateRequest(1L, null, null, 5000);
+        given(cardRepository.existsById(1L)).willReturn(true);
         given(watchlistRepository.existsByUserIdAndCardId(1L, 1L)).willReturn(false);
         given(watchlistRepository.countByUserId(1L)).willReturn(0L);
         given(watchlistRepository.save(any(Watchlist.class))).willAnswer(invocation -> invocation.getArgument(0));

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeConcurrencyTest.java
@@ -10,13 +10,13 @@ import com.pokade.domain.notification.store.SseEmitterStore;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.support.AbstractIntegrationTest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -39,8 +39,7 @@ import static org.mockito.Mockito.mock;
 // 스케줄러 실행 중첩 등)을 실제 스레드로 재현해, markAsNotifiedIfNotYet()의 조건부 원자적 UPDATE가
 // 중복 알림 생성을 막는지 검증한다.
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-class WatchlistTargetPriceNoticeConcurrencyTest {
+class WatchlistTargetPriceNoticeConcurrencyTest extends AbstractIntegrationTest {
 
     @Autowired
     private WatchlistRepository watchlistRepository;

--- a/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/watchlist/service/WatchlistTargetPriceNoticeTransactionIsolationTest.java
@@ -9,13 +9,13 @@ import com.pokade.domain.price.repository.PriceTradeStatsRepository;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.domain.watchlist.entity.Watchlist;
 import com.pokade.domain.watchlist.repository.WatchlistRepository;
+import com.pokade.support.AbstractIntegrationTest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
-import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -36,11 +36,10 @@ import static org.mockito.BDDMockito.given;
 // 실제 Postgres + 실제 Spring 트랜잭션 프록시로 검증한다(mock 기반 단위 테스트로는 AOP가 개입하지 않아
 // 이 버그 자체가 재현되지 않는다).
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({WatchlistTargetPriceNoticeScheduler.class, WatchlistTargetPriceNoticeProcessor.class,
         WatchlistService.class, WatchlistTargetPriceEvaluator.class, com.pokade.domain.notification.service.NotificationService.class,
         com.pokade.domain.notification.store.SseEmitterStore.class})
-class WatchlistTargetPriceNoticeTransactionIsolationTest {
+class WatchlistTargetPriceNoticeTransactionIsolationTest extends AbstractIntegrationTest {
 
     @Autowired
     private WatchlistRepository watchlistRepository;


### PR DESCRIPTION
## 📌 관련 이슈
- #338 

## ✨ 작업 내용
- 알림에 inquiryId 추가(문의 처리 알림 식별 가능하게)
- 워치리스트 목표가 역전/상한 검증 추가
- 존재하지 않는 카드/변형으로 등록 시 정확한 에러(CARD_NOT_FOUND/VARIANT_NOT_FOUND) 응답

## 📸 스크린샷 / 테스트 결과
- 실제 API 호출로 전 항목 재현 검증 (역전 조합, 상한 초과, 
  존재하지 않는 카드/변형, 다른 카드 소속 variant)
- 전체 스위트 회귀 확인, 신규 테스트 다수 추가(단위+통합)
- 진짜 중복 등록(DUPLICATE_WATCHLIST)은 기존 동작 그대로 유지 확인

## 🔍 리뷰 포인트
- ErrorCode.java에 항목 2개 추가(가산만, 기존 값 무변경)
- listings.variant_id에도 유사 문제 가능성 있어 별도 이슈로 등록(listing 도메인)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 문의 처리 알림에 문의 식별 정보가 포함되어 관련 문의로 바로 확인할 수 있습니다.
  - 워치리스트 등록 및 수정 시 카드와 카드 변형의 유효성을 검증합니다.
  - 목표 구매가와 판매가에 최대 금액 및 올바른 가격 순서 제한이 적용됩니다.

- **버그 수정**
  - 잘못된 카드 변형이나 유효하지 않은 목표 가격 입력에 대해 명확한 오류가 표시됩니다.
  - 워치리스트 부분 수정 시 기존 가격과 변경값을 올바르게 조합해 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->