### PR TITLE
[fix] #371 시세 랭킹 API가 카드 한글 이름을 내려주지 않던 문제 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/dto/PriceRankingResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/PriceRankingResponse.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 public record PriceRankingResponse(
         Long cardId,
         String cardName,
+        String cardNameKo,
         String imageUrl,
         long price,
         BigDecimal changeRate,

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -5,6 +5,7 @@ import com.pokade.domain.card.entity.CardPrice;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.repository.ListingRepository;
@@ -93,6 +94,7 @@ public class PriceService {
 
     private final CardRepository cardRepository;
     private final CardVariantRepository cardVariantRepository;
+    private final CardNameKoResolver cardNameKoResolver;
     private final ListingRepository listingRepository;
     private final BuyOfferRepository buyOfferRepository;
     private final BuyOfferOrderRepository buyOfferOrderRepository;
@@ -654,6 +656,7 @@ public class PriceService {
                     return new PriceRankingResponse(
                             change.cardId(),
                             card != null ? card.getName() : null,
+                            card != null ? cardNameKoResolver.resolve(card) : null,
                             card != null ? card.getImageSmall() : null,
                             change.recentAvgAmount().setScale(0, RoundingMode.HALF_UP).longValue(),
                             change.changeRate(),

--- a/Pokade/src/test/java/com/pokade/domain/chat/service/ChatServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/chat/service/ChatServiceTest.java
@@ -76,7 +76,7 @@ class ChatServiceTest {
     }
 
     private PriceRankingResponse ranking(String cardName) {
-        return new PriceRankingResponse(1L, cardName, null, 10000, BigDecimal.TEN, 1000);
+        return new PriceRankingResponse(1L, cardName, null, null, 10000, BigDecimal.TEN, 1000);
     }
 
     private void allowRateLimit() {

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -368,8 +368,8 @@ class PriceControllerTest {
     @Test
     void 급등_랭킹을_조회하면_200과_변동률_상위_목록을_반환한다() throws Exception {
         List<PriceRankingResponse> ranking = List.of(
-                new PriceRankingResponse(2L, "Charizard-GX", "img-2", 340000L, new BigDecimal("13.33"), 40000L),
-                new PriceRankingResponse(1L, "Blastoise", "img-1", 900000L, new BigDecimal("12.5"), 100000L)
+                new PriceRankingResponse(2L, "Charizard-GX", null, "img-2", 340000L, new BigDecimal("13.33"), 40000L),
+                new PriceRankingResponse(1L, "Blastoise", null, "img-1", 900000L, new BigDecimal("12.5"), 100000L)
         );
         given(priceService.getRanking("rise")).willReturn(ranking);
 
@@ -384,7 +384,7 @@ class PriceControllerTest {
     @Test
     void 급락_랭킹을_조회하면_200과_변동률_하위_목록을_반환한다() throws Exception {
         List<PriceRankingResponse> ranking = List.of(
-                new PriceRankingResponse(4L, "Charizard ex", "img-4", 430000L, new BigDecimal("-14"), -70000L)
+                new PriceRankingResponse(4L, "Charizard ex", null, "img-4", 430000L, new BigDecimal("-14"), -70000L)
         );
         given(priceService.getRanking("fall")).willReturn(ranking);
 

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -5,6 +5,7 @@ import com.pokade.domain.card.entity.CardPrice;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.listing.entity.ListingStatus;
@@ -76,6 +77,9 @@ class PriceServiceTest {
 
     @Mock
     private CardVariantRepository cardVariantRepository;
+
+    @Mock
+    private CardNameKoResolver cardNameKoResolver;
 
     @Mock
     private ListingRepository listingRepository;


### PR DESCRIPTION
## 📌 관련 이슈
- #371 

## ✨ 작업 내용

- `GET /api/prices/ranking` 응답이 카드 한글 이름을 내려주지 않아, 카드 상세페이지/워치리스트와 달리 항상 영문 이름만 표시되던 문제 수정
- `PriceRankingResponse`에 `cardNameKo` 필드 추가
- `PriceService.computeRanking()`에서 카드 상세/워치리스트가 이미 쓰던 `CardNameKoResolver`(카드 도감번호 기준 한글 종족명 치환)를 그대로 재사용해 각 카드의 한글 이름을 채워 반환
- 필드 추가로 시그니처가 바뀐 `PriceRankingResponse`를 참조하던 기존 테스트 3개 파일(`PriceServiceTest`, `PriceControllerTest`, `ChatServiceTest`)의 positional argument도 함께 수정

## 📸 스크린샷 / 테스트 결과

- `PriceServiceTest`(61) / `PriceControllerTest`(34) / `ChatServiceTest`(12) 전체 통과
- (Swagger/curl 응답 캡처는 리뷰 전 추가 예정)

## 🔍 리뷰 포인트

- `cardNameKo`가 없는 카드(도감번호 매핑 없음, 트레이너/에너지 카드 등)는 `null`로 내려가는 게 맞는 설계인지 — 카드 상세/워치리스트와 동일한 정책(어설픈 오번역보다 원문 폴백이 안전)
- 새 필드 추가로 수정한 기존 테스트들의 positional argument 위치가 정확한지

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?