### PR TITLE
chore: EC2 프로덕션 모니터링(Prometheus/Grafana) 인프라 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
               -e TZ=Asia/Seoul \
               -e OPENAI_API_KEY="$OPENAI_API_KEY" \
               -e REDIS_HOST=pokade-redis \
+              -e MANAGEMENT_ADDRESS=0.0.0.0 \
               "$IMAGE"
 
             HEALTHY=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,8 +30,8 @@ jobs:
   cleanup-old-images:
     needs: build-and-push
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
+    # GHCR_PAT(개인 액세스 토큰)로만 인증하고 GITHUB_TOKEN은 쓰지 않으므로 권한 불필요.
+    permissions: {}
     steps:
       # :latest 태그 하나만 쓰다 보니 push할 때마다 새 다이제스트가 쌓이고 이전 것은
       # 태그 없이(untagged) 남아 GHCR 저장 용량을 계속 먹는다. 최신 4개만 남기고 정리.
@@ -45,6 +45,8 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
+    # SSH 시크릿(SSH_HOST/SSH_USER/SSH_KEY)만 쓰고 GITHUB_TOKEN은 쓰지 않으므로 권한 불필요.
+    permissions: {}
     steps:
       # blue-green 배포. 두 슬롯(a/b)을 번갈아 쓰고, 새 슬롯이 헬스체크를 통과한 뒤에만
       # nginx 업스트림을 전환하고 이전 슬롯을 내린다 — 컨테이너 교체 사이의 다운타임(약

--- a/Pokade/docker-compose.observability.prod.yml
+++ b/Pokade/docker-compose.observability.prod.yml
@@ -17,7 +17,8 @@
 #     추가하지 않아도 tailnet 너머에서는 접근 가능하다.
 services:
   prometheus:
-    image: prom/prometheus:latest
+    # latest 대신 버전+digest로 고정 — 같은 파일을 다시 실행해도 항상 같은 이미지가 뜨도록 함
+    image: prom/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
     container_name: pokade-prometheus
     restart: unless-stopped
     volumes:
@@ -29,7 +30,8 @@ services:
       - pokade-net
 
   grafana:
-    image: grafana/grafana:latest
+    # latest 대신 버전+digest로 고정 — 같은 파일을 다시 실행해도 항상 같은 이미지가 뜨도록 함
+    image: grafana/grafana:13.2.0@sha256:3fd54ae1214669f8355f065ec9f6445d5279a3d77095ab048ca045685272429b
     container_name: pokade-grafana
     restart: unless-stopped
     environment:

--- a/Pokade/docker-compose.observability.prod.yml
+++ b/Pokade/docker-compose.observability.prod.yml
@@ -1,0 +1,57 @@
+# EC2 프로덕션용 Prometheus/Grafana 오버레이.
+# docker-compose.observability.yml(로컬 실험용)과 달리, 백엔드가 이미 host.docker.internal이 아니라
+# 같은 도커 네트워크(pokade_pokade-net) 위 컨테이너(pokade-app-a/b)로 떠 있다는 걸 전제로 한다.
+# 그 네트워크는 docker-compose.yml(redis 서비스) 또는 배포 스크립트가 이미 만들어 두므로 여기서는
+# external로 참조만 한다.
+#
+# EC2에서 실행:
+#   docker compose -f docker-compose.observability.prod.yml up -d
+#
+# 필요한 준비물:
+#   - ~/AIBE6_FinalProject_Team05_BE/Pokade/.env 에 GRAFANA_ADMIN_PASSWORD=<값> 한 줄 추가
+#     (docker compose가 같은 디렉터리의 .env를 자동으로 읽어 변수 치환에 쓴다)
+#   - .github/workflows/deploy.yml의 docker run에 -e MANAGEMENT_ADDRESS=0.0.0.0 이 추가돼 있어야
+#     Prometheus 컨테이너가 백엔드 컨테이너의 8081(actuator)에 도달할 수 있다.
+#   - 보안그룹 인바운드: 9090은 열지 않음(팀원이 볼 필요 없음). 3001(Grafana)도 인터넷 전체(0.0.0.0/0)로
+#     열지 말고, Tailscale 등으로 팀원 접근을 제한한다 - Tailscale을 EC2에 설치해두면 SG에 3001을 아예
+#     추가하지 않아도 tailnet 너머에서는 접근 가능하다.
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: pokade-prometheus
+    restart: unless-stopped
+    volumes:
+      - ./observability/prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    networks:
+      - pokade-net
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: pokade-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD}"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      # 0.0.0.0 바인딩이지만 보안그룹에 3001 인바운드 규칙을 추가하지 않으면 퍼블릭 인터넷에서는
+      # 여전히 도달 불가 - Tailscale(또는 VPN) 경유 접근만 허용하는 전제.
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - pokade-net
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  pokade-net:
+    name: pokade_pokade-net
+    external: true

--- a/Pokade/observability/prometheus.prod.yml
+++ b/Pokade/observability/prometheus.prod.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+
+scrape_configs:
+  - job_name: pokade-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      # blue-green 슬롯(a/b) 컨테이너 둘 다 타겟으로 등록한다. 도커 네트워크
+      # (pokade_pokade-net) 안에서는 컨테이너명으로 직접 resolve되고, management
+      # 포트(8081)는 호스트에 publish하지 않아도 같은 네트워크의 다른 컨테이너에서는
+      # 접근 가능하다 - 단 애플리케이션이 MANAGEMENT_ADDRESS=0.0.0.0으로 떠 있어야 한다
+      # (기본값 127.0.0.1이면 컨테이너 루프백이라 다른 컨테이너에서 접근 불가).
+      # 비활성 슬롯은 컨테이너가 내려가 있어 target down으로 보이는 게 정상이다.
+      - targets:
+          - "pokade-app-a:8081"
+          - "pokade-app-b:8081"


### PR DESCRIPTION
## 📌 관련 이슈
- #339

## ✨ 작업 내용
- 백엔드가 EC2에서 blue-green Docker 컨테이너(pokade-app-a/b)로 배포되는 구조에 맞춰, 같은 EC2에 Prometheus/Grafana 모니터링 스택을 컨테이너로 함께 배치하기 위한 설정 추가
- `Pokade/observability/prometheus.prod.yml` 신규: 로컬용(`host.docker.internal`)과 달리 blue-green 두 슬롯(`pokade-app-a:8081`, `pokade-app-b:8081`)을 직접 스크랩 타겟으로 지정
- `Pokade/docker-compose.observability.prod.yml` 신규: 새 네트워크를 만들지 않고 배포 스크립트가 이미 생성한 `pokade_pokade-net`을 외부 네트워크로 참조. Grafana는 3001 포트로 열되 보안그룹에서 퍼블릭 인바운드를 막고 Tailscale로만 접근 허용
- `.github/workflows/deploy.yml` 수정: `docker run`에 `-e MANAGEMENT_ADDRESS=0.0.0.0` 추가 — 기존 기본값(127.0.0.1)이면 다른 컨테이너(Prometheus)에서 actuator에 접근할 수 없어서, 애플리케이션 쪽 주석에 이미 명시돼 있던 대응을 반영

## 🔍 리뷰 포인트
- `MANAGEMENT_ADDRESS=0.0.0.0` 변경이 실제 배포(main 반영)에서 정상 동작하는지 — 배포 후 Prometheus 타겟이 정상적으로 up 상태인지 확인 필요
- Grafana 접근 제한을 Tailscale에만 의존하고 있음 — 팀 정책상 추가 인증 레이어가 필요한지 논의 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (설정 파일 변경만 있어 별도 빌드/테스트 대상 없음, YAML 문법 검증만 수행)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? (팀원용 Tailscale 접속 가이드는 별도 작업으로 진행 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - EC2 프로덕션 환경에서 Prometheus와 Grafana를 활용한 모니터링 구성을 추가했습니다.
  - 애플리케이션 메트릭을 주기적으로 수집하고 Grafana 대시보드에서 확인할 수 있습니다.
  - Grafana 관리자 비밀번호를 환경 변수로 설정할 수 있습니다.

- **개선 사항**
  - 배포 환경에서 관리 엔드포인트가 모든 네트워크 인터페이스를 통해 수신되도록 개선했습니다.
  - 로컬 메모 및 작업 파일이 버전 관리에 포함되지 않도록 제외 항목을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->