### PR TITLE
[Fix] ssh-action에 request_pty를 추가해 nginx reload 실패 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,10 @@ jobs:
           # GHCR 로그인·이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
           # nginx 설정을 건드리지 않은 채로 배포만 실패한다(기본값 false라 명시 필요).
           script_stop: true
+          # pty 없이 exec만 하면 sudo systemctl reload가 PAM/D-Bus 경로에서 종료
+          # 상태를 잘못 보고해 배포가 매번 실패했다 — pty를 할당해 표준 로그인
+          # 세션과 동일한 경로를 타게 한다.
+          request_pty: true
           script: |
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest


### PR DESCRIPTION
## 📌 관련 이슈
- #362

## ✨ 작업 내용
- 무중단 배포(blue-green)를 도입하면서 새로 생긴 마지막 단계 — "새 컨테이너 헬스체크 통과 → **nginx가 트래픽을 새 컨테이너로 넘기게 전환**" — 에서 배포가 매번 실패했다.
  - 새 컨테이너 띄우기 ✅ 정상
  - 헬스체크 통과 ✅ 정상
  - nginx 전환(`sudo systemctl reload nginx`) ❌ 여기서 매번 실패
- 원인: `systemctl reload`는 systemd에 D-Bus로 요청을 보내고 `sudo`가 PAM(`pam_systemd`)을 거치는데, 이 경로는 사람이 터미널로 로그인해 실행하는 상황을 가정하고 만들어져 있다. GitHub Actions가 EC2에 SSH로 접속할 때 쓰는 `appleboy/ssh-action`은 pty(가상 터미널) 없이 명령만 실행하기 때문에, 이 PAM 경로에서 명령의 성공/실패 판단이 잘못 나왔다(실제로는 reload가 됐을 가능성이 높은데도 CI엔 실패로 보고됨).
  - EC2에 직접 SSH로 여러 방식(대화형/비대화형/전체 스크립트)으로 같은 명령을 재현했을 때는 전부 정상 동작 → "이 SSH 도구가 pty 없이 실행하는 방식 + systemctl 조합"에서만 나는 문제로 특정.
- 해결: `appleboy/ssh-action`에 `request_pty: true`를 추가해 pty를 할당, 사람이 터미널로 로그인해 실행하는 것과 동일한 경로를 타게 했다. `systemctl reload nginx` 명령 자체는 그대로 유지.
  - Ansible 등에서도 같은 종류의 문제(비대화형 SSH + sudo + systemd/PAM)를 pty 할당으로 회피하는 게 표준적인 방법이라 이 쪽을 선택했다.

## 📸 스크린샷 / 테스트 결과
- 기존 실패 로그: `sudo nginx -t`(성공) 직후 `sudo systemctl reload nginx`에서 매번 출력 없이 `Process exited with status 1`
- 이 PR이 main까지 반영된 뒤 실제 배포에서 해당 단계 통과 여부 확인 필요(아래 체크리스트)

## 🔍 리뷰 포인트
- `request_pty: true`는 스크립트 전체(docker login/pull/run, curl 등)의 출력 방식에 영향을 줄 수 있음 — 배포 로그의 `out:`/`err:` 구분이 달라지는지 다음 배포에서 확인 필요
- 이걸로도 재발하면 root cause를 완전히 없애는 대안(`nginx -s reload`로 systemd 경로 자체를 피하기)으로 전환 예정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [ ] 실제 배포에서 통과 확인 (main 반영 후)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가? (docs/troubleshooting/decisions, push 제외 대상)