### PR TITLE
[Fix] #386 SSE 저장소 경합 해소 및 카드 API rate limit 임시 상향

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
+++ b/Pokade/src/main/java/com/pokade/domain/card/filter/CardRateLimitFilter.java
@@ -33,8 +33,13 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 public class CardRateLimitFilter extends OncePerRequestFilter {
 
-    // 분당 허용 요청 수 — 임시값(검색/자동완성 debounce 감안 여유치), 팀 정책 확정 시 조정 필요
-    private static final int CAPACITY_PER_MINUTE = 60;
+    // 분당 허용 요청 수 — 임시값(검색/자동완성 debounce 감안 여유치), 팀 정책 확정 시 조정 필요.
+    // #386: 발표 시연 대응으로 60 → 600 임시 상향. 버킷 키가 IP라, 발표장 NAT/공유 와이파이에서는
+    // 발표자와 청중이 하나의 버킷을 공유해 60회로는 시연 중 429가 터진다. 팀 정책 확정 시 재조정.
+    // private이 아닌 이유: CardRateLimitFilterTest가 이 값을 직접 참조해 루프 횟수를 정한다 —
+    // 테스트에 임계값을 복사해 두면 이 상수를 조정할 때마다 테스트가 조용히 어긋난다
+    // (bucketCountForTest()/evictIdleEntriesForTest()와 같은 패키지 전용 테스트 seam).
+    static final int CAPACITY_PER_MINUTE = 600;
     // bucketsByIp 무한 증가 방지용 유휴 만료 기준 — 이 시간 동안 요청이 없으면 정리 대상
     private static final Duration IDLE_TTL = Duration.ofMinutes(10);
     private static final Duration CLEANUP_INTERVAL = Duration.ofMinutes(5);

--- a/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/store/SseEmitterStore.java
@@ -36,17 +36,36 @@ public class SseEmitterStore {
                 m -> m.values().stream().mapToInt(List::size).sum());
     }
 
+    // #386: computeIfAbsent(...).add(emitter)가 아니라 compute()를 쓰는 이유 - 전자는 "리스트 획득"만
+    // 원자적이고 실제 add는 맵 잠금 밖에서 일어난다. 그 사이 remove()가 마지막 Emitter를 지워 맵 엔트리를
+    // 삭제하면(아래 참고) 새 Emitter는 맵에서 떨어진 리스트에 담겨 findByUserId/findAll에 영원히 안 잡힌다 -
+    // 알림도 하트비트도 못 받는 유령 연결이 된다(새로고침으로 기존 연결이 끊기며 새 연결이 열릴 때 발생).
+    // compute()의 remapping 함수는 해당 bin 잠금 안에서 실행되므로 "리스트 생성 → 추가 → 맵 반영"이 한
+    // 덩어리가 되고, remove()와 어느 순서로 겹쳐도 결과가 안전하다:
+    //   remove가 먼저 → 엔트리 삭제 → 여기서 list==null을 보고 새 리스트를 만들어 넣는다
+    //   save가 먼저   → 리스트 크기 1 → remove가 자기 것만 빼도 비지 않아 엔트리가 유지된다
+    // 반환값(항상 non-null)을 그대로 로깅에 쓴다 - 예전의 emitters.get(userId).size()는 같은 경합에서
+    // null.size() NPE로 subscribe 자체를 500으로 만들었다.
     public void save(Long userId, SseEmitter emitter) {
-        emitters.computeIfAbsent(userId, key -> new CopyOnWriteArrayList<>()).add(emitter);
-        log.info("[SSE] Emitter 등록 userId={}, 현재 연결 수={}", userId, emitters.get(userId).size());
+        List<SseEmitter> current = emitters.compute(userId, (key, list) -> {
+            List<SseEmitter> target = list != null ? list : new CopyOnWriteArrayList<>();
+            target.add(emitter);
+            return target;
+        });
+        log.info("[SSE] Emitter 등록 userId={}, 현재 연결 수={}", userId, current.size());
     }
 
+    // 리스트가 비면 null을 반환해 맵 엔트리까지 지운다 - 유저가 전부 접속을 끊었는데 빈 리스트만 남아
+    // 맵이 무한히 커지는 것을 막는다.
+    // computeIfPresent의 반환값을 그대로 쓴다(엔트리가 지워졌으면 null) - 예전엔 findByUserId()로 다시
+    // 조회해 크기를 찍었는데, 그 재조회 자체가 두 번째 경합 창이었다(그 사이 다른 탭이 등록하면 로그가
+    // 방금 제거한 결과와 다른 수를 찍는다).
     public void remove(Long userId, SseEmitter emitter) {
-        emitters.computeIfPresent(userId, (key, list) -> {
+        List<SseEmitter> remaining = emitters.computeIfPresent(userId, (key, list) -> {
             list.remove(emitter);
             return list.isEmpty() ? null : list;
         });
-        log.info("[SSE] Emitter 제거 userId={}, 남은 연결 수={}", userId, findByUserId(userId).size());
+        log.info("[SSE] Emitter 제거 userId={}, 남은 연결 수={}", userId, remaining == null ? 0 : remaining.size());
     }
 
     public List<SseEmitter> findByUserId(Long userId) {

--- a/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/card/filter/CardRateLimitFilterTest.java
@@ -12,6 +12,10 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 class CardRateLimitFilterTest {
 
+    // #386: 분당 임계값을 테스트에 리터럴로 복사해 두면(예전엔 60이 9곳에 박혀 있었다) 프로덕션 상수를
+    // 조정할 때마다 테스트가 조용히 어긋난다. 같은 패키지이므로 프로덕션 상수를 직접 참조한다.
+    private static final int CAPACITY = CardRateLimitFilter.CAPACITY_PER_MINUTE;
+
     // #343: 프로덕션의 no-arg 생성자를 없애면서, 레지스트리는 테스트가 직접 넘긴다.
     // 지표 값을 확인할 필요가 없는 테스트는 이 헬퍼로 일회용 레지스트리를 받는다.
     private CardRateLimitFilter newFilter() {
@@ -24,7 +28,7 @@ class CardRateLimitFilterTest {
         CardRateLimitFilter filter = newFilter();
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < CAPACITY; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr("127.0.0.1");
             MockHttpServletResponse response = new MockHttpServletResponse();
@@ -33,7 +37,7 @@ class CardRateLimitFilterTest {
 
             assertThat(response.getStatus()).isEqualTo(200);
         }
-        Mockito.verify(filterChain, Mockito.times(60)).doFilter(Mockito.any(), Mockito.any());
+        Mockito.verify(filterChain, Mockito.times(CAPACITY)).doFilter(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -42,7 +46,7 @@ class CardRateLimitFilterTest {
         CardRateLimitFilter filter = newFilter();
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < CAPACITY; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr("127.0.0.2");
             filter.doFilter(request, new MockHttpServletResponse(), filterChain);
@@ -56,7 +60,7 @@ class CardRateLimitFilterTest {
 
         assertThat(overLimitResponse.getStatus()).isEqualTo(429);
         assertThat(overLimitResponse.getContentAsString()).contains("CARD_RATE_LIMIT_EXCEEDED");
-        Mockito.verify(filterChain, Mockito.times(60)).doFilter(Mockito.any(), Mockito.any());
+        Mockito.verify(filterChain, Mockito.times(CAPACITY)).doFilter(Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -65,7 +69,7 @@ class CardRateLimitFilterTest {
         CardRateLimitFilter filter = newFilter();
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < CAPACITY; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr("127.0.0.3");
             filter.doFilter(request, new MockHttpServletResponse(), filterChain);
@@ -87,7 +91,7 @@ class CardRateLimitFilterTest {
         FilterChain filterChain = Mockito.mock(FilterChain.class);
         String untrustedRemoteAddr = "203.0.113.10";
 
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < CAPACITY; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr(untrustedRemoteAddr);
             request.addHeader("X-Forwarded-For", "1.1.1." + i);
@@ -115,7 +119,7 @@ class CardRateLimitFilterTest {
         FilterChain filterChain = Mockito.mock(FilterChain.class);
         String trustedRemoteAddr = "127.0.0.1";
 
-        for (int i = 0; i < 60; i++) {
+        for (int i = 0; i < CAPACITY; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr(trustedRemoteAddr);
             request.addHeader("X-Forwarded-For", "10.1.2.3");
@@ -167,14 +171,14 @@ class CardRateLimitFilterTest {
         CardRateLimitFilter filter = new CardRateLimitFilter(meterRegistry);
         FilterChain filterChain = Mockito.mock(FilterChain.class);
 
-        for (int i = 0; i < 61; i++) {
+        for (int i = 0; i < CAPACITY + 1; i++) {
             MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/cards");
             request.setRemoteAddr("127.0.0.7");
             filter.doFilter(request, new MockHttpServletResponse(), filterChain);
         }
 
-        // 61번째 요청만 분당 60회 제한에 걸린다.
-        assertThat(meterRegistry.counter("card.ratelimit.allowed").count()).isEqualTo(60.0);
+        // 임계값을 딱 1회 넘긴 마지막 요청만 제한에 걸린다.
+        assertThat(meterRegistry.counter("card.ratelimit.allowed").count()).isEqualTo((double) CAPACITY);
         assertThat(meterRegistry.counter("card.ratelimit.rejected").count()).isEqualTo(1.0);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/notification/store/SseEmitterStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/store/SseEmitterStoreTest.java
@@ -5,7 +5,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class SseEmitterStoreTest {
 
@@ -88,5 +97,61 @@ class SseEmitterStoreTest {
         store.save(2L, userTwo);
 
         assertThat(store.findAll()).containsExactlyInAnyOrder(userOneFirst, userOneSecond, userTwo);
+    }
+
+    // #386: 새로고침(F5) 시나리오 - 브라우저가 기존 SSE 연결을 끊으면서(onCompletion → remove) 새 연결을
+    // 여는(subscribe → save) 두 호출이 겹친다. 그 유저의 마지막 연결이 닫히는 순간이면 remove가 맵
+    // 엔트리를 삭제하는데, save가 맵 잠금 밖에서 리스트에 추가하면 새 Emitter가 맵에서 떨어진 리스트에
+    // 담겨 알림·하트비트를 영구히 못 받는다(로그의 재조회에서 NPE가 나기도 한다).
+    //
+    // 인터리빙 순서 자체는 스케줄러에 달려 있어 통제하지 않는다. 대신 "순서와 무관하게 항상 성립해야
+    // 하는 성질"만 단정한다 - 어느 쪽이 먼저 실행되든 방금 등록한 새 Emitter는 반드시 조회돼야 한다.
+    // 그래서 단정은 결정론적이고, 라운드를 반복하는 것은 두 순서를 모두 밟게 하기 위한 것일 뿐이다.
+    // sleep으로 순서를 유도하지 않고 CyclicBarrier로 두 스레드를 같은 시점에 출발시킨다.
+    @Test
+    @DisplayName("remove와 save가 동시에 일어나도 새로 등록한 Emitter는 유실되지 않는다(#386)")
+    void save_concurrentWithRemove_keepsNewEmitter() throws Exception {
+        int rounds = 500;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int round = 0; round < rounds; round++) {
+                // 라운드마다 다른 userId를 써서 이전 라운드의 잔여 상태가 다음 판정에 섞이지 않게 한다.
+                long userId = round;
+                SseEmitter closing = new SseEmitter();
+                SseEmitter opening = new SseEmitter();
+                // 이미 열려 있던 연결 하나 - 이게 마지막 연결이라 remove가 맵 엔트리를 지우게 된다.
+                store.save(userId, closing);
+
+                CyclicBarrier startLine = new CyclicBarrier(2);
+                List<Future<?>> futures = new ArrayList<>();
+                futures.add(executor.submit(() -> {
+                    startLine.await();
+                    store.remove(userId, closing);
+                    return null;
+                }));
+                futures.add(executor.submit(() -> {
+                    startLine.await();
+                    store.save(userId, opening);
+                    return null;
+                }));
+
+                // future.get()으로 각 스레드의 예외를 즉시 드러낸다 - submit만 하고 get을 부르지 않으면
+                // save() 안의 NPE가 조용히 삼켜져 "유실"만 보이고 원인을 놓친다.
+                for (Future<?> future : futures) {
+                    assertThatCode(future::get)
+                            .as("round=%d - save/remove 동시 실행이 예외 없이 끝나야 한다", round)
+                            .doesNotThrowAnyException();
+                }
+
+                assertThat(store.findByUserId(userId))
+                        .as("round=%d - 새로 등록한 Emitter는 remove와 겹쳐도 남아 있어야 한다", round)
+                        .contains(opening);
+            }
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS))
+                    .as("테스트 스레드풀이 타임아웃 전에 종료되어야 한다")
+                    .isTrue();
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #386 

## ✨ 작업 내용
- `SseEmitterStore.save()`를 `computeIfAbsent(...).add()` → `compute()`로 전환
  - 리스트 생성·추가·맵 반영이 맵 잠금 안에서 한 덩어리로 처리됨
  - `emitters.get(userId).size()` 재조회 제거 (NPE 원인)
- `SseEmitterStore.remove()`도 반환값 기반 null 안전 로깅으로 변경 (재조회 제거)
- `CardRateLimitFilter` 임계값 60 → 600 상향 (발표 시연 대응 임시값)
- 임계값 상수를 패키지 전용으로 완화, 테스트 9곳 하드코딩을 상수 참조로 통일

## 📸 스크린샷 / 테스트 결과
경합 테스트 신규 추가 (`save_concurrentWithRemove_keepsNewEmitter`, 500라운드)
- 수정 전 3회 실행 → 3/3 실패 (`NullPointerException: Map.get(Object) is null`)
- 수정 후 3회 실행 → 3/3 통과 

## 🔍 리뷰 포인트
- FE 동작 변화 2건: `/api/cards/*` 429 임계값이 10배가 되어 FE의 rate limit 에러 처리가 사실상 발동하지 않습니다. 
  새로고침 후 SSE 알림이 오지 않던 증상은 해소됩니다(FE 변경 불필요).
- 600은 발표 대응 임시값이고 버킷 키는 여전히 IP입니다. 
   `X-Forwarded-For` 신뢰 정책 문제는 이번 범위가 아니라 별건으로 남아 있습니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 카드 요청 제한이 분당 60회에서 600회로 확대되어 정상적인 대량 요청을 더 원활하게 처리합니다.
  - 실시간 알림 연결을 저장하거나 해제하는 과정의 동시성 문제가 개선되어, 연결이 누락될 가능성이 줄었습니다.
  - 연결 상태와 잔여 연결 수가 보다 정확하게 관리되어 실시간 알림 기능의 안정성이 향상되었습니다.

- **버그 수정**
  - 동시에 연결을 추가하고 제거할 때 새 연결이 유실될 수 있는 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->