### PR TITLE
[Fix] #374 시세 배치 조회(summaries) API가 동일 카드 동시각 체결 시 400을 반환하던 문제 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -40,14 +40,8 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
                                            @Param("status") TradeStatus status,
                                            @Param("from") LocalDateTime from);
 
-    /**
-     * 카드별 가장 최근 체결가 1건(grade 지정 시 해당 등급만). confirmedAt이 동률인 체결이 2건 이상이면
-     * "t.confirmedAt = MAX(...)" 방식은 둘 다 반환해 호출부의 Collectors.toMap()이 "Duplicate key"
-     * 예외를 던진다(실제로 더미 시드 데이터의 초 단위 미만 timestamp 충돌로 재현됨) - DISTINCT ON으로
-     * 동률이어도 항상 정확히 1건(그중 id가 가장 큰, 즉 가장 나중에 생성된 체결)만 반환하도록 네이티브
-     * 쿼리로 재작성했다. enum을 네이티브 쿼리에 그대로 바인딩하면 ordinal로 전송되는 문제
-     * (findPriceRangesByCardIdsSincePerCard 주석 참고)와 동일하게 문자열로 변환해서 넘긴다.
-     */
+    // 카드별 최근 체결가 1건: confirmedAt 동률 시 MAX()만으로는 2건이 반환돼 Collectors.toMap()이
+    // 깨지므로 DISTINCT ON으로 확정한다. 네이티브 쿼리라 enum은 문자열로 변환해서 넘긴다.
     default List<CardPriceView> findRecentCompletedTradePricesByCardIds(List<Long> cardIds, ListingGrade grade,
                                                                           TradeStatus status) {
         return findRecentCompletedTradePricesByCardIdsNative(cardIds, grade == null ? null : grade.name(),

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -40,16 +40,29 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
                                            @Param("status") TradeStatus status,
                                            @Param("from") LocalDateTime from);
 
-    // 카드별 가장 최근 체결가 1건(grade 지정 시 해당 등급만)
-    @Query("SELECT l.cardId AS cardId, t.price AS price FROM Trade t JOIN t.listing l "
-            + "WHERE l.cardId IN (:cardIds) AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status "
-            + "AND t.confirmedAt = ("
-            + "    SELECT MAX(t2.confirmedAt) FROM Trade t2 JOIN t2.listing l2 "
-            + "    WHERE l2.cardId = l.cardId AND (:grade IS NULL OR l2.grade = :grade) AND t2.status = :status"
-            + ")")
-    List<CardPriceView> findRecentCompletedTradePricesByCardIds(@Param("cardIds") List<Long> cardIds,
-                                                                  @Param("grade") ListingGrade grade,
-                                                                  @Param("status") TradeStatus status);
+    /**
+     * 카드별 가장 최근 체결가 1건(grade 지정 시 해당 등급만). confirmedAt이 동률인 체결이 2건 이상이면
+     * "t.confirmedAt = MAX(...)" 방식은 둘 다 반환해 호출부의 Collectors.toMap()이 "Duplicate key"
+     * 예외를 던진다(실제로 더미 시드 데이터의 초 단위 미만 timestamp 충돌로 재현됨) - DISTINCT ON으로
+     * 동률이어도 항상 정확히 1건(그중 id가 가장 큰, 즉 가장 나중에 생성된 체결)만 반환하도록 네이티브
+     * 쿼리로 재작성했다. enum을 네이티브 쿼리에 그대로 바인딩하면 ordinal로 전송되는 문제
+     * (findPriceRangesByCardIdsSincePerCard 주석 참고)와 동일하게 문자열로 변환해서 넘긴다.
+     */
+    default List<CardPriceView> findRecentCompletedTradePricesByCardIds(List<Long> cardIds, ListingGrade grade,
+                                                                          TradeStatus status) {
+        return findRecentCompletedTradePricesByCardIdsNative(cardIds, grade == null ? null : grade.name(),
+                status.name());
+    }
+
+    @Query(value = """
+            SELECT DISTINCT ON (l.card_id) l.card_id AS cardId, t.price AS price
+            FROM trades t JOIN listings l ON l.id = t.listing_id
+            WHERE l.card_id IN (:cardIds) AND (:grade IS NULL OR l.grade = :grade) AND t.status = :status
+            ORDER BY l.card_id, t.confirmed_at DESC, t.id DESC
+            """, nativeQuery = true)
+    List<CardPriceView> findRecentCompletedTradePricesByCardIdsNative(@Param("cardIds") List<Long> cardIds,
+                                                                        @Param("grade") String grade,
+                                                                        @Param("status") String status);
 
     interface CardPriceView {
         Long getCardId();


### PR DESCRIPTION
## 📌 관련 이슈
- #374 

## ✨ 작업 내용

- `GET /api/prices/summaries?...&includeRecentTradePrice=true`가 특정 카드 조합에서 `400 INVALID_INPUT`(`Duplicate key ...`)을 반환하던 버그 수정
- 원인: `PriceTradeStatsRepository.findRecentCompletedTradePricesByCardIds()`가 "카드별 최근 체결가 1건"을 `t.confirmedAt = MAX(confirmedAt)`로 찾는데, 같은 카드에 confirmedAt이 완전히 동일한(동률) 체결이 2건 이상이면 둘 다 반환해버려 호출부의 `Collectors.toMap()`이 예외를 던짐
- 네이티브 `DISTINCT ON` 쿼리로 교체 — 동률이어도 `ORDER BY confirmed_at DESC, id DESC` 기준으로 항상 정확히 1건(더 나중에 생성된 체결)만 반환하도록 수정
- API 요청/응답 형태(URL, 파라미터, 응답 필드)는 그대로라 FE 변경 없음

## 📸 스크린샷 / 테스트 결과

- `PriceServiceTest`(61), `PriceControllerTest`(34) 전체 통과
- 운영 DB에 실제로 confirmedAt이 동률인 카드가 있는 상태에서 수정된 쿼리를 직접 실행해, 해당 카드 포함 15개 카드 전부 중복 없이 1건씩 나오는 것까지 확인

## 🔍 리뷰 포인트

- `DISTINCT ON (l.card_id) ... ORDER BY l.card_id, t.confirmed_at DESC, t.id DESC` — 동률 시 "id가 더 큰(나중에 생성된) 체결"을 택하는 타이브레이커가 합리적인 기준인지
- `default` 메서드로 enum → 문자열 변환 후 네이티브 쿼리에 넘기는 기존 컨벤션(`findPriceRangesByCardIdsSincePerCard`)을 그대로 따랐는지

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?