### PR TITLE
[feat] #350 OAuth2 콜백 처리 계측 (응답시간·결과 분포)

### DIFF
--- a/Pokade/observability/grafana/dashboards/auth-domain.json
+++ b/Pokade/observability/grafana/dashboards/auth-domain.json
@@ -150,7 +150,7 @@
         },
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "auth_oauth2_callback_duration_seconds_max",
+          "expr": "max by (provider) (max_over_time(auth_oauth2_callback_duration_seconds_max[1h]))",
           "legendFormat": "{{provider}} max",
           "refId": "B"
         }

--- a/Pokade/observability/grafana/dashboards/auth-domain.json
+++ b/Pokade/observability/grafana/dashboards/auth-domain.json
@@ -132,6 +132,46 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "OAuth2 콜백 소요시간 (auth.oauth2.callback.duration)",
+      "description": "콜백 요청 전체 구간이다. 대부분이 구글·카카오와의 왕복(인가 코드 교환 + 사용자 정보 조회)이므로 값이 크다고 우리 처리가 느린 것이 아니다. 표본이 적어 1시간 창으로 계산한다.",
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(auth_oauth2_callback_duration_seconds_bucket[1h])))",
+          "legendFormat": "{{provider}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "auth_oauth2_callback_duration_seconds_max",
+          "legendFormat": "{{provider}} max",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "OAuth2 콜백 결과 분포 - 24시간 누적 (auth.oauth2.result)",
+      "description": "logged_in=기존 소셜 계정 로그인, signup_required=신규 가입 유도, conflict=같은 이메일이 다른 provider로 존재, error=우리 처리 중 거부, failure=인증 자체 실패. 소셜 로그인은 트래픽이 적어 rate()로는 평선이라 24시간 누적으로 본다.",
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (provider, result) (increase(auth_oauth2_result_total[24h]))",
+          "legendFormat": "{{provider}} {{result}}",
+          "refId": "A"
+        }
+      ]
     }
   ]
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2CallbackMetricsConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2CallbackMetricsConfig.java
@@ -1,0 +1,57 @@
+package com.pokade.global.security.oauth;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+import java.time.Duration;
+
+@Configuration
+public class OAuth2CallbackMetricsConfig {
+
+    private static final String CALLBACK_URL_PATTERN = "/api/oauth2/callback/*";
+
+    // 외부 IdP 왕복(인가 코드 교환 + 사용자 정보 조회)이 포함된 구간이라 조회성 API의 밀리초 버킷을
+    // 쓰면 전부 최상위 버킷에 몰린다. 초 단위로 잡는다.
+
+    private static final double[] CALLBACK_SLO_NANOS = {
+            Duration.ofMillis(500).toNanos(),
+            Duration.ofSeconds(1).toNanos(),
+            Duration.ofSeconds(2).toNanos(),
+            Duration.ofSeconds(5).toNanos(),
+    };
+
+    @Bean
+    public FilterRegistrationBean<OAuth2CallbackTimingFilter> oauth2CallbackTimingFilterRegistration(
+            MeterRegistry meterRegistry) {
+        FilterRegistrationBean<OAuth2CallbackTimingFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new OAuth2CallbackTimingFilter(meterRegistry));
+        registration.addUrlPatterns(CALLBACK_URL_PATTERN);
+        //Security 필터체인(-100)보다 먼저 서야 코드 교환, 사용자 정보 조회까지 시간에 포함된다.
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+
+    // 콜백 타이머에만 SLO 버킷을 붙인다. 이름이 http.server.requests와 분리돼 있어 타입 충돌이 없고,
+    // 버킷이면 histogram_quantile로 인스턴스 간 집계가 되므로 blue-green 두 슬롯에서도 합산된다.
+    @Bean
+    public MeterFilter oauth2CallbackTimingFilterMeterFilter() {
+        return new MeterFilter() {
+            @Override
+            public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                if (id.getType() != Meter.Type.TIMER || !OAuth2Metrics.CALLBACK_TIMER.equals(id.getName())) {
+                    return config;
+                }
+                return DistributionStatisticConfig.builder()
+                        .serviceLevelObjectives(CALLBACK_SLO_NANOS)
+                        .build()
+                        .merge(config);
+            }
+        };
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2CallbackTimingFilter.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2CallbackTimingFilter.java
@@ -1,0 +1,40 @@
+package com.pokade.global.security.oauth;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * OAuth2 콜백 한 건의 전체 소요시간을 잰다. 인가 코드 교환과 사용자 정보 조회는 Security 필터체인
+ * 안에서 일어나고 리다이렉트로 끝나므로 컨트롤러에 도달하지 않는다. 그래서 http.server.requests의
+ * uri 태그로는 구분되지 않고, 이 필터가 체인 바깥에서 감싸야 구간 전체가 잡힌다.
+ *
+ * <p>URL 스코프와 실행 순서는 {@link OAuth2CallbackMetricsConfig}가 강제한다.
+ */
+public class OAuth2CallbackTimingFilter extends OncePerRequestFilter {
+
+    private final MeterRegistry meterRegistry;
+
+    public OAuth2CallbackTimingFilter(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            // 인증 실패로 예외가 올라가도 소요시간은 남긴다.
+            sample.stop(Timer.builder(OAuth2Metrics.CALLBACK_TIMER)
+                    .tag(OAuth2Metrics.PROVIDER_TAG, OAuth2Metrics.providerTagFromUri(request.getRequestURI()))
+                    .register(meterRegistry));
+        }
+    }
+}

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandler.java
@@ -1,5 +1,7 @@
 package com.pokade.global.security.oauth;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,8 +20,12 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
 
     private final String redirectBase;
 
+    private final MeterRegistry meterRegistry;
+
     public OAuth2LoginFailureHandler(
+            MeterRegistry meterRegistry,
             @Value("${app.oauth2.redirect-base}") String redirectBase) {
+        this.meterRegistry = meterRegistry;
         this.redirectBase = redirectBase;
     }
 
@@ -29,6 +35,12 @@ public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
         if (exception instanceof OAuth2AuthenticationException oauthException) {
             reason = oauthException.getError().getErrorCode();
         }
+        Counter.builder(OAuth2Metrics.RESULT_COUNTER)
+                .tag(OAuth2Metrics.PROVIDER_TAG, OAuth2Metrics.providerTagFromUri(request.getRequestURI()))
+                .tag(OAuth2Metrics.RESULT_TAG, "failure")
+                .register(meterRegistry)
+                .increment();
         response.sendRedirect(redirectBase + "/login?error=" + URLEncoder.encode(reason, StandardCharsets.UTF_8));
+
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2LoginSuccessHandler.java
@@ -5,6 +5,8 @@ import com.pokade.domain.auth.service.OAuth2LoginService;
 import com.pokade.domain.user.entity.type.Provider;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.web.RefreshTokenCookieFactory;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,22 +27,27 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final OAuth2LoginService oauth2LoginService;
     private final RefreshTokenCookieFactory refreshTokenCookieFactory;
     private final String redirectBase;
+    private final MeterRegistry meterRegistry;
 
     public OAuth2LoginSuccessHandler(
             OAuth2LoginService oauth2LoginService,
             RefreshTokenCookieFactory refreshTokenCookieFactory,
+            MeterRegistry meterRegistry,
             @Value("${app.oauth2.redirect-base}") String redirectBase) {
         this.oauth2LoginService = oauth2LoginService;
         this.refreshTokenCookieFactory = refreshTokenCookieFactory;
+        this.meterRegistry = meterRegistry;
         this.redirectBase = redirectBase;
     }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        String providerTag = OAuth2Metrics.providerTag(token.getAuthorizedClientRegistrationId());
         String email = token.getPrincipal().getAttribute("email");
 
         if (email == null) {
+            countResult(providerTag, "error");
             redirect(response, "/login?error=email_required");
             return;
         }
@@ -49,6 +56,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         try {
             provider = Provider.valueOf(token.getAuthorizedClientRegistrationId().toUpperCase());
         } catch (IllegalArgumentException e) {
+            countResult(providerTag, "error");
             redirect(response, "/login?error=unsupported_provider");
             return;
         }
@@ -59,14 +67,22 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
                 case OAuth2Outcome.LoggedIn loggedIn -> {
                     response.addHeader(HttpHeaders.SET_COOKIE,
                             refreshTokenCookieFactory.create(loggedIn.refreshToken()).toString());
+                    countResult(providerTag, "logged_in");
                     redirect(response, "/oauth2/success");
                 }
-                case OAuth2Outcome.Conflict conflict -> redirect(response,
-                        "/login?error=email_conflict&provider=" + conflict.provider().name());
-                case OAuth2Outcome.SignupRequired signup -> redirect(response, "/signup/social#ticket="
-                        + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
+                case OAuth2Outcome.Conflict conflict -> {
+                    countResult(providerTag, "conflict");
+                    redirect(response, "/login?error=email_conflict&provider=" + conflict.provider().name());
+                }
+                case OAuth2Outcome.SignupRequired signup -> {
+                    countResult(providerTag, "signup_required");
+                    redirect(response, "/signup/social#ticket="
+                            + URLEncoder.encode(signup.ticket(), StandardCharsets.UTF_8));
+
+                }
             }
         } catch (BusinessException e) {   // resolve의 상태 가드(정지 등) → 에러 페이지
+            countResult(providerTag, "error");
             redirect(response, "/login?error=" + e.getErrorCode().name().toLowerCase());
         }
 
@@ -74,5 +90,14 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private void redirect(HttpServletResponse response, String path) throws IOException {
         response.sendRedirect(redirectBase + path);
+    }
+
+    // 콜백 처리 결과를 지표에 기록한다. 리다이렉트 동작은 그대로 두고 분포만 남긴다.
+    private void countResult(String providerTag, String result) {
+        Counter.builder(OAuth2Metrics.RESULT_COUNTER)
+                .tag(OAuth2Metrics.PROVIDER_TAG, providerTag)
+                .tag(OAuth2Metrics.RESULT_TAG, result)
+                .register(meterRegistry)
+                .increment();
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2Metrics.java
+++ b/Pokade/src/main/java/com/pokade/global/security/oauth/OAuth2Metrics.java
@@ -1,0 +1,41 @@
+package com.pokade.global.security.oauth;
+
+import com.pokade.domain.user.entity.type.Provider;
+
+import java.util.Locale;
+
+final class OAuth2Metrics {
+
+    static final String CALLBACK_TIMER = "auth.oauth2.callback.duration";
+    static final String RESULT_COUNTER = "auth.oauth2.result";
+
+    static final String PROVIDER_TAG = "provider";
+    static final String RESULT_TAG = "result";
+
+    // provider는 경로 세그먼트라 외부 입력이다. enum에 없는 값은 하나로 접어 카디널리티를 묶는다
+    private static final String UNKNOWN = "unknown";
+
+    private OAuth2Metrics() {
+    }
+
+    static String providerTag(String registrationId) {
+        if (registrationId == null) {
+            return UNKNOWN;
+        }
+        try {
+            Provider provider = Provider.valueOf(registrationId.toUpperCase(Locale.ROOT));
+            return provider == Provider.LOCAL ? UNKNOWN : provider.name().toLowerCase(Locale.ROOT);
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+
+    // 콜백 경로 /api/oauth2/callback/{registrationId}의 마지막 세그먼트를 태그값으로 쓴다.
+    static String providerTagFromUri(String requestUri) {
+        if (requestUri == null) {
+            return UNKNOWN;
+        }
+        int lastSlash = requestUri.lastIndexOf('/');
+        return providerTag(lastSlash < 0 ? null : requestUri.substring(lastSlash + 1));
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/oauth/OAuth2CallbackTimingFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/oauth/OAuth2CallbackTimingFilterTest.java
@@ -1,0 +1,56 @@
+package com.pokade.global.security.oauth;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2CallbackTimingFilterTest {
+
+    @Test
+    @DisplayName("t1 콜백 요청의 소요시간을 provider 태그와 함께 기록한다")
+    void t1() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OAuth2CallbackTimingFilter filter = new OAuth2CallbackTimingFilter(registry);
+
+        filter.doFilter(new MockHttpServletRequest("GET", "/api/oauth2/callback/google"),
+                new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
+
+        Timer timer = registry.find("auth.oauth2.callback.duration").tag("provider", "google").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("t2 등록되지 않은 provider 경로는 unknown 하나로 접어 카디널리티를 묶는다")
+    void t2() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OAuth2CallbackTimingFilter filter = new OAuth2CallbackTimingFilter(registry);
+
+        filter.doFilter(new MockHttpServletRequest("GET", "/api/oauth2/callback/anything"),
+                new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
+        filter.doFilter(new MockHttpServletRequest("GET", "/api/oauth2/callback/local"),
+                new MockHttpServletResponse(), Mockito.mock(FilterChain.class));
+
+        assertThat(registry.find("auth.oauth2.callback.duration").tag("provider", "unknown").timer().count())
+                .isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("t3 콜백 경로에만 스코프되고 Security 필터체인보다 먼저 실행되도록 등록된다")
+    void t3() {
+        FilterRegistrationBean<OAuth2CallbackTimingFilter> registration =
+                new OAuth2CallbackMetricsConfig().oauth2CallbackTimingFilterRegistration(new SimpleMeterRegistry());
+
+        assertThat(registration.getUrlPatterns()).containsExactly("/api/oauth2/callback/*");
+        assertThat(registration.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandlerTest.java
+++ b/Pokade/src/test/java/com/pokade/global/security/oauth/OAuth2LoginFailureHandlerTest.java
@@ -1,0 +1,72 @@
+package com.pokade.global.security.oauth;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2LoginFailureHandlerTest {
+
+    private static final String REDIRECT_BASE = "http://localhost:3000";
+
+    @Test
+    @DisplayName("t1 인증 실패를 provider·failure 태그로 집계하고 사유와 함께 로그인 페이지로 돌려보낸다")
+    void t1() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(registry, REDIRECT_BASE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(
+                new MockHttpServletRequest("GET", "/api/oauth2/callback/google"),
+                response,
+                new OAuth2AuthenticationException(new OAuth2Error("access_denied")));
+
+        assertThat(registry.find("auth.oauth2.result")
+                .tag("provider", "google")
+                .tag("result", "failure")
+                .counter().count()).isEqualTo(1);
+        assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_BASE + "/login?error=access_denied");
+    }
+
+    @Test
+    @DisplayName("t2 등록되지 않은 provider 경로는 unknown 하나로 접는다")
+    void t2() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(registry, REDIRECT_BASE);
+
+        handler.onAuthenticationFailure(
+                new MockHttpServletRequest("GET", "/api/oauth2/callback/anything"),
+                new MockHttpServletResponse(),
+                new OAuth2AuthenticationException(new OAuth2Error("access_denied")));
+
+        assertThat(registry.find("auth.oauth2.result")
+                .tag("provider", "unknown")
+                .tag("result", "failure")
+                .counter().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("t3 OAuth2 예외가 아니면 사유를 알 수 없으므로 기본 사유로 돌려보낸다")
+    void t3() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        OAuth2LoginFailureHandler handler = new OAuth2LoginFailureHandler(registry, REDIRECT_BASE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(
+                new MockHttpServletRequest("GET", "/api/oauth2/callback/kakao"),
+                response,
+                new BadCredentialsException("자격 증명 실패"));
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(REDIRECT_BASE + "/login?error=oauth2_failed");
+        assertThat(registry.find("auth.oauth2.result")
+                .tag("provider", "kakao")
+                .tag("result", "failure")
+                .counter().count()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #350

## ✨ 작업 내용

인증·프로필 도메인 계측 항목 넷 중 셋(로그인·회원가입 응답시간, 메일 발송 성공·실패, 토큰 재발급)은 #340에서 채웠다. 남은 하나인 OAuth2 콜백 처리 응답시간을 추가한다. 기존 리다이렉트 동작과 응답은 바꾸지 않는다.

**#340의 방식으로는 잡히지 않는다.** 콜백 경로 `/api/oauth2/callback/{provider}`는 `AuthMetricsConfig`가 퍼센타일을 붙이는 두 prefix(`/api/auth`·`/api/users`)에 걸리지 않는다. prefix를 추가해도 해결되지 않는데, 이 요청은 Security 필터체인 안의 `OAuth2LoginAuthenticationFilter`가 처리하고 핸들러가 `sendRedirect`로 끝내므로 컨트롤러에 도달하지 않기 때문이다. 기록 자체는 남는다 — 관측 필터가 `-2147483647`(`HIGHEST_PRECEDENCE + 1`)로 Security 필터체인(`-100`)보다 바깥에 서므로 `http.server.requests`에는 잡힌다. 다만 매칭된 핸들러 패턴이 없고 응답이 302라 `DefaultServerRequestObservationConvention`이 `uri` 태그를 `REDIRECTION`으로 접어, 서비스 전체의 리다이렉트 응답과 한 시계열에 섞인다.

그래서 콜백 구간을 감싸는 전용 계측을 넣었다.

- **소요시간** — `/api/oauth2/callback/*`에만 스코프된 `OAuth2CallbackTimingFilter`를 `FilterRegistrationBean`으로 등록하고 `Ordered.HIGHEST_PRECEDENCE`를 준다. Security 체인 바깥에 서므로 인가 코드 교환과 사용자 정보 조회까지 구간에 포함된다
- **결과 분포** — `OAuth2LoginSuccessHandler`의 분기 넷과 `OAuth2LoginFailureHandler`에 카운터를 붙인다. 소요시간만으로는 무엇이 느렸는지 해석할 수 없고, 이메일 충돌 빈도는 그 자체가 운영 신호다
- **분포 설정** — 타이머에 SLO 버킷(0.5s · 1s · 2s · 5s)을 붙인다
- **대시보드** — `auth-domain.json`에 패널 2개 추가

### 발행하는 지표

| 이름 | 타입 | 태그 |
|---|---|---|
| `auth.oauth2.callback.duration` | timer (histogram) | `provider` = google · kakao · unknown |
| `auth.oauth2.result` | counter | `provider`, `result` = logged_in · signup_required · conflict · error · failure |

`provider`는 URL 경로 세그먼트라 외부 입력이다. `Provider` enum에 있는 값만 통과시키고 나머지는 `unknown`으로 접어 카디널리티를 묶는다. IdP가 주는 실패 사유 문자열은 태그로 쓰지 않고 지금처럼 리다이렉트 URL에만 싣는다.

## 📸 스크린샷 / 테스트 결과

### 단위 테스트

`OAuth2CallbackTimingFilterTest` 3 · `OAuth2LoginFailureHandlerTest` 3 — **6개 전부 통과**.

타이밍 필터는 기록 동작과 태그 화이트리스트를, 등록 설정은 URL 패턴과 순서를 고정한다. 실패 핸들러는 provider 태그를 토큰이 아니라 요청 URI에서 뽑는 유일한 지점이라 따로 테스트를 뒀다.

### 로컬 실측

구글·카카오로 실제 로그인을 태우고 `/actuator/prometheus`에서 확인했다.

**소요시간** — 히스토그램 타입으로 발행되고 버킷 경계 네 개가 설계대로 붙는다.

| provider | 호출 | 합 | 최댓값 |
|---|---|---|---|
| google | 2건 | 1.808s | 1.490s |
| kakao | 1건 | 0.169s | 0.169s |

구글 첫 호출이 1.49초, 둘째가 0.32초다. 차이는 콜드 스타트이므로 이 값을 정상 구간으로 읽지 않는다. 웜 상태에서는 `le="0.5"` 버킷에 들어간다.

**결과 분포**

```
auth_oauth2_result_total{provider="google",result="logged_in"} 1.0
auth_oauth2_result_total{provider="google",result="signup_required"} 1.0
auth_oauth2_result_total{provider="google",result="failure"} 1.0
auth_oauth2_result_total{provider="kakao",result="logged_in"} 1.0
```

`failure`는 동의 화면 취소 대신 콜백을 직접 호출해 확인했다. state가 없으면 `OAuth2LoginAuthenticationFilter`가 `authorization_request_not_found`로 실패시키며, 취소와 핸들러 진입 경로가 같다.

```
$ curl -i "localhost:8080/api/oauth2/callback/google?code=fake&state=fake"
HTTP/1.1 302
Location: http://localhost:3000/login?error=authorization_request_not_found
```

`conflict`와 `error`는 실측하지 않았다. 계정 상태를 인위적으로 만들어야 하는데 두 값 모두 같은 `countResult` 호출을 타므로 위험도가 낮다고 판단했다.

## 리뷰 포인트

### ① 필터 등록 순서가 이 변경의 핵심이다

`setOrder(Ordered.HIGHEST_PRECEDENCE)`를 빼면 계측이 조용히 0건이 된다. 필터에 `@Component`만 붙이면 Spring Boot가 `LOWEST_PRECEDENCE`로 등록하는데, 그러면 콜백이 Security 체인 안에서 리다이렉트로 끝난 뒤에야 우리 필터 차례가 온다. 예외도 경고도 나지 않아 알아차리기 어렵다.

같은 이유로 필터 클래스에는 스테레오타입 애너테이션을 붙이지 않고 설정 클래스에서 직접 생성한다(중복 등록 방지). `CardRateLimitFilterConfig`가 같은 형태다.

부수 효과로 이 타이머는 관측 필터(`-2147483647`)보다 한 칸 바깥에 선다. 두 계측은 경쟁하지 않고 포함 관계이며, 이 값은 `http.server.requests`가 재는 시간을 포함한 상위 집합이다.

### ② 퍼센타일이 아니라 SLO 버킷을 썼다

#340의 인증 URI 응답시간은 `percentiles`로 발행해 인스턴스별로 미리 계산된 값이라 blue-green 두 슬롯을 합산할 수 없다. 이 지표는 이름이 `http.server.requests`와 분리돼 있어 타입 충돌 위험이 없으므로 버킷을 쓸 수 있고, 그러면 `histogram_quantile`로 인스턴스 간 집계가 성립한다. 경계는 외부 왕복이 포함된 구간임을 감안해 초 단위로 잡았다. 조회성 API의 밀리초 버킷을 쓰면 전부 최상위 버킷에 몰린다.

### ③ 측정값의 대부분은 외부 IdP 왕복이다

구글·카카오와의 인가 코드 교환과 사용자 정보 조회가 포함되므로 값이 크다고 우리 처리가 느린 것이 아니다. 패널 설명에도 적어 두었다. 우리 처리분만 분리해야 할 필요가 생기면 성공 핸들러 안쪽에 타이머를 하나 더 두는 방식으로 넓힐 수 있다.

### ④ 설정 클래스를 `global/config`가 아니라 oauth 패키지에 뒀다

이 설정은 OAuth2 계측 세 파일과 함께 태어나고 함께 지워질 물건이라 여러 도메인이 공유하는 `global/config`(`SecurityConfig`·`MetricsConfig`·`AsyncConfig`)와 성격이 다르다. `domain/card/filter/CardRateLimitFilterConfig`가 같은 형태로 필터 옆에 있다. 또한 지표 이름 상수를 담은 `OAuth2Metrics`가 package-private이라, 설정을 다른 패키지로 옮기면 이 클래스를 `public`으로 되돌려 지표 이름을 전역에 노출해야 한다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - OAuth2 로그인 콜백의 처리 시간과 결과를 제공자별로 자동 집계합니다.
  - 로그인 성공, 실패 및 주요 처리 결과를 확인할 수 있습니다.
  - 알 수 없는 제공자도 별도 항목으로 분류해 누락 없이 모니터링합니다.

- **개선 사항**
  - Grafana 대시보드에서 최근 1시간의 콜백 처리 지연 시간과 최근 24시간의 결과별 처리 건수를 확인할 수 있습니다.
  - 콜백 처리 중 오류가 발생해도 관련 지표가 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->