### PR TITLE
[Fix] #408 시세 거래 현황 집계 방식 평균값 전환 및 랭킹 갱신 시각 API 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/PriceController.java
@@ -8,6 +8,7 @@ import com.pokade.domain.price.dto.MarketOverviewResponse;
 import com.pokade.domain.price.dto.PriceRankingResponse;
 import com.pokade.domain.price.dto.PriceStatsResponse;
 import com.pokade.domain.price.dto.PriceSummaryResponse;
+import com.pokade.domain.price.dto.RankingRefreshedAtResponse;
 import com.pokade.domain.price.dto.TradeSummaryResponse;
 import com.pokade.domain.price.service.PriceService;
 import com.pokade.global.response.ApiResponse;
@@ -88,6 +89,11 @@ public class PriceController {
     @GetMapping("/ranking")
     public ApiResponse<List<PriceRankingResponse>> getRanking(@RequestParam String type) {
         return ApiResponse.ok(priceService.getRanking(type));
+    }
+
+    @GetMapping("/ranking/refreshed-at")
+    public ApiResponse<RankingRefreshedAtResponse> getRankingRefreshedAt(@RequestParam String type) {
+        return ApiResponse.ok(new RankingRefreshedAtResponse(priceService.getRankingRefreshedAt(type)));
     }
 
     @GetMapping("/market-overview")

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/DailyMarketStatResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/DailyMarketStatResponse.java
@@ -5,6 +5,6 @@ import java.time.LocalDate;
 public record DailyMarketStatResponse(
         LocalDate date,
         long volume,
-        Long medianPrice
+        Long avgPrice
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/MarketOverviewResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/MarketOverviewResponse.java
@@ -7,11 +7,11 @@ public record MarketOverviewResponse(
         long todayVolume,
         BigDecimal volumeChangeRate,
         long volumeChangeAmount,
-        Long todayMedianPrice,
-        BigDecimal medianChangeRate1d,
-        Long medianChangeAmount1d,
-        BigDecimal medianChangeRate7d,
-        BigDecimal medianChangeRate30d,
+        Long todayAvgPrice,
+        BigDecimal avgChangeRate1d,
+        Long avgChangeAmount1d,
+        BigDecimal avgChangeRate7d,
+        BigDecimal avgChangeRate30d,
         long totalVolume,
         List<DailyMarketStatResponse> dailyStats
 ) {

--- a/Pokade/src/main/java/com/pokade/domain/price/dto/RankingRefreshedAtResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/dto/RankingRefreshedAtResponse.java
@@ -1,0 +1,7 @@
+package com.pokade.domain.price.dto;
+
+import java.time.LocalDateTime;
+
+// GET /api/prices/ranking/refreshed-at 응답 - 아직 한 번도 배치가 돈 적 없으면(배포 직후 등) null.
+public record RankingRefreshedAtResponse(LocalDateTime refreshedAt) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/repository/PriceTradeStatsRepository.java
@@ -146,9 +146,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
 
     /**
      * 시세 랭킹 페이지의 "거래 현황" 개요용: 플랫폼 전체(카드/등급 구분 없음) 체결가를 일 단위로 묶어
-     * 거래 건수와 거래가 중간값(median)을 계산한다. 평균(AVG)이 아니라 PERCENTILE_CONT(0.5)로 중간값을
-     * 구하는 이유는 소수의 초고가/초저가 체결이 평균을 크게 왜곡할 수 있어서다(FR-PRICE-06 랭킹의
-     * 평균 기반 등락률과는 별개 지표). JPQL은 PERCENTILE_CONT/날짜 절삭을 지원하지 않아 네이티브 쿼리로
+     * 거래 건수와 거래가 평균(AVG)을 계산한다. JPQL은 날짜 절삭을 지원하지 않아 네이티브 쿼리로
      * 작성했고, enum을 네이티브 쿼리에 그대로 바인딩하면 ordinal로 전송되는 문제(findPriceRangesByCardIdsSincePerCard
      * 주석 참고)와 동일하게 상태값도 문자열로 변환해서 넘긴다.
      */
@@ -159,7 +157,7 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
     @Query(value = """
             SELECT CAST(t.confirmed_at AS date) AS tradeDate,
                    COUNT(*) AS volume,
-                   PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY t.price) AS medianPrice
+                   AVG(t.price) AS avgPrice
             FROM trades t
             WHERE t.status = :status AND t.confirmed_at >= :from
             GROUP BY CAST(t.confirmed_at AS date)
@@ -171,6 +169,6 @@ public interface PriceTradeStatsRepository extends Repository<Trade, Long> {
     interface DailyMarketStatView {
         LocalDate getTradeDate();
         Long getVolume();
-        Double getMedianPrice();
+        Double getAvgPrice();
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -85,9 +85,9 @@ public class PriceService {
     private static final String RANKING_CACHE = "priceRanking";
     // 시세 랭킹 페이지의 "거래 현황" 개요 차트가 보여주는 기간(일).
     private static final int MARKET_OVERVIEW_DAYS = 30;
-    // 거래가 중간값의 "30일 전 대비" 변화율 계산에 필요한 최대 조회 범위(일) - 차트 표시 기간(30일)과
+    // 거래가 평균의 "30일 전 대비" 변화율 계산에 필요한 최대 조회 범위(일) - 차트 표시 기간(30일)과
     // 우연히 같은 값이지만 의미가 다르다(하나는 표시 범위, 하나는 비교 기준점).
-    private static final int MEDIAN_COMPARISON_MAX_DAYS = 30;
+    private static final int AVG_COMPARISON_MAX_DAYS = 30;
     // CardUpsertService가 Scrydex 동기화 시 raw NM 시세를 저장하는 키와 동일해야 한다(card_prices 조회 fallback용).
     private static final String RAW_PRICE_TYPE = "raw";
     private static final String RAW_GRADE = "";
@@ -719,16 +719,15 @@ public class PriceService {
     }
 
     // 시세 랭킹 페이지의 "거래 현황" 개요 - getRanking()의 카드별 등락률과는 별개로, 플랫폼 전체(카드/등급
-    // 구분 없음) 체결의 일별 거래량과 거래가 중간값(median)을 보여준다. 평균 대신 중간값을 쓰는 이유는
-    // 소수의 초고가/초저가 체결 때문에 평균이 왜곡되는 걸 피하기 위함(사용자 요청, KREAM TCG 시세 페이지
-    // 참고). 최근 30일치를 항상 30개(빈 날짜는 volume=0/medianPrice=null로) 반환하고, 오늘 대비 전일/
-    // 일주일 전/30일 전 세 시점으로 거래가 중간값 변화율을 각각 계산한다(사용자 요청 - 하루 단위 변화만
-    // 보여주면 단기 잡음에 흔들리는 인상을 줄 수 있어, 더 긴 기준선도 함께 보여준다).
+    // 구분 없음) 체결의 일별 거래량과 거래가 평균을 보여준다(사용자 요청으로 중간값에서 평균값으로 전환).
+    // 최근 30일치를 항상 30개(빈 날짜는 volume=0/avgPrice=null로) 반환하고, 오늘 대비 전일/일주일 전/
+    // 30일 전 세 시점으로 거래가 평균 변화율을 각각 계산한다(사용자 요청 - 하루 단위 변화만 보여주면
+    // 단기 잡음에 흔들리는 인상을 줄 수 있어, 더 긴 기준선도 함께 보여준다).
     public MarketOverviewResponse getMarketOverview() {
         LocalDate today = LocalDate.now();
         LocalDate chartFrom = today.minusDays(MARKET_OVERVIEW_DAYS - 1L);
         // 30일 전 대비 비교를 하려면 차트 표시 범위(chartFrom)보다 하루 더 과거 체결까지 조회해야 한다.
-        LocalDate queryFrom = today.minusDays(MEDIAN_COMPARISON_MAX_DAYS);
+        LocalDate queryFrom = today.minusDays(AVG_COMPARISON_MAX_DAYS);
 
         Map<LocalDate, PriceTradeStatsRepository.DailyMarketStatView> statsByDate = priceTradeStatsRepository
                 .findDailyMarketStats(TradeStatus.COMPLETED, queryFrom.atStartOfDay()).stream()
@@ -744,19 +743,19 @@ public class PriceService {
         DailyMarketStatResponse yesterdayStat = dailyStats.get(dailyStats.size() - 2);
         long totalVolume = dailyStats.stream().mapToLong(DailyMarketStatResponse::volume).sum();
 
-        Long median7dAgo = toDailyMarketStatResponse(today.minusDays(7), statsByDate.get(today.minusDays(7))).medianPrice();
-        Long median30dAgo = toDailyMarketStatResponse(today.minusDays(MEDIAN_COMPARISON_MAX_DAYS),
-                statsByDate.get(today.minusDays(MEDIAN_COMPARISON_MAX_DAYS))).medianPrice();
+        Long avg7dAgo = toDailyMarketStatResponse(today.minusDays(7), statsByDate.get(today.minusDays(7))).avgPrice();
+        Long avg30dAgo = toDailyMarketStatResponse(today.minusDays(AVG_COMPARISON_MAX_DAYS),
+                statsByDate.get(today.minusDays(AVG_COMPARISON_MAX_DAYS))).avgPrice();
 
         return new MarketOverviewResponse(
                 todayStat.volume(),
                 computeVolumeChangeRate(yesterdayStat.volume(), todayStat.volume()),
                 todayStat.volume() - yesterdayStat.volume(),
-                todayStat.medianPrice(),
-                computeMedianChangeRate(yesterdayStat.medianPrice(), todayStat.medianPrice()),
-                computeMedianChangeAmount(yesterdayStat.medianPrice(), todayStat.medianPrice()),
-                computeMedianChangeRate(median7dAgo, todayStat.medianPrice()),
-                computeMedianChangeRate(median30dAgo, todayStat.medianPrice()),
+                todayStat.avgPrice(),
+                computeAvgChangeRate(yesterdayStat.avgPrice(), todayStat.avgPrice()),
+                computeAvgChangeAmount(yesterdayStat.avgPrice(), todayStat.avgPrice()),
+                computeAvgChangeRate(avg7dAgo, todayStat.avgPrice()),
+                computeAvgChangeRate(avg30dAgo, todayStat.avgPrice()),
                 totalVolume,
                 dailyStats
         );
@@ -765,10 +764,10 @@ public class PriceService {
     private DailyMarketStatResponse toDailyMarketStatResponse(LocalDate date,
                                                                 PriceTradeStatsRepository.DailyMarketStatView view) {
         long volume = view != null ? view.getVolume() : 0L;
-        Long medianPrice = view != null && view.getMedianPrice() != null
-                ? Math.round(view.getMedianPrice())
+        Long avgPrice = view != null && view.getAvgPrice() != null
+                ? Math.round(view.getAvgPrice())
                 : null;
-        return new DailyMarketStatResponse(date, volume, medianPrice);
+        return new DailyMarketStatResponse(date, volume, avgPrice);
     }
 
     // 어제 거래가 0건이면 "증가율"이라는 지표 자체가 의미 없어(0에서 몇 건이 늘어도 무한대%) null로 남긴다.
@@ -782,23 +781,23 @@ public class PriceService {
                 .setScale(2, RoundingMode.HALF_UP);
     }
 
-    // 오늘 또는 어제 중 하루라도 체결이 없어 중간값을 못 구했으면 변화율도 계산할 수 없다.
-    private BigDecimal computeMedianChangeRate(Long previousMedian, Long todayMedian) {
-        if (previousMedian == null || todayMedian == null || previousMedian == 0) {
+    // 오늘 또는 어제 중 하루라도 체결이 없어 평균을 못 구했으면 변화율도 계산할 수 없다.
+    private BigDecimal computeAvgChangeRate(Long previousAvg, Long todayAvg) {
+        if (previousAvg == null || todayAvg == null || previousAvg == 0) {
             return null;
         }
-        return BigDecimal.valueOf(todayMedian - previousMedian)
-                .divide(BigDecimal.valueOf(previousMedian), 4, RoundingMode.HALF_UP)
+        return BigDecimal.valueOf(todayAvg - previousAvg)
+                .divide(BigDecimal.valueOf(previousAvg), 4, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
                 .setScale(2, RoundingMode.HALF_UP);
     }
 
-    // 전일 대비 거래가 중간값 변동을 원화 금액으로도 보여주기 위한 값(사용자 요청) - 비율과 달리 어제
-    // 중간값이 0이어도(이론상 없는 값이지만) 계산 가능하나, 둘 중 하나가 아예 없으면(체결 없음) 계산 불가.
-    private Long computeMedianChangeAmount(Long previousMedian, Long todayMedian) {
-        if (previousMedian == null || todayMedian == null) {
+    // 전일 대비 거래가 평균 변동을 원화 금액으로도 보여주기 위한 값(사용자 요청) - 비율과 달리 어제
+    // 평균이 0이어도(이론상 없는 값이지만) 계산 가능하나, 둘 중 하나가 아예 없으면(체결 없음) 계산 불가.
+    private Long computeAvgChangeAmount(Long previousAvg, Long todayAvg) {
+        if (previousAvg == null || todayAvg == null) {
             return null;
         }
-        return todayMedian - previousMedian;
+        return todayAvg - previousAvg;
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -38,6 +38,7 @@ import com.pokade.domain.price.repository.BuyOfferOrderRepository;
 import com.pokade.domain.price.repository.BuyOfferRepository;
 import com.pokade.domain.price.repository.PriceCardStatsRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.price.store.PriceRankingRefreshStore;
 import com.pokade.domain.trade.repository.TradeRepository;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.TradeStatus;
@@ -104,6 +105,7 @@ public class PriceService {
     private final BuyOfferOrderRepository buyOfferOrderRepository;
     private final TradeRepository tradeRepository;
     private final PriceTradeStatsRepository priceTradeStatsRepository;
+    private final PriceRankingRefreshStore priceRankingRefreshStore;
     private final PriceCardStatsRepository priceCardStatsRepository;
     private final CardPriceRepository cardPriceRepository;
     private final UserAccessChecker userAccessChecker;
@@ -644,6 +646,12 @@ public class PriceService {
         return computeRanking(type);
     }
 
+    // 화면에 "마지막 갱신: ..." 안내를 보여주기 위한 조회 - 아직 한 번도 계산된 적이 없으면(배포 직후 등) null.
+    public LocalDateTime getRankingRefreshedAt(String type) {
+        RankingType.from(type);
+        return priceRankingRefreshStore.findRefreshedAt(type);
+    }
+
     // FR-PRICE-06: getStats()와 같은 방식(자체 AI등급 S, COMPLETED 거래, 최근 7일 vs 이전 7일 블록 평균 비교)을
     // 전체 카드로 확장해 등락률 상위/하위 10개 카드를 랭킹으로 뽑는다. card_prices(Scrydex 동기화)는 쓰지 않는다 —
     // 그 테이블은 PSA/CGC 같은 공인 등급만 있고 우리 자체 S등급 데이터가 없다(getStats와 동일한 이유).
@@ -655,6 +663,8 @@ public class PriceService {
         RankingType rankingType = RankingType.from(type);
         // 임시 계측 - Grafana 테스트용, 팀 논의 전 커밋 대상 아님
         meterRegistry.counter("price.ranking.requests", "type", rankingType.name()).increment();
+        // "언제 갱신됐는지" 화면 안내용 - 캐시 자체는 값만 들고 있어 시각을 알 수 없으므로 별도로 기록한다.
+        priceRankingRefreshStore.recordNow(type, LocalDateTime.now());
 
         LocalDateTime recentFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS);
         LocalDateTime previousFrom = LocalDateTime.now().minusDays(STATS_PERIOD_DAYS * 2L);

--- a/Pokade/src/main/java/com/pokade/domain/price/store/PriceRankingRefreshStore.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/store/PriceRankingRefreshStore.java
@@ -1,0 +1,31 @@
+package com.pokade.domain.price.store;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+// 시세 랭킹(priceRanking 캐시)이 실제로 마지막에 계산된 시각을 별도로 기록한다 - 캐시 자체는
+// 값만 들고 있어 "언제 채워졌는지"를 알 수 없다. TTL을 캐시(CacheConfig.PRICE_RANKING_CACHE)와
+// 동일한 48시간으로 맞춰서, 캐시가 만료되면 이 기록도 함께 사라지게 한다.
+@Repository
+@RequiredArgsConstructor
+public class PriceRankingRefreshStore {
+
+    private static final String KEY_PREFIX = "priceRanking:refreshedAt:";
+    private static final Duration TTL = Duration.ofHours(48);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void recordNow(String type, LocalDateTime now) {
+        redisTemplate.opsForValue().set(KEY_PREFIX + type, now.toString(), TTL);
+    }
+
+    public LocalDateTime findRefreshedAt(String type) {
+        String value = redisTemplate.opsForValue().get(KEY_PREFIX + type);
+        return value != null ? LocalDateTime.parse(value) : null;
+    }
+}

--- a/Pokade/src/main/resources/data.sql
+++ b/Pokade/src/main/resources/data.sql
@@ -500,7 +500,7 @@ INSERT INTO trades (listing_id, buyer_id, price, status, confirmed_at, settled_a
 -- =========================================================
 -- 시세 랭킹 "거래 현황"(GET /api/prices/market-overview) 검증용 시드
 -- 카드/등급 구분 없이 플랫폼 전체 COMPLETED 체결을 일 단위로 집계하는 지표라, 위 FR-PRICE-02/03/04/06
--- 블록만으로는 "오늘"(0일 전)과 "30일 전" 시점에 체결이 전혀 없어 todayMedianPrice/medianChangeRate1d/
+-- 블록만으로는 "오늘"(0일 전)과 "30일 전" 시점에 체결이 전혀 없어 todayAvgPrice/avgChangeRate1d/
 -- 7d/30d가 계속 null로만 나왔다. 여러 카드/등급에 걸쳐 0~30일 전을 고르게 채워 차트와 전일/1주일 전/
 -- 30일 전 대비 변화율 배지가 모두 실제 값을 보여주도록 보강한다(자동화 테스트에는 사용되지 않음).
 -- =========================================================

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -422,7 +422,7 @@ class PriceControllerTest {
     }
 
     @Test
-    void 거래_현황_개요를_조회하면_200과_오늘_거래량_중간값_전일_일주일_30일_변화율을_반환한다() throws Exception {
+    void 거래_현황_개요를_조회하면_200과_오늘_거래량_평균_전일_일주일_30일_변화율을_반환한다() throws Exception {
         MarketOverviewResponse overview = new MarketOverviewResponse(
                 12L,
                 new BigDecimal("20.00"),
@@ -442,11 +442,11 @@ class PriceControllerTest {
                 .andExpect(jsonPath("$.data.todayVolume").value(12))
                 .andExpect(jsonPath("$.data.volumeChangeRate").value(20.00))
                 .andExpect(jsonPath("$.data.volumeChangeAmount").value(2))
-                .andExpect(jsonPath("$.data.todayMedianPrice").value(3100000))
-                .andExpect(jsonPath("$.data.medianChangeRate1d").value(3.33))
-                .andExpect(jsonPath("$.data.medianChangeAmount1d").value(100000))
-                .andExpect(jsonPath("$.data.medianChangeRate7d").value(10.71))
-                .andExpect(jsonPath("$.data.medianChangeRate30d").value(55.00))
+                .andExpect(jsonPath("$.data.todayAvgPrice").value(3100000))
+                .andExpect(jsonPath("$.data.avgChangeRate1d").value(3.33))
+                .andExpect(jsonPath("$.data.avgChangeAmount1d").value(100000))
+                .andExpect(jsonPath("$.data.avgChangeRate7d").value(10.71))
+                .andExpect(jsonPath("$.data.avgChangeRate30d").value(55.00))
                 .andExpect(jsonPath("$.data.totalVolume").value(250))
                 .andExpect(jsonPath("$.data.dailyStats.length()").value(1));
     }

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/PriceControllerTest.java
@@ -422,6 +422,35 @@ class PriceControllerTest {
     }
 
     @Test
+    void 랭킹_갱신시각_조회에_성공하면_200과_시각을_반환한다() throws Exception {
+        given(priceService.getRankingRefreshedAt("rise"))
+                .willReturn(java.time.LocalDateTime.of(2026, 8, 25, 4, 0, 0));
+
+        mockMvc.perform(get("/api/prices/ranking/refreshed-at").param("type", "rise"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.refreshedAt").value("2026-08-25T04:00:00"));
+    }
+
+    @Test
+    void 랭킹_갱신시각이_아직_없으면_200과_null을_반환한다() throws Exception {
+        given(priceService.getRankingRefreshedAt("rise")).willReturn(null);
+
+        mockMvc.perform(get("/api/prices/ranking/refreshed-at").param("type", "rise"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.refreshedAt").value(org.hamcrest.Matchers.nullValue()));
+    }
+
+    @Test
+    void 랭킹_갱신시각_조회시_잘못된_type_값이면_400을_반환한다() throws Exception {
+        given(priceService.getRankingRefreshedAt("up"))
+                .willThrow(new BusinessException(ErrorCode.INVALID_RANKING_TYPE));
+
+        mockMvc.perform(get("/api/prices/ranking/refreshed-at").param("type", "up"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_RANKING_TYPE"));
+    }
+
+    @Test
     void 거래_현황_개요를_조회하면_200과_오늘_거래량_평균_전일_일주일_30일_변화율을_반환한다() throws Exception {
         MarketOverviewResponse overview = new MarketOverviewResponse(
                 12L,

--- a/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/repository/PriceTradeStatsRepositoryTest.java
@@ -269,7 +269,7 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("t10 findDailyMarketStats()는 카드/등급 구분 없이 일 단위로 거래량과 거래가 중간값을 계산한다")
+    @DisplayName("t10 findDailyMarketStats()는 카드/등급 구분 없이 일 단위로 거래량과 거래가 평균을 계산한다")
     void t10() {
         Listing a = persistListing(1000000, ListingGrade.S);
         Listing b = persistListing(2000000, ListingGrade.PSA10);
@@ -277,7 +277,7 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
         Listing outsideWindow = persistListing(9000000, ListingGrade.S);
 
         java.time.LocalDate today = java.time.LocalDate.now();
-        // 같은 날(오늘)에 3건 체결 - 중간값은 정렬 시 가운데 값인 2000000이어야 한다.
+        // 같은 날(오늘)에 3건 체결 - 평균은 (1000000+2000000+3000000)/3 = 2000000이어야 한다.
         persistCompletedTrade(a, today.atTime(9, 0));
         persistCompletedTrade(b, today.atTime(15, 0));
         persistCompletedTrade(c, today.atTime(21, 0));
@@ -290,6 +290,6 @@ class PriceTradeStatsRepositoryTest extends AbstractIntegrationTest {
         assertThat(stats).hasSize(1);
         assertThat(stats.get(0).getTradeDate()).isEqualTo(today);
         assertThat(stats.get(0).getVolume()).isEqualTo(3L);
-        assertThat(stats.get(0).getMedianPrice()).isEqualTo(2000000.0);
+        assertThat(stats.get(0).getAvgPrice()).isEqualTo(2000000.0);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -33,6 +33,7 @@ import com.pokade.domain.price.repository.BuyOfferOrderRepository;
 import com.pokade.domain.price.repository.BuyOfferRepository;
 import com.pokade.domain.price.repository.PriceCardStatsRepository;
 import com.pokade.domain.price.repository.PriceTradeStatsRepository;
+import com.pokade.domain.price.store.PriceRankingRefreshStore;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
@@ -101,6 +102,9 @@ class PriceServiceTest {
 
     @Mock
     private PriceTradeStatsRepository priceTradeStatsRepository;
+
+    @Mock
+    private PriceRankingRefreshStore priceRankingRefreshStore;
 
     @Mock
     private PriceCardStatsRepository priceCardStatsRepository;
@@ -557,6 +561,36 @@ class PriceServiceTest {
 
         assertThat(result).isEmpty();
         verify(cardRepository, never()).findAllById(any());
+    }
+
+    @Test
+    @DisplayName("t20b getRanking 호출 시 랭킹이 계산된 시각을 기록한다")
+    void t20b() {
+        given(priceTradeStatsRepository.findAveragePricesByGradeSince(eq(ListingGrade.S), eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
+                .willReturn(List.of());
+
+        priceService.getRanking("rise");
+
+        verify(priceRankingRefreshStore).recordNow(eq("rise"), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("t20c getRankingRefreshedAt은 저장소에 기록된 시각을 그대로 반환한다")
+    void t20c() {
+        LocalDateTime refreshedAt = LocalDateTime.now().minusHours(3);
+        given(priceRankingRefreshStore.findRefreshedAt("rise")).willReturn(refreshedAt);
+
+        assertThat(priceService.getRankingRefreshedAt("rise")).isEqualTo(refreshedAt);
+    }
+
+    @Test
+    @DisplayName("t20d getRankingRefreshedAt은 잘못된 type이면 INVALID_RANKING_TYPE 예외가 발생한다")
+    void t20d() {
+        assertThatThrownBy(() -> priceService.getRankingRefreshedAt("up"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_RANKING_TYPE);
+        verifyNoInteractions(priceRankingRefreshStore);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1139,7 +1139,7 @@ class PriceServiceTest {
     }
 
     private PriceTradeStatsRepository.DailyMarketStatView dailyMarketStatView(
-            LocalDate date, long volume, Double medianPrice) {
+            LocalDate date, long volume, Double avgPrice) {
         return new PriceTradeStatsRepository.DailyMarketStatView() {
             @Override
             public LocalDate getTradeDate() {
@@ -1152,14 +1152,14 @@ class PriceServiceTest {
             }
 
             @Override
-            public Double getMedianPrice() {
-                return medianPrice;
+            public Double getAvgPrice() {
+                return avgPrice;
             }
         };
     }
 
     @Test
-    @DisplayName("t57 오늘/어제 모두 체결이 있으면 전일 대비 거래량/중간값 변화율을 계산하고 30일치 일별 통계를 반환한다")
+    @DisplayName("t57 오늘/어제 모두 체결이 있으면 전일 대비 거래량/평균 변화율을 계산하고 30일치 일별 통계를 반환한다")
     void t57() {
         LocalDate today = LocalDate.now();
         LocalDate yesterday = today.minusDays(1);
@@ -1174,10 +1174,10 @@ class PriceServiceTest {
         assertThat(result.todayVolume()).isEqualTo(12L);
         assertThat(result.volumeChangeRate()).isEqualByComparingTo("20.00");
         assertThat(result.volumeChangeAmount()).isEqualTo(2L);
-        assertThat(result.todayMedianPrice()).isEqualTo(3100000L);
+        assertThat(result.todayAvgPrice()).isEqualTo(3100000L);
         // (3100000-3000000)/3000000*100 = 3.3333... -> 3.33
-        assertThat(result.medianChangeRate1d()).isEqualByComparingTo("3.33");
-        assertThat(result.medianChangeAmount1d()).isEqualTo(100000L);
+        assertThat(result.avgChangeRate1d()).isEqualByComparingTo("3.33");
+        assertThat(result.avgChangeAmount1d()).isEqualTo(100000L);
         assertThat(result.totalVolume()).isEqualTo(22L);
         assertThat(result.dailyStats()).hasSize(30);
         assertThat(result.dailyStats().get(29).date()).isEqualTo(today);
@@ -1195,12 +1195,12 @@ class PriceServiceTest {
 
         assertThat(result.todayVolume()).isEqualTo(5L);
         assertThat(result.volumeChangeRate()).isNull();
-        assertThat(result.medianChangeRate1d()).isNull();
-        assertThat(result.medianChangeAmount1d()).isNull();
+        assertThat(result.avgChangeRate1d()).isNull();
+        assertThat(result.avgChangeAmount1d()).isNull();
     }
 
     @Test
-    @DisplayName("t59 오늘 체결이 전혀 없으면 오늘의 거래량/중간값이 0과 null이고 변화율도 null이다")
+    @DisplayName("t59 오늘 체결이 전혀 없으면 오늘의 거래량/평균이 0과 null이고 변화율도 null이다")
     void t59() {
         given(priceTradeStatsRepository.findDailyMarketStats(eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
                 .willReturn(List.of());
@@ -1208,18 +1208,18 @@ class PriceServiceTest {
         MarketOverviewResponse result = priceService.getMarketOverview();
 
         assertThat(result.todayVolume()).isZero();
-        assertThat(result.todayMedianPrice()).isNull();
+        assertThat(result.todayAvgPrice()).isNull();
         assertThat(result.volumeChangeRate()).isNull();
-        assertThat(result.medianChangeRate1d()).isNull();
-        assertThat(result.medianChangeAmount1d()).isNull();
-        assertThat(result.medianChangeRate7d()).isNull();
-        assertThat(result.medianChangeRate30d()).isNull();
+        assertThat(result.avgChangeRate1d()).isNull();
+        assertThat(result.avgChangeAmount1d()).isNull();
+        assertThat(result.avgChangeRate7d()).isNull();
+        assertThat(result.avgChangeRate30d()).isNull();
         assertThat(result.totalVolume()).isZero();
         assertThat(result.dailyStats()).hasSize(30);
     }
 
     @Test
-    @DisplayName("t60 일주일 전/30일 전 체결이 있으면 오늘 중간값과 비교해 각 기준의 변화율을 계산한다")
+    @DisplayName("t60 일주일 전/30일 전 체결이 있으면 오늘 평균과 비교해 각 기준의 변화율을 계산한다")
     void t60() {
         LocalDate today = LocalDate.now();
         given(priceTradeStatsRepository.findDailyMarketStats(eq(TradeStatus.COMPLETED), any(LocalDateTime.class)))
@@ -1232,9 +1232,9 @@ class PriceServiceTest {
         MarketOverviewResponse result = priceService.getMarketOverview();
 
         // (3000000-2500000)/2500000*100 = 20.00
-        assertThat(result.medianChangeRate7d()).isEqualByComparingTo("20.00");
+        assertThat(result.avgChangeRate7d()).isEqualByComparingTo("20.00");
         // (3000000-2000000)/2000000*100 = 50.00
-        assertThat(result.medianChangeRate30d()).isEqualByComparingTo("50.00");
+        assertThat(result.avgChangeRate30d()).isEqualByComparingTo("50.00");
     }
 
     @Test
@@ -1246,8 +1246,8 @@ class PriceServiceTest {
 
         MarketOverviewResponse result = priceService.getMarketOverview();
 
-        assertThat(result.medianChangeRate7d()).isNull();
-        assertThat(result.medianChangeRate30d()).isNull();
+        assertThat(result.avgChangeRate7d()).isNull();
+        assertThat(result.avgChangeRate30d()).isNull();
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/store/PriceRankingRefreshStoreTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/store/PriceRankingRefreshStoreTest.java
@@ -1,0 +1,69 @@
+package com.pokade.domain.price.store;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.redis.test.autoconfigure.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@Testcontainers
+@Import(PriceRankingRefreshStore.class)
+class PriceRankingRefreshStoreTest {
+
+    @Container
+    static final GenericContainer<?> REDIS =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @Autowired
+    PriceRankingRefreshStore store;
+    @Autowired
+    StringRedisTemplate redisTemplate;
+
+    @BeforeEach
+    void clean() {
+        redisTemplate.delete("priceRanking:refreshedAt:rise");
+    }
+
+    @Test
+    @DisplayName("한 번도 기록된 적 없으면 null을 반환한다")
+    void findRefreshedAt_returnsNullWhenNeverRecorded() {
+        assertThat(store.findRefreshedAt("rise")).isNull();
+    }
+
+    @Test
+    @DisplayName("recordNow로 기록한 시각을 그대로 조회할 수 있다")
+    void recordNow_thenFindReturnsSameValue() {
+        LocalDateTime now = LocalDateTime.now().withNano(0);
+
+        store.recordNow("rise", now);
+
+        assertThat(store.findRefreshedAt("rise")).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("recordNow는 TTL을 설정한다(48시간 이내)")
+    void recordNow_setsTtl() {
+        store.recordNow("rise", LocalDateTime.now());
+
+        Long ttl = redisTemplate.getExpire("priceRanking:refreshedAt:rise");
+        assertThat(ttl).isNotNull().isGreaterThan(0).isLessThanOrEqualTo(48 * 3600L);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #408

## ✨ 작업 내용
- 시세 랭킹 페이지 "거래 현황" 위젯의 거래가 집계 방식을 중앙값(PERCENTILE_CONT)에서 평균값(AVG)으로 변경
  - 응답 필드명도 함께 정리: `todayMedianPrice`→`todayAvgPrice`, `medianChangeRate1d/7d/30d`→`avgChangeRate1d/7d/30d`, `medianChangeAmount1d`→`avgChangeAmount1d`, `DailyMarketStatResponse.medianPrice`→`avgPrice`
- `GET /api/prices/ranking/refreshed-at?type=rise|fall` 신규 추가 — 급등/급락 TOP 10 랭킹이 마지막으로 계산된 시각을 조회
  - `PriceRankingRefreshStore`(Redis, TTL 48h — 랭킹 캐시와 동일)에 계산 시점을 기록, 배치가 한 번도 안 돌았으면(배포 직후 등) `null` 반환

## 📸 스크린샷 / 테스트 결과
- 신규/수정 테스트 9개 추가(`PriceRankingRefreshStoreTest`, `PriceServiceTest`, `PriceControllerTest`) 전부 통과
- curl로 실제 확인: 배치 실행 전 `refreshedAt: null` → 랭킹 조회 후 실제 시각으로 채워짐 → 잘못된 `type` 값은 400
- 전체 테스트 1188개 중 8개 실패(기존에 알려진 `TradeRepositoryTest`/`WithdrawalConfirmIntegrationTest`, 이번 변경과 무관)

## 🔍 리뷰 포인트
- 필드명을 median→avg로 바꾸면서 FE가 이 응답을 그대로 파싱하는 곳(`MarketOverviewResponse` 타입, `MarketOverviewChart.tsx`)도 같은 세션에서 동시에 변경했습니다 — FE PR과 반드시 같은 배포 시점에 나가야 합니다(필드명이 겹치는 부분이라 한쪽만 배포되면 깨짐).
- `PriceRankingRefreshStore`는 랭킹 계산이 일어나는 모든 경로(배치 스케줄러 + 캐시 미스 시 사용자 요청으로 인한 즉시 계산)에서 공통으로 기록되도록 `computeRanking()` 내부에 넣었습니다 — 위치가 적절한지 확인 부탁드립니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?