### PR TITLE
[Feature] 인기순 정렬 기준을 일간 조회수로 변경 및 자정 리셋 스케줄러 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/dto/CardDetailResponse.java
@@ -30,7 +30,7 @@ public record CardDetailResponse(
 
     /**
      * viewCount는 card.getViewCount()로 읽지 않고 별도 파라미터로 받는다 - 호출부(CardQueryService.getDetail())가
-     * incrementViewCount()의 조회수 원자적 증가(UPDATE) 이후에도 이 조회 한 건에 한해 "증가된 값"을 응답에
+     * incrementViewCounts()의 조회수 원자적 증가(UPDATE) 이후에도 이 조회 한 건에 한해 "증가된 값"을 응답에
      * 보여주기 위해 계산한 값을 넘기기 때문이다. card 엔티티 자체의 필드를 직접 mutate하지 않는 이유는,
      * 그러면 이 영속 엔티티가 dirty로 잡혀 트랜잭션 커밋 시 별도 UPDATE가 한 번 더 나가면서, 그 사이 다른
      * 요청이 원자적으로 증가시킨 최신 값을 이 요청의 "오래된 값+1"로 덮어써버리는 lost update가 재발할 수 있다.

--- a/Pokade/src/main/java/com/pokade/domain/card/entity/Card.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/entity/Card.java
@@ -99,12 +99,20 @@ public class Card {
     @Column(name = "view_count", nullable = false)
     private Integer viewCount = 0;
 
+    /**
+     * 인기순 정렬(sort=popular) 전용 일간 조회수 - 매일 자정 DailyViewCountResetScheduler가 0으로 되돌린다(#377).
+     * 카드 상세의 "N회 조회"에 쓰는 누적값은 viewCount 쪽이고, 이 값은 응답에 노출하지 않는다.
+     */
+    @Builder.Default
+    @Column(name = "daily_view_count", nullable = false)
+    private Integer dailyViewCount = 0;
+
     @Column(name = "synced_at")
     private LocalDateTime syncedAt;
 
     /**
      * Scrydex 동기화 배치에서 이미 존재하는 카드(external_id 매칭)를 갱신할 때 사용한다.
-     * id·externalId·viewCount는 애플리케이션이 별도로 관리하는 값이라 여기서 건드리지 않는다.
+     * id·externalId·viewCount·dailyViewCount는 애플리케이션이 별도로 관리하는 값이라 여기서 건드리지 않는다.
      */
     public void applySync(CardSyncFields fields) {
         this.name = fields.name();

--- a/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/repository/CardRepository.java
@@ -75,7 +75,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                   @Param("expansionId") String expansionId,
                                   Pageable pageable);
 
-    @Query(value = CardSearchSql.CARD_SEARCH_BASE + "ORDER BY c.view_count DESC, c.id DESC",
+    @Query(value = CardSearchSql.CARD_SEARCH_BASE + "ORDER BY c.daily_view_count DESC, c.id DESC",
             countQuery = CardSearchSql.CARD_SEARCH_COUNT,
             nativeQuery = true)
     Page<Card> searchOrderByPopular(@Param("hasTypes") boolean hasTypes,
@@ -90,10 +90,28 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                      @Param("expansionId") String expansionId,
                                      Pageable pageable);
 
+    /**
+     * 누적 조회수와 일간 조회수를 한 문장으로 함께 증가시킨다(#377). 두 UPDATE로 나누면 같은 행에
+     * 왕복·행 락이 두 번 걸리고, 한쪽만 성공하는 경로가 생기면 두 카운터가 어긋날 수 있다.
+     */
     @Transactional
     @Modifying
-    @Query(value = "UPDATE cards SET view_count = view_count + 1 WHERE id = :id", nativeQuery = true)
-    void incrementViewCount(@Param("id") Long id);
+    @Query(value = "UPDATE cards SET view_count = view_count + 1, daily_view_count = daily_view_count + 1 WHERE id = :id",
+            nativeQuery = true)
+    void incrementViewCounts(@Param("id") Long id);
+
+    /**
+     * 인기순 정렬 기준을 하루 단위로 고정하기 위해 매일 자정 일간 조회수를 0으로 되돌린다(#377).
+     * 누적 view_count는 건드리지 않는다. {@code WHERE daily_view_count <> 0}이 붙은 이유는 Postgres가
+     * UPDATE마다 새 튜플을 쓰기 때문이다 - 조건 없이 매일 전체 행을 갱신하면 테이블·인덱스 블로트가
+     * 매일 누적된다. 실제로 값이 남아 있는 소수 행만 되돌리면 결과는 동일하다.
+     *
+     * @return 0으로 되돌린 행 수
+     */
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE cards SET daily_view_count = 0 WHERE daily_view_count <> 0", nativeQuery = true)
+    int resetDailyViewCounts();
 
     /**
      * 카드별 ACTIVE 매물에 존재하는 등급(S/A/B) 집합을 배치로 조회한다.
@@ -216,7 +234,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                         @Param("expansionId") String expansionId,
                                         Pageable pageable);
 
-    @Query(value = CardSearchSql.NAME_EXACT_FILTER_BASE + "ORDER BY c.view_count DESC, c.id DESC",
+    @Query(value = CardSearchSql.NAME_EXACT_FILTER_BASE + "ORDER BY c.daily_view_count DESC, c.id DESC",
             countQuery = CardSearchSql.NAME_EXACT_FILTER_COUNT,
             nativeQuery = true)
     Page<Card> searchByNameOrderByPopular(@Param("keyword") String keyword,
@@ -286,7 +304,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
                                                   @Param("expansionId") String expansionId,
                                                   Pageable pageable);
 
-    @Query(value = CardSearchSql.POKEDEX_SEARCH_FILTER_BASE + "ORDER BY c.view_count DESC, c.id DESC",
+    @Query(value = CardSearchSql.POKEDEX_SEARCH_FILTER_BASE + "ORDER BY c.daily_view_count DESC, c.id DESC",
             countQuery = CardSearchSql.POKEDEX_SEARCH_FILTER_COUNT,
             nativeQuery = true)
     Page<Card> searchByPokedexNumbersOrderByPopular(@Param("pokedexNumbers") List<Integer> pokedexNumbers,

--- a/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/CardQueryService.java
@@ -142,10 +142,12 @@ public class CardQueryService {
     public CardDetailResponse getDetail(Long id) {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
-        cardRepository.incrementViewCount(id);
+        cardRepository.incrementViewCounts(id);
         // 운영 계측 - #217 도입, card 대시보드가 사용 중
         meterRegistry.counter("card.view.increment.calls").increment();
-        // incrementViewCount()는 벌크 UPDATE라 위에서 조회해 둔 card 엔티티의 메모리 값에는 반영되지
+        // #377: incrementViewCounts()는 누적 view_count와 인기순 정렬용 daily_view_count를 함께 올린다.
+        // 응답에 노출하는 건 누적값(displayedViewCount)뿐이고, 일간값은 정렬 기준으로만 쓰인다.
+        // incrementViewCounts()는 벌크 UPDATE라 위에서 조회해 둔 card 엔티티의 메모리 값에는 반영되지
         // 않는다(영속성 컨텍스트를 거치지 않음) - 그래서 "이번 방문으로 +1된" 값을 직접 계산해서 응답에
         // 쓴다. card.setViewCount()로 엔티티 자체를 고치지 않는 이유는 CardDetailResponse.of() 주석 참고 -
         // 영속 엔티티를 mutate하면 커밋 시 dirty checking으로 별도 UPDATE가 나가면서 동시 요청의 원자적

--- a/Pokade/src/main/java/com/pokade/domain/card/service/DailyViewCountResetScheduler.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/service/DailyViewCountResetScheduler.java
@@ -1,0 +1,36 @@
+package com.pokade.domain.card.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.pokade.domain.card.repository.CardRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+// 인기순 정렬(sort=popular)의 기준을 하루 단위로 고정하기 위해, 매일 자정에 cards.daily_view_count를
+// 0으로 되돌린다(#377). 카드 상세의 "N회 조회"에 쓰는 누적 view_count는 건드리지 않는다 - 두 값을
+// 분리한 이유가 "누적은 그대로 보여주고 랭킹만 하루 단위로 끊는다"는 것이기 때문이다.
+//
+// 자정을 고른 이유: "오늘의 인기 카드"가 달력상 하루와 어긋나지 않게 하려면 경계가 00:00이어야 한다.
+// 트래픽이 적은 새벽 시간대로 미루면 그만큼 전날 조회수가 오늘 랭킹에 섞인다. 리셋은 조건부 단일
+// UPDATE라 비용이 거의 없어서 트래픽 시간대를 피할 필요가 없다.
+//
+// 실패 시 try/catch로 감싸지 않는 이유: 쿼리 1개짜리 전량 처리라 다른 스케줄러들처럼 "일부만 실패해도
+// 나머지는 진행"시킬 대상이 없다. 실패하면 Spring 스케줄러가 스택트레이스를 남기고, 그날 하루 랭킹이
+// 전날 값을 이어받은 상태로 유지된다(다음 자정에 자동 복구).
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DailyViewCountResetScheduler {
+
+    private final CardRepository cardRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void resetDailyViewCounts() {
+        int resetCount = cardRepository.resetDailyViewCounts();
+        if (resetCount > 0) {
+            log.info("일간 조회수 리셋된 카드 수: {}", resetCount);
+        }
+    }
+}

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -100,6 +100,9 @@ UPDATE cards SET view_count = 2500 WHERE external_id = 'me1-12';
 UPDATE cards SET view_count = 1800 WHERE external_id = 'xy7-54';
 UPDATE cards SET view_count = 1200 WHERE external_id = 'sm11-95';
 UPDATE cards SET view_count = 300 WHERE external_id = 'sv10_ja-1';
+-- 인기순 정렬은 daily_view_count 기준(#377)이라 시드도 같은 값으로 맞춘다. 위 12건을 복제하지 않고
+-- view_count를 그대로 옮겨 담아 두 값이 갈라지지 않게 한다(시드 대상이 아닌 카드는 양쪽 모두 0).
+UPDATE cards SET daily_view_count = view_count;
 
 
 -- =========================================================

--- a/Pokade/src/main/resources/db/migration/V20__add_daily_view_count_to_cards.sql
+++ b/Pokade/src/main/resources/db/migration/V20__add_daily_view_count_to_cards.sql
@@ -1,0 +1,10 @@
+-- 카드 상세의 "N회 조회"는 누적 view_count를 그대로 쓰고, 인기순 정렬(sort=popular)만 하루 단위로
+-- 고정하기 위해 일간 카운터를 분리한다(#377). 매일 자정 DailyViewCountResetScheduler가 0으로 되돌린다.
+ALTER TABLE cards ADD COLUMN IF NOT EXISTS daily_view_count INTEGER NOT NULL DEFAULT 0;
+
+-- V10의 idx_cards_view_count_id와 같은 이유로 필수다: 인기순 쿼리는 항상
+-- "ORDER BY <정렬컬럼> DESC, id DESC ... LIMIT n" 형태라 이 복합 인덱스가 없으면 풀스캔으로 회귀한다.
+-- id를 두 번째 컬럼에 두는 것도 쿼리의 타이브레이커(c.id DESC)와 일치시켜 정렬을 인덱스로 끝내기 위함.
+-- (V10의 idx_cards_view_count_id는 인기순이 유일한 소비처였어서 이 시점부터 사실상 미사용이 되지만,
+--  이번 변경 범위를 좁게 두기 위해 삭제하지 않고 남겨둔다.)
+CREATE INDEX IF NOT EXISTS idx_cards_daily_view_count_id ON cards(daily_view_count DESC, id DESC);

--- a/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/repository/CardRepositoryTest.java
@@ -374,7 +374,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("t22 sort=popular이면 조회수 내림차순으로 정렬한다")
+    @DisplayName("t22 sort=popular이면 일간 조회수 내림차순으로 정렬한다")
     void t22() {
         Expansion popExpansion = persistExpansion("popTest", "Popularity Test");
         persistCardWithViewCount("Mewtwo", popExpansion, 50);
@@ -389,11 +389,11 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("t23 필터와 sort=popular를 함께 적용해도 필터링된 결과 안에서 조회수순으로 정렬한다")
+    @DisplayName("t23 필터와 sort=popular를 함께 적용해도 필터링된 결과 안에서 일간 조회수순으로 정렬한다")
     void t23() {
-        cardRepository.incrementViewCount(charizard.getId());
-        cardRepository.incrementViewCount(charizard.getId());
-        cardRepository.incrementViewCount(charizardEx.getId());
+        cardRepository.incrementViewCounts(charizard.getId());
+        cardRepository.incrementViewCounts(charizard.getId());
+        cardRepository.incrementViewCounts(charizardEx.getId());
         entityManager.flush();
         entityManager.clear();
 
@@ -405,14 +405,16 @@ class CardRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("t24 상세 조회 시 view_count를 원자적 UPDATE로 1 증가시킨다")
+    @DisplayName("t24 상세 조회 시 view_count와 daily_view_count를 원자적 UPDATE로 함께 1 증가시킨다")
     void t24() {
-        cardRepository.incrementViewCount(charizard.getId());
+        cardRepository.incrementViewCounts(charizard.getId());
         entityManager.flush();
         entityManager.clear();
 
         Card reloaded = cardRepository.findById(charizard.getId()).orElseThrow();
         assertThat(reloaded.getViewCount()).isEqualTo(1);
+        // #377: 두 카운터를 한 문장으로 올리므로 누적/일간이 어긋나지 않는지 함께 확인한다.
+        assertThat(reloaded.getDailyViewCount()).isEqualTo(1);
     }
 
     @Test
@@ -437,7 +439,7 @@ class CardRepositoryTest extends AbstractIntegrationTest {
             ExecutorService executor = Executors.newFixedThreadPool(threadCount);
             List<Future<?>> futures = new ArrayList<>();
             for (int i = 0; i < threadCount; i++) {
-                futures.add(executor.submit(() -> cardRepository.incrementViewCount(cardId)));
+                futures.add(executor.submit(() -> cardRepository.incrementViewCounts(cardId)));
             }
             executor.shutdown();
             boolean terminated = executor.awaitTermination(10, TimeUnit.SECONDS);
@@ -450,19 +452,24 @@ class CardRepositoryTest extends AbstractIntegrationTest {
                 assertThatCode(future::get).doesNotThrowAnyException();
             }
 
-            Integer finalViewCount = requiresNew.execute(status ->
-                    cardRepository.findById(cardId).orElseThrow().getViewCount());
-            assertThat(finalViewCount).isEqualTo(threadCount);
+            Card finalCard = requiresNew.execute(status ->
+                    cardRepository.findById(cardId).orElseThrow());
+            assertThat(finalCard.getViewCount()).isEqualTo(threadCount);
+            // #377: 한 문장에서 두 컬럼을 함께 올리므로 동시 요청에서도 일간 카운터가 같은 값으로 누적돼야 한다.
+            assertThat(finalCard.getDailyViewCount()).isEqualTo(threadCount);
         } finally {
             requiresNew.executeWithoutResult(status -> cardRepository.deleteById(cardId));
         }
     }
 
+    // #377: 인기순 정렬 기준이 daily_view_count로 바뀌었으므로 누적/일간 두 값을 같은 값으로 심는다.
+    // 한쪽만 심으면 정렬 기준 컬럼이 전부 0이 되어 c.id DESC 타이브레이커만 남아 테스트가 무의미해진다.
     private Card persistCardWithViewCount(String name, Expansion expansion, int viewCount) {
         Card card = Card.builder()
                 .name(name)
                 .expansion(expansion)
                 .viewCount(viewCount)
+                .dailyViewCount(viewCount)
                 .build();
         entityManager.persist(card);
         return card;
@@ -793,5 +800,26 @@ class CardRepositoryTest extends AbstractIntegrationTest {
         assertThat(result.getContent())
                 .extracting(Card::getName)
                 .containsExactlyInAnyOrder("Mega Lucario ex", "クヌギダマ");
+    }
+
+    @Test
+    @DisplayName("t61 resetDailyViewCounts()는 daily_view_count만 0으로 되돌리고 누적 view_count는 유지한다(#377)")
+    void t61() {
+        Expansion resetExpansion = persistExpansion("resetTest", "Daily Reset Test");
+        persistCardWithViewCount("Pikachu", resetExpansion, 70);
+        persistCardWithViewCount("Raichu", resetExpansion, 0);
+        entityManager.flush();
+
+        int resetCount = cardRepository.resetDailyViewCounts();
+        entityManager.clear();
+
+        // daily_view_count가 0인 행은 WHERE 절에서 제외되므로 갱신 대상은 값이 남아 있던 1건뿐이다
+        // (setUp()이 만드는 카드들도 일간 조회수가 전부 0이라 대상에 들어오지 않는다).
+        assertThat(resetCount).isEqualTo(1);
+        assertThat(cardRepository.search(null, null, "resetTest", null, null, "popular", PageRequest.of(0, 10)).getContent())
+                .extracting(Card::getName, Card::getViewCount, Card::getDailyViewCount)
+                .containsExactlyInAnyOrder(
+                        tuple("Pikachu", 70, 0),
+                        tuple("Raichu", 0, 0));
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/CardQueryServiceTest.java
@@ -368,9 +368,12 @@ class CardQueryServiceTest {
         assertThat(result.variants().get(0).variantName()).isEqualTo("unlimitedHolofoil");
         assertThat(result.variants().get(0).grades()).containsExactly("A");
         assertThat(result.variants().get(1).grades()).containsExactly("B");
-        verify(cardRepository).incrementViewCount(1L);
-        // #308 후속: incrementViewCount()는 벌크 UPDATE라 메모리상 card.viewCount(0)에는 반영되지
+        // #377: 누적 view_count와 인기순 정렬용 daily_view_count를 한 문장으로 올리므로 호출은 1회다
+        // (두 컬럼이 실제로 함께 증가하는지는 CardRepositoryTest t24/t25에서 DB로 검증한다).
+        verify(cardRepository).incrementViewCounts(1L);
+        // #308 후속: incrementViewCounts()는 벌크 UPDATE라 메모리상 card.viewCount(0)에는 반영되지
         // 않는데, 응답은 "이번 방문으로 증가된 값"(0+1=1)을 보여줘야 한다 - 증가 전 값(0)이 아니라야 한다.
+        // 일간 카운터는 정렬 기준으로만 쓰이고 응답 DTO에 필드 자체가 없다.
         assertThat(result.viewCount()).isEqualTo(1);
     }
 
@@ -383,7 +386,7 @@ class CardQueryServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.CARD_NOT_FOUND);
-        verify(cardRepository, never()).incrementViewCount(any());
+        verify(cardRepository, never()).incrementViewCounts(any());
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/card/service/DailyViewCountResetSchedulerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/service/DailyViewCountResetSchedulerTest.java
@@ -1,0 +1,45 @@
+package com.pokade.domain.card.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pokade.domain.card.repository.CardRepository;
+
+// 실제 리셋 쿼리의 동작(일간만 0으로, 누적은 유지, 조건부 갱신 건수)은 CardRepositoryTest t61에서
+// DB로 검증한다 - 이 클래스는 스케줄러가 그 쿼리에 위임하고 누적 카운터를 건드리지 않는지만 본다.
+@ExtendWith(MockitoExtension.class)
+class DailyViewCountResetSchedulerTest {
+
+    @Mock CardRepository cardRepository;
+    @InjectMocks DailyViewCountResetScheduler scheduler;
+
+    @Test
+    @DisplayName("리셋 대상이 있으면 resetDailyViewCounts()에 위임하고 누적 조회수는 건드리지 않는다")
+    void reset_delegatesToRepository() {
+        given(cardRepository.resetDailyViewCounts()).willReturn(3);
+
+        scheduler.resetDailyViewCounts();
+
+        then(cardRepository).should().resetDailyViewCounts();
+        then(cardRepository).should(never()).incrementViewCounts(any());
+    }
+
+    @Test
+    @DisplayName("리셋 대상이 0건이어도 예외 없이 정상 종료된다")
+    void reset_noRows_doesNotThrow() {
+        given(cardRepository.resetDailyViewCounts()).willReturn(0);
+
+        scheduler.resetDailyViewCounts();
+
+        then(cardRepository).should().resetDailyViewCounts();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #377 

## ✨ 작업 내용
- `cards` 테이블에 `daily_view_count` 컬럼 추가 (V20 마이그레이션)
- 카드 상세 조회 시 `view_count`(누적)와 `daily_view_count`(일간) 동시 증가
- 인기순 정렬 기준을 `view_count` → `daily_view_count`로 변경 (3곳)
- 매일 자정 `daily_view_count` 리셋 스케줄러 추가 (`DailyViewCountResetScheduler`)
- 카드 상세의 "N회 조회"는 누적 `view_count` 그대로 유지

## 📸 스크린샷 / 테스트 결과
- `card` 도메인 전체 테스트 BUILD SUCCESSFUL
- 전체 테스트 1114개 중 11개 실패 — 전부 기존 결함 (develop 대조 확인)
  - `AiGradeServiceTest` 2건: MeterRegistry null (ai 도메인)
  - `WithdrawalConfirmIntegrationTest` 4건: MeterRegistry 빈 없음 (user 도메인)
  - `TradeRepositoryTest` 4건: ClosedChannelException (trade 도메인)
  - `NotificationRepositoryTest` 1건: createdAt 동일 시 정렬 불안정 (플래키, notification 도메인)

## 🔍 리뷰 포인트
- 앱을 한 번 기동하기 전에는 슬라이스 테스트(`@DataJpaTest` 계열)가 깨질 수 있습니다. 
   로컬 dev DB에 V20이 미적용 상태이기 때문이며, 앱 기동 시 Flyway가 자동 적용합니다.
- `NotificationRepositoryTest` 플래키 1건은 `createdAt DESC` 정렬에 `id`를 2차 키로 추가하면 해소됩니다. 
   notification 담당자 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인기순 카드 정렬이 누적 조회수가 아닌 일간 조회수를 기준으로 제공됩니다.
  * 카드 상세 조회 시 누적 조회수와 일간 조회수가 함께 반영됩니다.
  * 일간 조회수는 매일 자정에 자동으로 초기화되며, 누적 조회수는 유지됩니다.

* **개선**
  * 조회수 집계의 일관성과 동시성 처리가 강화되었습니다.
  * 카드 동기화 과정에서 일간 조회수가 보존됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->