### PR TITLE
[Fix] 거래 상세 화면 카드 이미지 미출력 오류 #391

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
@@ -12,6 +12,7 @@ public record TradeResponse(
         Long sellerId,
         Long cardId,
         String cardName,
+        String cardImageUrl,
         Integer price,
         TradeStatus status,
         LocalDateTime shippedAt,
@@ -26,7 +27,7 @@ public record TradeResponse(
         Integer pointsUsed
 ) {
 
-    public static TradeResponse of(Trade trade, String cardName, Integer pointsUsed) {
+    public static TradeResponse of(Trade trade, String cardName, String cardImageUrl, Integer pointsUsed) {
         return new TradeResponse(
                 trade.getId(),
                 trade.getListing().getId(),
@@ -34,6 +35,7 @@ public record TradeResponse(
                 trade.getListing().getSellerId(),
                 trade.getListing().getCardId(),
                 cardName,
+                cardImageUrl,
                 trade.getPrice(),
                 trade.getStatus(),
                 trade.getShippedAt(),

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -60,13 +60,15 @@ public class TradeService {
     private final PortfolioService portfolioService;
 
     private TradeResponse toResponse(Trade trade) {
-        String cardName = cardRepository.findById(trade.getListing().getCardId())
-                .map(Card::getName)
-                .orElse(null);
+        Card card = cardRepository.findById(trade.getListing().getCardId()).orElse(null);
         Integer pointsUsed = paymentRepository.findByTradeId(trade.getId())
                 .map(Payment::getPointsUsed)
                 .orElse(null);
-        return TradeResponse.of(trade, cardName, pointsUsed);
+        return TradeResponse.of(
+                trade,
+                card != null ? card.getName() : null,
+                card != null ? card.getImageSmall() : null,
+                pointsUsed);
     }
 
     // 결제창을 띄우기 전에 주문을 먼저 PENDING으로 기록한다 - 매물은 아직 잠그지 않는다(TRADING으로

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
@@ -82,7 +82,7 @@ class AdminTradeControllerTest {
 
     private TradeResponse tradeResponseOf(Long id, TradeStatus status) {
         return new TradeResponse(
-                id, 10L, 200L, 100L, 1L, "리자몽 ex", 10000, status,
+                id, 10L, 200L, 100L, 1L, "리자몽 ex", null, 10000, status,
                 LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now(), null);
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1068,7 +1068,7 @@ class PriceServiceTest {
         given(buyOfferRepository.findById(7L)).willReturn(java.util.Optional.of(buyOffer));
         given(listingRepository.save(any(Listing.class))).willAnswer(invocation -> invocation.getArgument(0));
         TradeResponse expected = new TradeResponse(
-                100L, null, 2L, 1L, 1L, "리자몽", 250000, TradeStatus.PENDING,
+                100L, null, 2L, 1L, 1L, "리자몽", null, 250000, TradeStatus.PENDING,
                 null, null, null, null, null,
                 "김철수", "010-1234-5678", "서울시 강남구", java.time.LocalDateTime.now(), null);
         given(tradeService.createMatchedTrade(

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -146,7 +146,7 @@ class TradeControllerTest {
     void 결제승인에_성공하면_200과_생성된_거래를_반환한다() throws Exception {
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest("pay_123", "order-1", 10000L);
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, "pay_123", "order-1", 10000L))
@@ -181,7 +181,7 @@ class TradeControllerTest {
         // paymentKey 없이도 요청 자체는 컨트롤러를 통과하는지만 확인한다.
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest(null, "order-1", 0L);
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, null, "order-1", 0L)).willReturn(response);
@@ -212,7 +212,7 @@ class TradeControllerTest {
     @Test
     void 본인_거래를_조회하면_200과_거래정보를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.getTrade(200L, 1L)).willReturn(response);
@@ -254,7 +254,7 @@ class TradeControllerTest {
         LocalDateTime deliveredAt = LocalDateTime.now().minusDays(1);
         LocalDateTime confirmedAt = LocalDateTime.now();
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.COMPLETED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.COMPLETED,
                 shippedAt, inspectedAt, deliveredAt, confirmedAt, confirmedAt, null, null, null, confirmedAt, null);
 
         given(tradeService.confirmTrade(200L, 1L)).willReturn(response);
@@ -304,7 +304,7 @@ class TradeControllerTest {
     @Test
     void 구매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.CANCELLED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.CANCELLED,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(200L, 1L)).willReturn(response);
@@ -318,7 +318,7 @@ class TradeControllerTest {
     @Test
     void 판매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", 10000, TradeStatus.CANCELLED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.CANCELLED,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(100L, 1L)).willReturn(response);


### PR DESCRIPTION
## 📌 관련 이슈
- #391

## ✨ 작업 내용
<!-- 어떤 변경 사항이 있었는지 주요 내용을 적어주세요. -->
 - `TradeResponse`에 `cardImageUrl` 필드 추가                                                                                                                               
 - `TradeService.toResponse()`에서 `Card.getImageSmall()`로 채워서 반환 (마이페이지 거래 내역용 `MyTradeResponse.of()`와 동일한 소스)                                       
            

## 📸 스크린샷 / 테스트 결과
<!-- API 응답 결과(Postman/Swagger)나 실행 결과 스크린샷을 첨부해주세요. -->
- 

## 🔍 리뷰 포인트
<!-- 리뷰어가 집중해서 봐주었으면 하는 부분이 있다면 적어주세요. -->
- 

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?