### PR TITLE
fix: 도감 총 평가액/손익 계산 시 카드 원본 통화를 KRW로 환산

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -49,6 +49,14 @@ public class PortfolioService {
     private static final String EMPTY_GRADE = "";
     private static final String EMPTY_COMPANY = "";
     private static final String UNCLASSIFIED = "미분류";
+    private static final String KRW = "KRW";
+
+    // card_prices는 카드에 따라 USD/JPY로 저장돼 있어 KRW 금액과 그대로 합산할 수 없다.
+    // 실시간 환율 API가 없어 프론트(lib/currency.ts)와 동일한 고정 근사치를 사용한다.
+    private static final Map<String, BigDecimal> FX_TO_KRW = Map.of(
+            "KRW", BigDecimal.ONE,
+            "USD", BigDecimal.valueOf(1400),
+            "JPY", BigDecimal.valueOf(9));
 
     private final PortfolioItemRepository portfolioItemRepository;
     private final CardRepository cardRepository;
@@ -143,20 +151,22 @@ public class PortfolioService {
             if (price == null || price.getMarket() == null) {
                 continue;
             }
+            BigDecimal marketInKrw = toKrw(price.getMarket(), price.getCurrency());
+            if (marketInKrw == null) {
+                continue;
+            }
 
             BigDecimal quantity = BigDecimal.valueOf(item.getQuantity());
-            totalValue = totalValue.add(price.getMarket().multiply(quantity));
-            if (currency == null) {
-                currency = price.getCurrency();
-            }
+            totalValue = totalValue.add(marketInKrw.multiply(quantity));
+            currency = KRW;
 
             BigDecimal change1dPct = price.getChange1dPct();
             BigDecimal divisor = change1dPct == null
                     ? BigDecimal.ONE
                     : BigDecimal.ONE.add(change1dPct.divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP));
             BigDecimal previousUnitPrice = divisor.signum() == 0
-                    ? price.getMarket()
-                    : price.getMarket().divide(divisor, 2, RoundingMode.HALF_UP);
+                    ? marketInKrw
+                    : marketInKrw.divide(divisor, 2, RoundingMode.HALF_UP);
             previousValue = previousValue.add(previousUnitPrice.multiply(quantity));
         }
 
@@ -192,10 +202,14 @@ public class PortfolioService {
         if (price == null || price.getMarket() == null) {
             throw new BusinessException(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
         }
+        BigDecimal marketInKrw = toKrw(price.getMarket(), price.getCurrency());
+        if (marketInKrw == null) {
+            throw new BusinessException(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
+        }
 
         BigDecimal quantity = BigDecimal.valueOf(item.getQuantity());
         BigDecimal acquiredTotal = BigDecimal.valueOf(item.getAcquiredPrice()).multiply(quantity);
-        BigDecimal currentTotal = price.getMarket().multiply(quantity);
+        BigDecimal currentTotal = marketInKrw.multiply(quantity);
         BigDecimal pnlAmount = currentTotal.subtract(acquiredTotal).setScale(0, RoundingMode.HALF_UP);
         BigDecimal pnlRate = acquiredTotal.signum() == 0
                 ? BigDecimal.ZERO
@@ -313,6 +327,12 @@ public class PortfolioService {
                 })
                 .sorted(Comparator.comparing(PortfolioSetCompletionResponse::completionRate).reversed())
                 .toList();
+    }
+
+    // 지원하지 않는 통화면 null을 반환한다 - 환율 1배로 조용히 잘못된 값을 합산하지 않기 위함(프론트 toKrw()와 동일한 원칙).
+    private BigDecimal toKrw(BigDecimal amount, String currency) {
+        BigDecimal rate = currency != null ? FX_TO_KRW.get(currency) : null;
+        return rate != null ? amount.multiply(rate) : null;
     }
 
     // variantId가 명시된 항목은 그대로, null인 항목은 카드의 대표 변형으로 일괄 해석한다(enrich()의 변형 해석 로직과 동일한 규칙).

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -219,7 +219,7 @@ public class PortfolioService {
 
         return new PortfolioItemPnlResponse(
                 item.getId(), item.getCardId(), item.getQuantity(), item.getAcquiredPrice(),
-                price.getMarket(), price.getCurrency(), pnlAmount, pnlRate);
+                marketInKrw, KRW, pnlAmount, pnlRate);
     }
 
     // FR-PORT-06: 세트별·레어도별 구성 비율을 계산한다. 시세 유무와 무관하게 항상 계산 가능하도록

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -335,6 +335,46 @@ class PortfolioServiceTest {
                 new BigDecimal("20000"), new BigDecimal("4000"), new BigDecimal("25.00"), "KRW"));
     }
 
+    @Test
+    @DisplayName("총 평가액: USD/JPY 시세는 고정 환율(1400원/9원)로 환산해 합산한다")
+    void getSummary_convertsUsdAndJpyToKrw() {
+        PortfolioItem usdItem = PortfolioItem.builder()
+                .userId(1L).cardId(10L).variantId(5L).quantity(1).build();
+        ReflectionTestUtils.setField(usdItem, "id", 100L);
+        PortfolioItem jpyItem = PortfolioItem.builder()
+                .userId(1L).cardId(20L).variantId(6L).quantity(1).build();
+        ReflectionTestUtils.setField(jpyItem, "id", 200L);
+
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(usdItem, jpyItem));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(
+                        variantMarketPriceView(5L, new BigDecimal("10"), "USD", null),
+                        variantMarketPriceView(6L, new BigDecimal("100"), "JPY", null)));
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        // USD: 10*1400=14000, JPY: 100*9=900 → 총 14900
+        assertThat(result.totalValue()).isEqualTo(new BigDecimal("14900"));
+        assertThat(result.currency()).isEqualTo("KRW");
+    }
+
+    @Test
+    @DisplayName("총 평가액: 지원하지 않는 통화는 시세 없음과 동일하게 계산에서 제외된다")
+    void getSummary_excludesUnsupportedCurrency() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L).cardId(10L).variantId(5L).quantity(1).build();
+        ReflectionTestUtils.setField(item, "id", 100L);
+
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "EUR", null)));
+
+        PortfolioSummaryResponse result = portfolioService.getSummary(1L);
+
+        assertThat(result).isEqualTo(new PortfolioSummaryResponse(
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, null));
+    }
+
     // ===== getPnl =====
 
     @Test
@@ -435,6 +475,37 @@ class PortfolioServiceTest {
         assertThat(result).isEqualTo(new PortfolioItemPnlResponse(
                 null, 10L, 1, 10000, new BigDecimal("7500"), "KRW",
                 new BigDecimal("-2500"), new BigDecimal("-25.00")));
+    }
+
+    @Test
+    @DisplayName("손익: 지원하지 않는 통화면 PORTFOLIO_PRICE_NOT_FOUND")
+    void getPnl_unsupportedCurrency_priceNotFound() {
+        PortfolioItem item = stubItem(1L, 10L, 5L);
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10000"), "EUR", null)));
+
+        assertThatThrownBy(() -> portfolioService.getPnl(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_PRICE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("손익: USD 시세는 고정 환율(1400원)로 환산해 손익을 계산하고 응답도 KRW로 내려간다")
+    void getPnl_convertsUsdToKrw() {
+        PortfolioItem item = PortfolioItem.builder()
+                .userId(1L).cardId(10L).variantId(5L).quantity(1).acquiredPrice(10000)
+                .acquiredAt(LocalDateTime.now()).build();
+        given(portfolioItemRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(item));
+        given(cardPriceRepository.findMarketPricesByVariantIds(anyList(), anyString(), anyString(), anyString()))
+                .willReturn(List.of(variantMarketPriceView(5L, new BigDecimal("10"), "USD", null)));
+
+        PortfolioItemPnlResponse result = portfolioService.getPnl(1L, 1L);
+
+        // 현재 시세: 10*1400=14000원 → pnlAmount=14000-10000=4000, pnlRate=40.00
+        assertThat(result).isEqualTo(new PortfolioItemPnlResponse(
+                null, 10L, 1, 10000, new BigDecimal("14000"), "KRW",
+                new BigDecimal("4000"), new BigDecimal("40.00")));
     }
 
     // ===== getAnalytics =====


### PR DESCRIPTION
## 📌 관련 이슈
- #400

## ✨ 작업 내용
- card_prices에 USD/JPY 등 원본 통화로 저장된 시세를 PortfolioService.getSummary()가 환율 변환 없이 그대로 합산해 총 평가액이 실제 시세와 어긋나던 문제 수정
- getPnl()의 손익 계산도 동일한 원인으로 틀려 있어 함께 수정
- 프론트(lib/currency.ts)와 동일한 고정 환율표(USD 1400원, JPY 9원)를 백엔드에도 추가해 합산 전에 KRW로 환산

## 📸 스크린샷 / 테스트 결과
- ./gradlew compileJava, ./gradlew test --tests "com.pokade.domain.portfolio.service.PortfolioServiceTest" 통과

## 🔍 리뷰 포인트
- 환율은 실시간 API 없이 프론트와 동일한 고정 근사치를 그대로 사용함(현재 시세 데이터가 목업/추정 단계라 근사치로 처리). 실환율 연동 시 프론트/백엔드 두 곳을 함께 수정해야 함
- 지원하지 않는 통화는 시세 없음과 동일하게 계산에서 제외 처리

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [x] 관련 문서를 함께 수정했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 포트폴리오 평가액과 손익을 원화(KRW) 기준으로 계산하도록 개선했습니다.
  * KRW, USD, JPY 통화를 지원하며, 지원되지 않는 통화는 계산에서 제외됩니다.
  * 요약 평가액과 전일 평가액, 개별 손익의 현재 총액이 원화로 표시됩니다.
  * 가격 정보가 없는 자산은 오류로 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->