### PR TITLE
Fix/#413 predevho[Fix] #413 닉네임 공백 허용 문제 — 공백 포함 닉네임이 검증을 통과한다

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/OAuth2RegisterRequest.java
@@ -2,6 +2,7 @@ package com.pokade.domain.auth.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record OAuth2RegisterRequest(
@@ -10,6 +11,7 @@ public record OAuth2RegisterRequest(
 
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+        @Pattern(regexp = "^\\S+$", message = "닉네임은 공백을 포함할 수 없습니다.")
         String nickname,
 
         @AssertTrue(message = "이용약관에 동의해야 가입할 수 있습니다.")

--- a/Pokade/src/main/java/com/pokade/domain/auth/dto/request/SignupRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/auth/dto/request/SignupRequest.java
@@ -17,6 +17,7 @@ public record SignupRequest(
 
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해주세요.")
+        @Pattern(regexp = "^\\S+$", message = "닉네임은 공백을 포함할 수 없습니다.")
         String nickname,
 
         @AssertTrue(message = "이용약관에 동의해야 가입할 수 있습니다.")

--- a/Pokade/src/main/java/com/pokade/domain/user/dto/request/NicknameUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/user/dto/request/NicknameUpdateRequest.java
@@ -1,11 +1,13 @@
 package com.pokade.domain.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record NicknameUpdateRequest(
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하로 입력해야 합니다.")
+        @Pattern(regexp = "^\\S+$", message = "닉네임은 공백을 포함할 수 없습니다.")
         String nickname
 ) {
 }

--- a/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/auth/controller/AuthControllerTest.java
@@ -186,4 +186,54 @@ class AuthControllerTest {
 
         then(authService).should().signup(any());
     }
+
+    private static String signupBodyWithNickname(String nickname) {
+        return """
+                {"email":"user@pokade.com","password":"pokade1234","nickname":"%s",
+                 "termsOfService":true,"privacyPolicy":true,"thirdPartySharing":true,"marketing":false}
+                """.formatted(nickname);
+    }
+
+    @Test
+    @DisplayName("닉네임에 공백이 섞이면 400을 반환하고 가입 서비스를 호출하지 않는다")
+    void signup_nicknameWithWhitespace() {
+        // 닉네임 중복 검사는 입력을 원문 그대로 비교하므로, 공백이 통과하면
+        // "홍길동"과 "홍 길동"이 서로 다른 계정으로 공존해 UNIQUE 제약이 무의미해진다.
+        String[] nicknames = {
+                "홍 길동",   // 중간 공백
+                " 홍길동",   // 앞 공백
+                "홍길동 ",   // 뒤 공백
+                "홍\\t길동", // 탭
+                "  ",       // 전부 공백
+        };
+
+        for (String nickname : nicknames) {
+            mockMvcTester.post()
+                    .uri("/api/auth/signup")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(signupBodyWithNickname(nickname))
+                    .assertThat()
+                    .hasStatus(HttpStatus.BAD_REQUEST);
+        }
+
+        then(authService).should(never()).signup(any());
+    }
+
+    @Test
+    @DisplayName("소셜 회원가입도 닉네임 공백을 거부한다")
+    void oauth2Register_nicknameWithWhitespace() {
+        String body = """
+                {"ticket":"signup-ticket","nickname":"홍 길동",
+                 "termsOfService":true,"privacyPolicy":true,"thirdPartySharing":true,"marketing":false}
+                """;
+
+        mockMvcTester.post()
+                .uri("/api/auth/oauth2/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .assertThat()
+                .hasStatus(HttpStatus.BAD_REQUEST);
+
+        then(oauth2LoginService).should(never()).register(any());
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/controller/UserControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -48,6 +49,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -208,5 +210,21 @@ class UserControllerTest {
                 .andExpect(status().isOk());
 
         then(profileImageService).should().upload(eq(1L), any());
+    }
+
+    @Test
+    @DisplayName("닉네임에 공백이 섞이면 400을 반환하고 변경 서비스를 호출하지 않는다")
+    void updateNickname_withWhitespace() throws Exception {
+        String[] nicknames = {"홍 길동", " 홍길동", "홍길동 ", "  "};
+
+        for (String nickname : nicknames) {
+            mockMvc.perform(patch("/api/users/me")
+                            .with(userId(1L))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"nickname\":\"" + nickname + "\"}"))
+                    .andExpect(status().isBadRequest());
+        }
+
+        then(userService).should(never()).updateNickname(any(), any());
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- #413

## ✨ 작업 내용

닉네임 검증이 길이만 보고 있어 공백이 든 닉네임이 그대로 통과했다. 세 DTO 모두 `@NotBlank` + `@Size(2, 20)`만 있고 `@Pattern`이 없었다. `@NotBlank`는 "전부 공백"만 막으므로 `"홍 길동"`, `"a b"`, `" ab "`는 전부 통과한다.

- `SignupRequest`·`OAuth2RegisterRequest`·`NicknameUpdateRequest`의 닉네임에 `@Pattern(regexp = "^\\S+$")` 추가
- 가입·소셜 가입·닉네임 변경 세 경로에 대한 검증 테스트 추가

### UNIQUE 제약이 의도대로 동작하지 않았다

닉네임에는 UNIQUE 제약이 걸려 있지만, 중복 검사가 입력을 원문 그대로 비교한다.

```java
// AuthService:58, OAuth2LoginService:75
if (userRepository.existsByNickname(request.nickname())) { ... }
```

정규화가 없으므로 `홍길동`이 이미 있어도 `홍 길동`, `홍길동 `은 중복으로 걸리지 않는다. 화면에서는 사실상 같은 이름으로 보이므로 사칭 여지가 된다. 제약은 걸려 있는데 그 제약이 막으려던 상황이 막히지 않는 상태였다.

### 새 정책이 아니라 누락 보완이다

`SignupRequest`의 비밀번호는 이미 `^(?=.*[A-Za-z])(?=.*\d)\S+$`로 공백을 금지하고 있다. 같은 DTO 안에서 닉네임만 규칙에서 빠져 있었다. 기준을 새로 만든 것이 아니라 빠진 항목을 같은 기준에 맞췄다.

### 공백을 전면 금지했다

앞뒤만 잘라내는 방식은 `홍 길동` 형태의 사칭 여지를 남기므로 중간 공백까지 금지한다.

### 기존 데이터는 영향받지 않는다

현재 users 2080건 중 공백이 포함된 닉네임과 앞뒤 공백이 있는 닉네임이 각각 **0건**이다. 데이터 마이그레이션이 필요 없고 기존 사용자가 잠기지도 않는다.

## 📸 스크린샷 / 테스트 결과

전체 스위트 **1191건 중 8건 실패**이며, **8건 모두 이 PR 이전부터 실패하던 것**이다. 아래 "기존 실패" 항목에 근거를 적었다. 이 PR이 추가한 3건은 통과한다.

| 테스트 | 대상 | 검증 |
|---|---|---|
| `AuthControllerTest` | `POST /api/auth/signup` | 중간 공백·앞 공백·뒤 공백·탭·전부 공백 → `400`, `signup()` 미호출 |
| `AuthControllerTest` | `POST /api/auth/oauth2/register` | 중간 공백 → `400`, `register()` 미호출 |
| `UserControllerTest` | `PATCH /api/users/me` | 중간 공백·앞뒤 공백·전부 공백 → `400`, `updateNickname()` 미호출 |

### 테스트가 실제로 잡는지 확인했다

통과 자체는 검증을 안 해도 나올 수 있으므로, `SignupRequest`의 `@Pattern`을 임시로 제거하고 다시 돌렸다.

```
AuthControllerTest > 닉네임에 공백이 섞이면 400을 반환하고 가입 서비스를 호출하지 않는다 FAILED
```

애너테이션이 없으면 실패한다. 검증이 실제로 동작한다.

### 기존 실패 8건 (이 PR과 무관)

| 클래스 | 실패 |
|---|---|
| `TradeRepositoryTest` | 4건 |
| `WithdrawalConfirmIntegrationTest` | 4건 |

이 PR의 변경을 `git stash`로 모두 치운 뒤 두 클래스만 돌렸을 때 **같은 8건이 같은 이름으로 실패**했다. 둘 다 닉네임과 접점이 없고 실제 DB를 쓰는 테스트다. 작업 범위 밖이므로 손대지 않았다.

## 🔍 리뷰 포인트

### 공백을 전면 금지한 판단

`trim()` 후 저장하는 방식과 비교했다. 앞뒤만 자르면 `홍 길동`이 남아 사칭 여지가 그대로다. 닉네임은 사용자를 식별하는 표시 이름이므로 중간 공백까지 막는 편이 UNIQUE 제약의 의도에 맞다.

### 정규화가 아니라 거부를 택했다

서버가 조용히 공백을 지우고 저장하면 사용자가 입력한 것과 다른 이름이 등록된다. 무엇이 문제인지 알려주고 다시 입력하게 하는 편이 낫다고 보아 `400`으로 거부한다.

### 프론트 검증은 별도 이슈다

프론트도 같은 규칙으로 맞춰야 하며 FE 이슈로 등록했다. 다만 강제는 이쪽이 담당한다. 프론트 검증만으로는 API를 직접 호출하는 경로를 막지 못한다.

### 기존 닉네임 정규화는 범위에 넣지 않았다

`existsByNickname`이 원문 비교라는 점은 그대로 두었다. 공백이 입구에서 막히면 이번 문제는 해소되지만, 대소문자나 유사 문자(전각·유니코드 유사자)까지 보려면 정규화 정책을 따로 정해야 한다. 지금 데이터에 해당 사례가 없어 후속으로 미룬다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? — 기존 실패 8건 제외, 추가한 3건 통과
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — API 스펙 변경이 아닌 입력 제약 강화라 문서 변경 없음