### PR TITLE
fix: AI 진단 이미지 형식 검증에서 GIF 제외 및 안내 문구 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -52,9 +52,10 @@ public class AiGradeService {
     private static final int MAX_PAGE_SIZE = 100;
     private static final int VISION_MAX_ATTEMPTS = 3;
 
-    // OpenAI Vision이 실제로 지원하는 이미지 포맷 (ImageIO는 디코딩되지만 Vision은 거부하는 bmp/tiff 등을 사전 차단)
+    // 실제 카메라로 촬영한 "사진"만 받는다 — GIF는 Vision이 첫 프레임만 읽어 애니메이션/움짤이면
+    // 실제로 찍은 카드 사진이 아닐 가능성이 높고, bmp/tiff 등은 Vision이 아예 거부하므로 사전 차단.
     private static final Set<String> SUPPORTED_IMAGE_TYPES =
-            Set.of("image/png", "image/jpeg", "image/jpg", "image/gif", "image/webp");
+            Set.of("image/png", "image/jpeg", "image/jpg", "image/webp");
 
     // 매 요청마다 new로 생성하지 않도록 공유 인스턴스 사용 (ObjectMapper는 thread-safe)
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -251,7 +252,7 @@ public class AiGradeService {
             String contentType = file.getContentType();
             if (contentType == null || !SUPPORTED_IMAGE_TYPES.contains(contentType.toLowerCase())) {
                 throw new IllegalArgumentException(
-                        "지원하지 않는 이미지 형식입니다(png/jpeg/gif/webp만 가능): " + file.getOriginalFilename());
+                        "지원하지 않는 사진 형식입니다(jpeg/png/webp만 가능): " + file.getOriginalFilename());
             }
         }
     }


### PR DESCRIPTION
## 요약
- AI 등급 진단 업로드 허용 형식에서 GIF 제외 (jpeg/png/webp만 허용)
- GIF는 실제 카메라로 찍은 "사진"일 가능성이 낮고, OpenAI Vision도 첫 프레임만 읽어 카드 상태 판정에 부적합
- 에러 메시지 문구를 "이미지 형식" → "사진 형식"으로 수정

## 변경 파일
- `Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java`: `SUPPORTED_IMAGE_TYPES`에서 `image/gif` 제거, 에러 메시지 수정

## Test plan
- [x] `./gradlew compileJava` 통과
- [x] 로컬에서 실제 요청으로 형식 오류 트리거 → 새 메시지("지원하지 않는 사진 형식입니다(jpeg/png/webp만 가능)") 응답 확인
- [x] 형식 검증 실패가 포인트/무료횟수 차감 이전에 실행됨을 코드로 재확인 (기존 로직, 변경 없음)

Closes #384