### PR TITLE
[Feature] 거래 조회 응답에 결제 시 사용한 포인트 노출 #361

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingCreateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingCreateRequest.java
@@ -15,6 +15,7 @@ public record ListingCreateRequest(
         @Positive(message = "price는 0보다 커야 합니다.")
         Integer price,
 
+        @NotNull(message = "grade는 필수입니다.")
         ListingGrade grade,
 
         @NotBlank(message = "정산 받을 은행명은 필수입니다.")

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
@@ -22,10 +22,11 @@ public record TradeResponse(
         String recipientName,
         String recipientPhone,
         String recipientAddress,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        Integer pointsUsed
 ) {
 
-    public static TradeResponse of(Trade trade, String cardName) {
+    public static TradeResponse of(Trade trade, String cardName, Integer pointsUsed) {
         return new TradeResponse(
                 trade.getId(),
                 trade.getListing().getId(),
@@ -43,7 +44,8 @@ public record TradeResponse(
                 trade.getRecipientName(),
                 trade.getRecipientPhone(),
                 trade.getRecipientAddress(),
-                trade.getCreatedAt()
+                trade.getCreatedAt(),
+                pointsUsed
         );
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -63,7 +63,10 @@ public class TradeService {
         String cardName = cardRepository.findById(trade.getListing().getCardId())
                 .map(Card::getName)
                 .orElse(null);
-        return TradeResponse.of(trade, cardName);
+        Integer pointsUsed = paymentRepository.findByTradeId(trade.getId())
+                .map(Payment::getPointsUsed)
+                .orElse(null);
+        return TradeResponse.of(trade, cardName, pointsUsed);
     }
 
     // 결제창을 띄우기 전에 주문을 먼저 PENDING으로 기록한다 - 매물은 아직 잠그지 않는다(TRADING으로

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
@@ -83,7 +83,7 @@ class AdminTradeControllerTest {
     private TradeResponse tradeResponseOf(Long id, TradeStatus status) {
         return new TradeResponse(
                 id, 10L, 200L, 100L, 1L, "리자몽 ex", 10000, status,
-                LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now());
+                LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now(), null);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1070,7 +1070,7 @@ class PriceServiceTest {
         TradeResponse expected = new TradeResponse(
                 100L, null, 2L, 1L, 1L, "리자몽", 250000, TradeStatus.PENDING,
                 null, null, null, null, null,
-                "김철수", "010-1234-5678", "서울시 강남구", java.time.LocalDateTime.now());
+                "김철수", "010-1234-5678", "서울시 강남구", java.time.LocalDateTime.now(), null);
         given(tradeService.createMatchedTrade(
                 any(), eq(2L), eq(250000), eq(252000), eq("김철수"), eq("010-1234-5678"),
                 eq("서울시 강남구"), eq("pay_999"), eq(1000)))

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -147,7 +147,7 @@ class TradeControllerTest {
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest("pay_123", "order-1", 10000L);
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
-                null, null, null, null, null, null, null, null, LocalDateTime.now());
+                null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, "pay_123", "order-1", 10000L))
                 .willReturn(response);
@@ -182,7 +182,7 @@ class TradeControllerTest {
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest(null, "order-1", 0L);
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
-                null, null, null, null, null, null, null, null, LocalDateTime.now());
+                null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, null, "order-1", 0L)).willReturn(response);
 
@@ -213,7 +213,7 @@ class TradeControllerTest {
     void 본인_거래를_조회하면_200과_거래정보를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
-                null, null, null, null, null, null, null, null, LocalDateTime.now());
+                null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.getTrade(200L, 1L)).willReturn(response);
 
@@ -255,7 +255,7 @@ class TradeControllerTest {
         LocalDateTime confirmedAt = LocalDateTime.now();
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.COMPLETED,
-                shippedAt, inspectedAt, deliveredAt, confirmedAt, confirmedAt, null, null, null, confirmedAt);
+                shippedAt, inspectedAt, deliveredAt, confirmedAt, confirmedAt, null, null, null, confirmedAt, null);
 
         given(tradeService.confirmTrade(200L, 1L)).willReturn(response);
 
@@ -305,7 +305,7 @@ class TradeControllerTest {
     void 구매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.CANCELLED,
-                null, null, null, null, null, null, null, null, LocalDateTime.now());
+                null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(200L, 1L)).willReturn(response);
 
@@ -319,7 +319,7 @@ class TradeControllerTest {
     void 판매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
                 1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.CANCELLED,
-                null, null, null, null, null, null, null, null, LocalDateTime.now());
+                null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(100L, 1L)).willReturn(response);
 

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -401,6 +401,25 @@ class TradeServiceTest {
     }
 
     @Test
+    void 조회시_결제에_사용된_포인트를_함께_반환한다() {
+        Trade trade = tradeOf(100L, 200L);
+        given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));
+        given(paymentRepository.findByTradeId(any())).willReturn(Optional.of(
+                Payment.builder()
+                        .trade(trade)
+                        .buyerId(200L)
+                        .amount(trade.getPrice())
+                        .pointsUsed(5000)
+                        .method(com.pokade.domain.trade.entity.PaymentMethod.CARD)
+                        .tossPaymentKey("pay_123")
+                        .build()));
+
+        TradeResponse response = tradeService.getTrade(200L, 1L);
+
+        assertThat(response.pointsUsed()).isEqualTo(5000);
+    }
+
+    @Test
     void 판매자_본인이_조회하면_거래정보를_반환한다() {
         Trade trade = tradeOf(100L, 200L);
         given(tradeRepository.findById(1L)).willReturn(Optional.of(trade));


### PR DESCRIPTION
## 📌 관련 이슈
- #361

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
## 변경사항                                                                                                                                                                 
                                                                                                                                                                              
  ### 거래 조회 응답에 포인트 사용액 노출                                                                                                                                     
  - `TradeResponse`에 `pointsUsed` 필드 추가                                                                                                                                  
  - `TradeService.toResponse()`에서 `paymentRepository.findByTradeId()`로 조회한 `Payment.pointsUsed`를 채워서 반환                                                           
                                                                                                                                                                              
  ### 매물 등록 시 등급 선택 필수화                                                                                                                                           
  - `ListingCreateRequest.grade`에 `@NotNull` 추가 (기존엔 선택값이라 등급 없이도 등록 가능했음)                                                                                                                                         

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?