### PR TITLE
[Feature] #417 구매입찰 등록 시 판매자에게 알림 발송

### DIFF
--- a/Pokade/.env.example
+++ b/Pokade/.env.example
@@ -2,10 +2,13 @@
 # SPRING_PROFILES_ACTIVE=dev
 
 # ===== PostgreSQL =====
+# POSTGRES_*는 docker-compose 전용. Spring은 DB_*를 읽으며 prod는 DB_HOST/PORT/NAME/USER/PASSWORD 필수
 POSTGRES_DB=pokade
 POSTGRES_USER=pokade
 POSTGRES_PASSWORD=pokade
 POSTGRES_PORT=5432
+
+DB_POOL_SIZE=20   # prod의 Hikari 풀 크기. 미설정 시 20
 
 # ===== Redis (dev: no password) =====
 REDIS_PORT=6379

--- a/Pokade/observability/grafana/dashboards/system-resources.json
+++ b/Pokade/observability/grafana/dashboards/system-resources.json
@@ -38,7 +38,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "DB 커넥션 풀 (HikariCP)",
-      "description": "active가 max(10)에 붙고 pending(커넥션을 기다리는 스레드)이 0을 넘기 시작하면 DB 풀이 병목이다. pending이 진짜 포화 신호 — active가 10이어도 pending이 0이면 아직 여유가 있다.",
+      "description": "active가 max(20)에 붙고 pending(커넥션을 기다리는 스레드)이 0을 넘기 시작하면 DB 풀이 병목이다. pending이 진짜 포화 신호 — active가 20이어도 pending이 0이면 아직 여유가 있다.",
       "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListener.java
@@ -50,13 +50,22 @@ public class BuyOfferReceivedNoticeListener {
     private final CardNameKoResolver cardNameKoResolver;
     private final NotificationService notificationService;
 
-    // 본문 전체를 try/catch로 감싸는 이유: 이 메서드가 실패하면 그 예외가 AFTER_COMMIT 동기화를 타고
-    // 바깥 commit() 호출부까지 전파된다. 그 지점은 이미 커밋이 끝난 confirmBuyOfferPurchase()라,
-    // 토스 승인·포인트 차감·BuyOffer 저장은 전부 반영된 채로 POST /api/buy-offers/confirm-payment만
-    // 500을 돌려주게 된다 - 구매자 눈에는 "결제 실패"로 보이지만 실제로는 과금과 입찰 등록이 모두
-    // 성공한 상태다. 알림 하나 때문에 그 오해를 만들 이유가 없어 여기서 삼키고 로그만 남긴다.
+    // 본문 전체를 try/catch로 감싸는 이유: 아래 두 가지다. "예외가 새어나가면 결제 API가 500이 된다"는
+    // 이유가 아니다 - 정상 경로에서는 애초에 새어나가지 않는다. Spring 7.0.8 기준 AFTER_COMMIT
+    // @TransactionalEventListener는 afterCommit()이 아니라 afterCompletion()에서 호출되고
+    // (TransactionalApplicationListenerSynchronization$PlatformSynchronization),
+    // AbstractPlatformTransactionManager는 afterCompletion 예외를 잡아 로그만 남기고 삼킨다.
+    // 즉 트랜잭션을 타고 온 이벤트라면 catch가 있든 없든 commit() 호출부까지 올라가지 않는다
+    // (catch를 재던지기로 바꿔도 알림_저장이_실패해도_결제_확정은_예외_없이_끝나고... 테스트가
+    // 그대로 통과하는 것으로 실측 확인).
     //
-    // 이 메서드에 @Transactional을 붙이지 않는 것이 그 격리의 전제다. 트랜잭션 안에서 잡으면 DB 오류를
+    // 1. fallbackExecution=true 경로에는 그 프레임워크 보호가 없다. 활성 트랜잭션이 없어 동기화를
+    //    아예 타지 않으면 리스너가 발행 지점에서 그냥 인라인 실행되므로, 예외는 publishEvent()를
+    //    호출한 쪽으로 곧장 올라간다. 그 경로에서는 이 catch가 유일한 방어다.
+    // 2. 프레임워크가 남기는 것은 맥락 없는 일반 경고뿐이다. 어느 입찰의 어느 카드에서 알림이
+    //    유실됐는지, 결제가 롤백된 것인지 알림만 잃은 것인지는 아래 log.error가 아니면 알 수 없다.
+    //
+    // 이 메서드에 @Transactional을 붙이지 않는 것이 1번 성립의 전제다. 트랜잭션 안에서 잡으면 DB 오류를
     // 삼켜도 트랜잭션이 이미 rollback-only로 표시돼 있어, 정상 반환한 뒤 프록시 커밋 시점에
     // UnexpectedRollbackException이 다시 밖으로 나간다 - catch가 트랜잭션 경계 바깥에 있어야
     // 격리가 실제로 성립한다.
@@ -68,10 +77,20 @@ public class BuyOfferReceivedNoticeListener {
     //   EntityManagerHolder가 아직 바인딩돼 있어 REQUIRED로는 거기 참여만 하고 커밋되지 않는데,
     //   그 함정을 리스너가 아니라 그쪽에서 막는다(자세한 근거는 해당 메서드 주석 참고).
     //   실패하면 그쪽 프록시가 롤백까지 마친 뒤 예외를 던지므로 아래 catch가 깨끗하게 받는다.
-    // - 조회 두 건(findOrderbook, findById)은 트랜잭션 없이도 동작한다(각각 auto-commit).
-    // - 트랜잭션 밖에서 Card를 만지지만 지연 로딩이 없어 LazyInitializationException 위험이 없다.
-    //   cardNameKoResolver가 읽는 Card.nationalPokedexNumbers는 연관관계가 아니라
-    //   @JdbcTypeCode(SqlTypes.ARRAY)로 매핑된 기본 컬럼이라 조회 시점에 이미 채워져 온다.
+    // - 조회 두 건(findOrderbook, findById)은 "트랜잭션 없이 auto-commit으로" 도는 게 아니다.
+    //   SimpleJpaRepository의 조회 메서드에는 @Transactional(readOnly = true)가 붙어 있고,
+    //   AFTER_COMMIT 시점에는 isActualTransactionActive()가 아직 true라(바로 위 항목이 설명하는 그
+    //   상태다) REQUIRED로 이미 커밋된 바깥 트랜잭션에 그대로 참여한다. 그래도 안전한 이유는
+    //   "트랜잭션이 없어서"가 아니라 이 두 건이 읽기뿐이어서다 - 커밋될 쓰기가 없으니 그 트랜잭션이
+    //   더는 커밋되지 않는다는 사실이 아무것도 잃게 하지 않는다. 여기에 쓰기를 추가하면 그 순간
+    //   위의 REQUIRES_NEW 근거가 그대로 적용되므로 반드시 자기 트랜잭션을 여는 쪽으로 빼야 한다.
+    // - 조회해 온 Card를 트랜잭션 경계 밖에서 다루지만 지연 로딩을 건드리는 경로가 없다.
+    //   Card에는 @ManyToOne(fetch = LAZY) expansion이 있어 프록시 초기화 위험 자체는 존재하는데,
+    //   이 리스너에서 Card를 읽는 두 곳 모두 그 필드를 지나가지 않는다.
+    //   cardNameKoResolver는 name과 nationalPokedexNumbers(연관관계가 아니라
+    //   @JdbcTypeCode(SqlTypes.ARRAY)로 매핑된 기본 컬럼)만 읽고, 이 Card를 그대로 넘겨받는
+    //   NotificationResponse.of는 썸네일용으로 imageMedium/imageSmall만 읽는다 - 셋 다 조회 시점에
+    //   이미 채워져 오는 기본 컬럼이다. Card를 쓰는 경로를 새로 늘릴 때 이 전제를 다시 확인할 것.
     //
     // 같은 AFTER_COMMIT 리스너인 WatchlistListingAvailableNoticeListener가 리스너 자체에 REQUIRES_NEW를
     // 두는 것과 갈리는 지점이 여기다 - 그쪽은 알림 생성 권한을 선점하는 조건부 UPDATE

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListener.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListener.java
@@ -1,0 +1,133 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.global.event.BuyOfferCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Objects;
+
+// 구매입찰이 등록되면 그 카드에 매물을 올려둔 판매자에게 알린다. 지금까지 입찰 관련 알림은 체결 시점
+// (BUY_OFFER_MATCHED)에만 있었는데, 그건 이미 거래가 끝난 뒤라 판매자가 "이 가격에 팔지"를 판단할
+// 기회 자체가 없었다.
+//
+// 위치가 price가 아니라 listing인 이유: WatchlistListingAvailableNoticeListener가 이벤트 발행자
+// (listing)가 아니라 수신자 도메인(watchlist)에 있는 것과 같은 규칙이다. 이 알림의 수신자는
+// 매물을 가진 판매자이므로 listing 쪽이 맞다.
+//
+// 결제 트랜잭션이 커밋된 뒤에만 동작해야 한다 - confirmBuyOfferPurchase()는 토스 승인과 포인트 차감이
+// 이미 끝난 트랜잭션이라, 알림 저장이 그 트랜잭션에 얹히면 알림 쪽 DB 오류로 "결제는 됐는데 입찰은
+// 없는" 상태가 만들어질 수 있다. AFTER_COMMIT으로 그 경로를 구조적으로 끊고, 리스너를 비트랜잭션으로
+// 둬서 뒤늦게 터지는 예외까지 막는다(자세한 근거는 onBuyOfferCreated 위 주석 참고).
+//
+// 스코프 제한(의도적으로 이번 범위에서 제외):
+// - variantId가 null인 매물은 수신자에서 빠진다. BuyOffer.variantId는 등록 시점에 대표 variant로
+//   치환되지만(PriceService.readyBuyOffer) Listing.variantId는 nullable이고, findOrderbook의
+//   l.variantId = :variantId는 SQL 특성상 NULL 행을 매칭하지 못한다. 워치리스트처럼 null을 치환해서
+//   맞출 수도 있지만, 호가창(GET /api/listings/{cardId}/orderbook)이 이미 같은 쿼리로 그 매물을
+//   숨기고 있어 알림만 다른 규칙을 쓰면 "알림 받고 들어갔는데 호가창에 내 매물이 없다"는 더 큰
+//   불일치가 생긴다. 근본 해결은 매물 등록 시 variantId를 대표 판본으로 치환하는 것이고 별도 이슈다.
+// - 팬아웃 인원에 상한이 없다. 매물이 많은 인기 카드면 입찰 1건에 수백 명이 알림을 받고, 같은 카드에
+//   입찰이 연달아 들어오면 같은 판매자에게 계속 쌓인다. createInquiryReceivedNotification(관리자
+//   팬아웃)도 같은 구조이고 현재 데이터 규모에서는 감내한다 - 상한/쿨다운은 별도 이슈다.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuyOfferReceivedNoticeListener {
+
+    private final ListingRepository listingRepository;
+    private final CardRepository cardRepository;
+    private final CardNameKoResolver cardNameKoResolver;
+    private final NotificationService notificationService;
+
+    // 본문 전체를 try/catch로 감싸는 이유: 이 메서드가 실패하면 그 예외가 AFTER_COMMIT 동기화를 타고
+    // 바깥 commit() 호출부까지 전파된다. 그 지점은 이미 커밋이 끝난 confirmBuyOfferPurchase()라,
+    // 토스 승인·포인트 차감·BuyOffer 저장은 전부 반영된 채로 POST /api/buy-offers/confirm-payment만
+    // 500을 돌려주게 된다 - 구매자 눈에는 "결제 실패"로 보이지만 실제로는 과금과 입찰 등록이 모두
+    // 성공한 상태다. 알림 하나 때문에 그 오해를 만들 이유가 없어 여기서 삼키고 로그만 남긴다.
+    //
+    // 이 메서드에 @Transactional을 붙이지 않는 것이 그 격리의 전제다. 트랜잭션 안에서 잡으면 DB 오류를
+    // 삼켜도 트랜잭션이 이미 rollback-only로 표시돼 있어, 정상 반환한 뒤 프록시 커밋 시점에
+    // UnexpectedRollbackException이 다시 밖으로 나간다 - catch가 트랜잭션 경계 바깥에 있어야
+    // 격리가 실제로 성립한다.
+    //
+    // 트랜잭션 없이 둬도 안전한 근거:
+    // - 이 리스너 자체에는 쓰기가 없다. 실제 쓰기는 전부
+    //   NotificationService.createBuyOfferReceivedNotification 안에서 일어나고, 그 메서드가
+    //   REQUIRES_NEW로 자기 트랜잭션을 직접 연다. AFTER_COMMIT 시점엔 이미 커밋된 트랜잭션의
+    //   EntityManagerHolder가 아직 바인딩돼 있어 REQUIRED로는 거기 참여만 하고 커밋되지 않는데,
+    //   그 함정을 리스너가 아니라 그쪽에서 막는다(자세한 근거는 해당 메서드 주석 참고).
+    //   실패하면 그쪽 프록시가 롤백까지 마친 뒤 예외를 던지므로 아래 catch가 깨끗하게 받는다.
+    // - 조회 두 건(findOrderbook, findById)은 트랜잭션 없이도 동작한다(각각 auto-commit).
+    // - 트랜잭션 밖에서 Card를 만지지만 지연 로딩이 없어 LazyInitializationException 위험이 없다.
+    //   cardNameKoResolver가 읽는 Card.nationalPokedexNumbers는 연관관계가 아니라
+    //   @JdbcTypeCode(SqlTypes.ARRAY)로 매핑된 기본 컬럼이라 조회 시점에 이미 채워져 온다.
+    //
+    // 같은 AFTER_COMMIT 리스너인 WatchlistListingAvailableNoticeListener가 리스너 자체에 REQUIRES_NEW를
+    // 두는 것과 갈리는 지점이 여기다 - 그쪽은 알림 생성 권한을 선점하는 조건부 UPDATE
+    // (markListingNotifiedIfNotYet)와 엔티티 변경(markAsListingNotified, 더티 체킹)이라는 자체 쓰기가
+    // 있어 리스너 레벨에 트랜잭션이 반드시 필요하다. 이 리스너에는 그런 쓰기가 없어 트랜잭션 경계를
+    // 서비스 쪽으로 미룰 수 있고, 그 덕에 catch가 경계 바깥에 남아 예외 격리까지 함께 얻는다.
+    //
+    // fallbackExecution=true인 이유: @TransactionalEventListener는 발행 시점에 활성 트랜잭션이 없으면
+    // 아무 로그도 남기지 않고 리스너를 조용히 건너뛴다. 정상 경로(confirmBuyOfferPurchase)는 항상
+    // 트랜잭션 안이지만, 트랜잭션 없는 컨텍스트(단위 테스트, 이후 추가될 다른 호출부)에서 이벤트가
+    // 발행되면 알림이 소리 없이 사라진다. 이 리스너는 트랜잭션에 얹히는 게 없으므로(위 근거 참고)
+    // 그런 경우에도 그냥 실행되는 편이 낫다 - NotificationService.onNotificationPush와 같은 판단이다.
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onBuyOfferCreated(BuyOfferCreatedEvent event) {
+        try {
+            notifySellers(event);
+        } catch (Exception e) {
+            // TradeService.notifyQuietly의 문구를 그대로 쓰지 않는다 - 그쪽은 거래 트랜잭션 안(REQUIRED)이라
+            // "거래까지 함께 롤백될 수 있다"를 경고해야 하지만, 여기는 AFTER_COMMIT이라 결제와 입찰은
+            // 이미 커밋이 끝나 안전하다. 실제로 잃는 것은 알림뿐이므로 그 사실만 정확히 적는다.
+            log.error("구매입찰 등록 알림 발행 실패 - 결제와 입찰은 이미 커밋되어 그대로 유효하고 알림만 유실된다:"
+                    + " buyOfferId={}, cardId={}", event.buyOfferId(), event.cardId(), e);
+        }
+    }
+
+    private void notifySellers(BuyOfferCreatedEvent event) {
+        // 매도 호가창과 같은 쿼리를 그대로 쓴다 - 이 입찰에 실제로 팔 수 있는 매물의 집합이 곧 알림
+        // 대상이기 때문이다. 정지/탈퇴 판매자를 걸러내는 서브쿼리도 여기 이미 들어있어 따로 볼 필요가 없다.
+        // grade가 null이면(등급 무관 입찰) 쿼리가 전 등급을 돌려준다 - 어떤 등급이든 팔 수 있다는
+        // 뜻이므로 의도한 동작이다.
+        List<Listing> listings = listingRepository.findOrderbook(
+                event.cardId(), event.variantId(), ListingStatus.ACTIVE, event.grade());
+
+        // 자기 자신 제외를 distinct보다 먼저 한다(결과는 같지만 중복 제거 대상이 줄어든다).
+        // 입찰자가 같은 카드의 매물도 갖고 있을 수 있는데, 자기가 방금 건 입찰을 자기에게 알리는 건
+        // 소음이다 - fulfillBuyOffer가 SELF_BUY_OFFER_NOT_ALLOWED로 막는 것과 같은 기준.
+        // distinct는 한 판매자가 같은 카드에 매물을 여러 개 올린 경우 알림이 그 수만큼 가는 걸 막는다.
+        List<Long> sellerIds = listings.stream()
+                .map(Listing::getSellerId)
+                .filter(Objects::nonNull)
+                .filter(sellerId -> !sellerId.equals(event.buyerId()))
+                .distinct()
+                .toList();
+        if (sellerIds.isEmpty()) {
+            return;
+        }
+
+        Card card = cardRepository.findById(event.cardId()).orElse(null);
+        if (card == null) {
+            log.warn("구매입찰 등록 알림 대상 카드를 찾을 수 없어 스킵합니다: cardId={}, buyOfferId={}",
+                    event.cardId(), event.buyOfferId());
+            return;
+        }
+        String cardName = Objects.requireNonNullElse(cardNameKoResolver.resolve(card), card.getName());
+
+        notificationService.createBuyOfferReceivedNotification(
+                sellerIds, event.cardId(), cardName, event.price(), card);
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/entity/NotificationType.java
@@ -27,5 +27,12 @@ public enum NotificationType {
     // #392: 등록해 둔 구매 입찰이 판매자의 즉시판매로 체결된 시점 - 입찰자는 아무 행동도 하지 않았는데
     // 거래가 시작되므로 알림이 없으면 알 방법이 없다. 수신자 관점이 "거래"가 아니라 "내 입찰"이라
     // TRADE_ 접두사를 쓰지 않는다.
-    BUY_OFFER_MATCHED
+    BUY_OFFER_MATCHED,
+
+    // 구매 입찰이 새로 등록된 시점 - 그 카드에 매물을 올려둔 판매자에게 간다. BUY_OFFER_MATCHED가
+    // "이미 팔렸다"를 알리는 사후 통보라면 이쪽은 "이 값에 팔 수 있다"를 알리는 사전 기회다.
+    // 입찰 계열끼리 나란히 읽히도록 BUY_OFFER_ 접두사를 공유하고, INQUIRY_RECEIVED와 같은 뜻으로
+    // (= 내가 처리할 것이 들어왔다) _RECEIVED를 쓴다.
+    // INQUIRY_RECEIVED와 마찬가지로 수신자가 여럿이다 - 한 입찰에 판매자 여러 명이 동시에 받는다.
+    BUY_OFFER_RECEIVED
 }

--- a/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
+++ b/Pokade/src/main/java/com/pokade/domain/notification/service/NotificationService.java
@@ -285,6 +285,65 @@ public class NotificationService {
                 String.format("%s 카드 구매 입찰이 %,d원에 체결되었습니다.", cardName, matchedPrice));
     }
 
+    /**
+     * 구매 입찰이 새로 등록됐을 때 그 카드에 매물을 올려둔 판매자들에게 보내는 알림. 수신자가 여럿이라
+     * {@link #createInquiryReceivedNotification}과 같은 팬아웃 구조를 쓴다 - 저장은 saveAll 한 번,
+     * 푸시 이벤트만 인원수만큼 발행한다.
+     *
+     * <p>수신자 선별(중복 제거, 입찰자 본인 제외, 정지/탈퇴 판매자 제외)은 호출자인
+     * BuyOfferReceivedNoticeListener가 이미 끝낸 상태로 넘긴다 - 여기서는 목록을 그대로 믿는다.
+     *
+     * <p>문의 팬아웃과 다른 점 두 가지: inquiryId 대신 cardId를 채워 알림을 누르면 카드 상세로
+     * 가게 하고(notifications에는 buy_offer_id 컬럼이 없어 특정 입찰로 보낼 방법이 아직 없다),
+     * 호출자가 문구를 만들려고 이미 조회해 둔 {@link Card}를 받아 푸시 payload의 썸네일까지 채운다.
+     *
+     * @param sellerIds 알림을 받을 판매자 ID - 비어 있으면 아무것도 하지 않는다(매물이 전부 입찰자
+     *                  본인 것이었거나 애초에 없는 경우)
+     * @param offeredPrice 입찰가(상품가) - 배송비/포인트를 뺀 값이라 판매자가 받는 정산 기준가와 같다
+     */
+    // 이 메서드만 REQUIRES_NEW인 이유: 유일한 호출 맥락이 AFTER_COMMIT 리스너
+    // (BuyOfferReceivedNoticeListener)이기 때문이다. AFTER_COMMIT 콜백은 커밋이 끝난 뒤이긴 해도 아직
+    // 트랜잭션 정리(cleanupAfterCompletion) 전이라 EntityManagerHolder가 스레드에 그대로 바인딩돼 있고
+    // transactionActive도 true다. 그 상태에서 REQUIRED로 들어오면 새 트랜잭션이 열리는 게 아니라 이미
+    // 커밋된 그 트랜잭션에 "참여"만 하게 되는데, 참여 트랜잭션은 isNewTransaction()이 false라
+    // AbstractPlatformTransactionManager가 doCommit을 건너뛴다 - 즉 아래 saveAll()이 영영 커밋되지 않고
+    // 커넥션 반납 시점에 사라진다. REQUIRES_NEW로 기존 리소스를 잠시 밀어내고 진짜 새 트랜잭션을 열어야
+    // 저장이 실제로 남는다. (Spring javadoc의 "Use PROPAGATION_REQUIRES_NEW for any transactional
+    // operation that is called from here"가 가리키는 상황이 정확히 이것이다.)
+    //
+    // 나머지 10개 create*Notification이 REQUIRED인 것과 갈리는 지점이기도 하다 - 그쪽은 거래/문의 같은
+    // 업무 트랜잭션 <b>안에서</b> 불리므로 업무가 롤백되면 알림도 함께 사라지는 게 맞다. 이 메서드는
+    // 업무(결제·입찰)가 이미 커밋을 마친 뒤에 불리므로 같이 묶을 대상 자체가 없다.
+    //
+    // 주의: 그래서 이 메서드를 업무 트랜잭션 안에서 호출하면 의도와 다르게 동작한다 - 알림만 독립적으로
+    // 먼저 커밋돼, 이후 그 업무가 롤백돼도 알림은 남는다. 새 호출부를 만들 때는 그 맥락이 AFTER_COMMIT인지
+    // 먼저 확인할 것.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createBuyOfferReceivedNotification(
+            List<Long> sellerIds, Long cardId, String cardName, Integer offeredPrice, Card card) {
+        if (sellerIds == null || sellerIds.isEmpty()) {
+            return;
+        }
+
+        String message = String.format(
+                "%s 카드에 %,d원 구매 입찰이 등록되었습니다. 즉시판매로 바로 팔 수 있어요.", cardName, offeredPrice);
+        List<Notification> notifications = sellerIds.stream()
+                .map(sellerId -> Notification.builder()
+                        .userId(sellerId)
+                        .type(NotificationType.BUY_OFFER_RECEIVED)
+                        .message(message)
+                        .cardId(cardId)
+                        .build())
+                .toList();
+
+        // createInquiryReceivedNotification과 같은 이유로 saveAll()이 돌려주는 인스턴스를 쓴다 -
+        // id가 채워진 건 이쪽이라, 인자로 넘긴 목록으로 응답 DTO를 만들면 id가 null인 알림이 SSE로 나간다.
+        for (Notification saved : notificationRepository.saveAll(notifications)) {
+            eventPublisher.publishEvent(
+                    new NotificationPushEvent(saved.getUserId(), NotificationResponse.of(saved, card)));
+        }
+    }
+
     // #392: "저장 → 커밋 후 푸시용 이벤트 발행"이라는 똑같은 절차를 공용화했다. 알림 레코드에 카드를
     // 붙이지 않는(=푸시 시점에 썸네일이 없는) 타입들이 쓴다 - 목록 조회 시 getNotifications()의 배치
     // 조회가 이미지를 채워준다.

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -45,6 +45,7 @@ import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.trade.service.TradeService;
 import com.pokade.domain.user.entity.User;
 import com.pokade.domain.user.repository.UserRepository;
+import com.pokade.global.event.BuyOfferCreatedEvent;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import com.pokade.global.port.UserAccessChecker;
@@ -53,6 +54,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -119,6 +121,8 @@ public class PriceService {
     private final TradeService tradeService;
     // 임시 계측 - Grafana 테스트용, 팀 논의 전 커밋 대상 아님
     private final MeterRegistry meterRegistry;
+    // 구매입찰 등록 사실만 알리고 알림 생성은 listing 도메인 리스너에 맡긴다(BuyOfferReceivedNoticeListener).
+    private final ApplicationEventPublisher eventPublisher;
 
     public PriceSummaryResponse getSummary(Long cardId, Long variantId) {
         if (!cardRepository.existsById(cardId)) {
@@ -338,6 +342,17 @@ public class PriceService {
         BuyOffer saved = buyOfferRepository.save(buyOffer);
 
         order.markConfirmed();
+
+        // 이 카드에 매물을 올려둔 판매자에게 "이 값에 팔 수 있다"를 알린다. 알림 저장을 이 트랜잭션에
+        // 얹지 않는 이유는 여기가 토스 승인/포인트 차감이 이미 끝난 자리이기 때문이다 - 알림 쪽 DB
+        // 오류가 결제까지 롤백시키면 안 된다. 받는 쪽(BuyOfferReceivedNoticeListener)은 AFTER_COMMIT이라
+        // 결제와 입찰이 실제로 커밋된 뒤에만 돈다. 그 리스너 자체에는 트랜잭션이 없고, 실제 알림 저장은
+        // 리스너가 호출하는 NotificationService.createBuyOfferReceivedNotification이 REQUIRES_NEW로
+        // 자기 트랜잭션을 열어 처리한다. 리스너는 그 트랜잭션 경계 바깥에서 예외를 삼키므로 알림이
+        // 실패해도 이 경로로 새어나오지 않는다.
+        eventPublisher.publishEvent(new BuyOfferCreatedEvent(
+                saved.getId(), saved.getCardId(), saved.getVariantId(),
+                saved.getGrade(), buyerId, saved.getPrice()));
 
         return BuyOfferResponse.of(saved);
     }

--- a/Pokade/src/main/java/com/pokade/global/event/BuyOfferCreatedEvent.java
+++ b/Pokade/src/main/java/com/pokade/global/event/BuyOfferCreatedEvent.java
@@ -1,0 +1,21 @@
+package com.pokade.global.event;
+
+import com.pokade.domain.listing.entity.ListingGrade;
+
+// 구매입찰이 실제로 등록된(=결제 승인까지 끝난) 시점에 발행된다 - PriceService.confirmBuyOfferPurchase()가
+// 유일한 발행 지점이다. readyBuyOffer()는 아직 BuyOffer 행이 없는 단계라 발행하지 않는다.
+//
+// ListingCreatedEvent와 나란히 두는 이유: 둘 다 "한 도메인에서 일어난 일을 다른 도메인이 알림으로 바꾸는"
+// 같은 성격이고, 서로 참조하지 않는 두 도메인이 공유해야 해서 global에 둔다.
+//
+// ListingGrade(listing 도메인 enum)를 참조하지만 BuyOffer 엔티티가 이미 같은 타입을 쓰고 있어
+// 새로 생기는 결합은 아니다. grade는 null일 수 있고 "등급 무관 입찰"을 뜻한다.
+public record BuyOfferCreatedEvent(
+        Long buyOfferId,
+        Long cardId,
+        Long variantId,
+        ListingGrade grade,
+        Long buyerId,
+        Integer price
+) {
+}

--- a/Pokade/src/main/resources/application-dev.yaml
+++ b/Pokade/src/main/resources/application-dev.yaml
@@ -4,6 +4,7 @@ spring:
     username: ${DB_USER:pokade}
     password: ${DB_PASSWORD:pokade}
     driver-class-name: org.postgresql.Driver
+    # 커넥션 풀은 application.yaml 공통값을 그대로 쓴다(부하테스트를 dev에서 돌리므로 prod와 같아야 함)
 
   jpa:
     hibernate:

--- a/Pokade/src/main/resources/application-prod.yaml
+++ b/Pokade/src/main/resources/application-prod.yaml
@@ -5,7 +5,7 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
     hikari:
-      maximum-pool-size: ${DB_POOL_SIZE:10}
+      maximum-pool-size: ${DB_POOL_SIZE:20}   # 기본값은 application.yaml과 동일, RDS 클래스에 맞춰 env로만 조정
 
   jpa:
     hibernate:

--- a/Pokade/src/main/resources/application.yaml
+++ b/Pokade/src/main/resources/application.yaml
@@ -34,6 +34,11 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  datasource:
+    hikari:
+      connection-timeout: 10000   # 기본 30초는 풀 고갈을 느린 요청으로 감춰 톰캣 워커까지 묶는다
+      maximum-pool-size: 20       # AFTER_COMMIT 리스너 REQUIRES_NEW 이중 점유 대응, 기존 10
+
   jpa:
     open-in-view: false
     properties:

--- a/Pokade/src/test/java/com/pokade/domain/listing/repository/ListingRepositoryTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/repository/ListingRepositoryTest.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
@@ -89,21 +91,88 @@ class ListingRepositoryTest {
         assertThat(updated).isEqualTo(0);
     }
 
+    // findOrderbook은 호가창(GET /api/listings/{cardId}/orderbook)과 구매입찰 등록 알림
+    // (BuyOfferReceivedNoticeListener)이 함께 쓰는 쿼리다. 두 호출부 모두 "정지/탈퇴한 판매자는
+    // 빠진다"를 전제로 동작하는데(알림 쪽은 그 전제를 근거로 수신자 필터를 따로 두지 않는다),
+    // 그 전제를 만드는 것은 JPQL 안의 서브쿼리 하나뿐이라 여기서 직접 고정한다.
+    @Test
+    void findOrderbook은_ACTIVE가_아닌_판매자의_매물을_제외한다() {
+        Long cardId = insertCard("orderbook-seller-filter");
+        Long variantId = insertVariant(cardId);
+        Long activeSeller = insertUser("orderbook-active@test.com", "ACTIVE");
+        Listing visible = saveListing(activeSeller, cardId, variantId);
+        // 알림이 절대 가면 안 되는 상태들 - SUSPENDED/DELETED뿐 아니라 아직 ACTIVE가 된 적 없는
+        // PENDING, 탈퇴 진행 중인 WITHDRAWAL_PENDING까지 같은 서브쿼리 하나로 걸러진다.
+        for (String status : List.of("SUSPENDED", "DELETED", "PENDING", "WITHDRAWAL_PENDING")) {
+            saveListing(insertUser("orderbook-" + status + "@test.com", status), cardId, variantId);
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Listing> orderbook = listingRepository.findOrderbook(
+                cardId, variantId, ListingStatus.ACTIVE, null);
+
+        assertThat(orderbook)
+                .extracting(Listing::getId)
+                .containsExactly(visible.getId());
+    }
+
+    // 판매자가 ACTIVE라도 매물 자체가 ACTIVE가 아니면 빠진다 - 위 테스트가 판매자 조건만 보므로
+    // 매물 상태 조건이 함께 살아있는지도 같이 고정해 둔다.
+    @Test
+    void findOrderbook은_ACTIVE가_아닌_매물을_제외한다() {
+        Long cardId = insertCard("orderbook-status-filter");
+        Long variantId = insertVariant(cardId);
+        Long sellerId = insertUser("orderbook-status@test.com", "ACTIVE");
+        Listing active = saveListing(sellerId, cardId, variantId);
+        Listing hidden = saveListing(sellerId, cardId, variantId);
+        listingRepository.hideIfNotAlreadyHidden(hidden.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Listing> orderbook = listingRepository.findOrderbook(
+                cardId, variantId, ListingStatus.ACTIVE, null);
+
+        assertThat(orderbook)
+                .extracting(Listing::getId)
+                .containsExactly(active.getId());
+    }
+
     private Listing saveListing(Long sellerId, Long cardId) {
+        return saveListing(sellerId, cardId, null);
+    }
+
+    private Listing saveListing(Long sellerId, Long cardId, Long variantId) {
         return listingRepository.save(
                 Listing.builder()
                         .cardId(cardId)
                         .sellerId(sellerId)
+                        .variantId(variantId)
                         .price(10000)
                         .build()
         );
     }
 
     private Long insertUser(String email) {
+        return insertUser(email, "ACTIVE");
+    }
+
+    // nickname은 UNIQUE라 한 테스트에서 유저를 여럿 만들 때 고정값을 쓰면 제약에 걸린다 - email에서 파생시킨다.
+    private Long insertUser(String email, String status) {
         return ((Number) entityManager.createNativeQuery(
                         "INSERT INTO users (email, nickname, provider, role, status) "
-                                + "VALUES (:email, 'tester', 'LOCAL', 'USER', 'ACTIVE') RETURNING id")
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', :status) RETURNING id")
                 .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .setParameter("status", status)
+                .getSingleResult()).longValue();
+    }
+
+    private Long insertVariant(Long cardId) {
+        return ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO card_variants (card_id, variant_name, is_primary, synced_at) "
+                                + "VALUES (:cardId, 'repo-test-variant', true, now()) RETURNING id")
+                .setParameter("cardId", cardId)
                 .getSingleResult()).longValue();
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeIntegrationTest.java
@@ -1,0 +1,355 @@
+package com.pokade.domain.listing.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.card.support.PokedexKoNameCache;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.notification.entity.Notification;
+import com.pokade.domain.notification.entity.NotificationType;
+import com.pokade.domain.notification.event.NotificationPushEvent;
+import com.pokade.domain.notification.repository.NotificationRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.domain.notification.store.SseEmitterStore;
+import com.pokade.domain.point.client.TossPaymentClient;
+import com.pokade.domain.point.service.PointService;
+import com.pokade.domain.price.entity.BuyOffer;
+import com.pokade.domain.price.entity.BuyOfferOrder;
+import com.pokade.domain.price.entity.BuyOfferOrderStatus;
+import com.pokade.domain.price.repository.BuyOfferOrderRepository;
+import com.pokade.domain.price.repository.BuyOfferRepository;
+import com.pokade.domain.price.service.PriceService;
+import com.pokade.domain.price.store.PriceRankingRefreshStore;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.global.event.BuyOfferCreatedEvent;
+import com.pokade.global.port.UserAccessChecker;
+import com.pokade.support.AbstractIntegrationTest;
+import com.pokade.support.TestMetricsConfig;
+
+import jakarta.persistence.EntityManager;
+
+// 구매입찰 등록 알림의 트랜잭션 배선을 검증한다(#417). 단위 테스트 세 개(리스너/NotificationService/
+// PriceService)는 전부 mock 기반이라 "이벤트가 발행되는가", "리스너가 수신자를 어떻게 고르는가",
+// "saveAll이 불리는가"까지만 본다 - 실제로 DB에 행이 남는지는 이 테스트가 아니면 알 수 없다.
+//
+// 이 테스트가 있어야 하는 진짜 이유: AFTER_COMMIT 콜백은 커밋 직후지만 아직 트랜잭션 정리 전이라
+// EntityManagerHolder가 스레드에 그대로 바인딩돼 있다. 그 상태에서 알림 저장을 PROPAGATION_REQUIRED로
+// 하면 새 트랜잭션이 열리는 게 아니라 이미 커밋된 트랜잭션에 참여만 하게 되고, 참여 트랜잭션은
+// isNewTransaction()이 false라 커밋 자체를 건너뛴다 - saveAll이 조용히 사라진다. mock 기반 테스트는
+// 전부 초록인 채로 이 결함을 통과시킨다(실제로 한 번 통과시켰다). 그래서 커밋 이후 DB를 다시 읽는
+// 검증이 필요하다.
+//
+// 슬라이스 구성과 클래스 트랜잭션을 끄는 이유는 WatchlistListingAvailableNoticeIntegrationTest와 동일하다
+// (전체 컨텍스트는 S3/메일/OAuth2 자격 증명을 요구하고, @DataJpaTest 기본 테스트 트랜잭션 위에서는
+// TransactionTemplate로 연 트랜잭션도 물리적으로 커밋되지 않아 AFTER_COMMIT이 아예 발동하지 않는다).
+//
+// PriceService까지 함께 올리는 이유: 위 세 테스트는 eventPublisher.publishEvent로 "발행 지점만 흉내"내므로
+// 정작 그 이벤트를 실제로 발행하는 업무 서비스(confirmBuyOfferPurchase) 앞단은 한 번도 타지 않는다.
+// 즉 "업무 서비스가 자기 트랜잭션 안에서 이벤트를 발행한다"는 전제 자체는 어디서도 검증되지 않는다
+// (PriceServiceTest는 mock 기반이라 publishEvent 호출만 본다). 마지막 테스트가 그 구멍을 메운다.
+@DataJpaTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import({BuyOfferReceivedNoticeListener.class, NotificationService.class, CardNameKoResolver.class,
+        PokedexKoNameCache.class, SseEmitterStore.class, TestMetricsConfig.class, PriceService.class,
+        BuyOfferReceivedNoticeIntegrationTest.PushEventRecorderConfig.class})
+class BuyOfferReceivedNoticeIntegrationTest extends AbstractIntegrationTest {
+
+    // SSE 푸시 검증용. NotificationService가 발행하는 NotificationPushEvent를 실제 SSE 대신 여기 모은다.
+    // 일부러 @TransactionalEventListener(AFTER_COMMIT)으로 받는다 - 평범한 @EventListener로 받으면
+    // "발행됐다"까지만 보이지만, 이 방식은 알림 트랜잭션이 실제로 커밋됐을 때만 기록된다. 즉 저장이
+    // 사라지는 시나리오에서는 이쪽도 비게 되어 같은 결함을 두 각도에서 잡는다.
+    static class PushEventRecorder {
+
+        private final List<NotificationPushEvent> received = new ArrayList<>();
+
+        @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+        void on(NotificationPushEvent event) {
+            received.add(event);
+        }
+
+        List<NotificationPushEvent> received() {
+            return received;
+        }
+
+        void clear() {
+            received.clear();
+        }
+    }
+
+    @TestConfiguration
+    static class PushEventRecorderConfig {
+
+        @Bean
+        PushEventRecorder pushEventRecorder() {
+            return new PushEventRecorder();
+        }
+    }
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private PushEventRecorder pushEventRecorder;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private PriceService priceService;
+
+    @Autowired
+    private BuyOfferOrderRepository buyOfferOrderRepository;
+
+    @Autowired
+    private BuyOfferRepository buyOfferRepository;
+
+    // PriceService의 협력자 중 DB 밖에 있는 것들만 잘라낸다. 잘라낸 기준:
+    // - tossPaymentClient: 외부 HTTP. 다만 "결제금액 > 0" 분기는 그대로 태우고 호출만 스텁한다
+    //   (금액을 0으로 맞춰 분기를 건너뛰면 정작 검증하려는 실제 결제 경로가 빠진다).
+    // - pointService: 포인트 원장까지 세팅하는 비용이 이 테스트의 관심사(알림 배선)에 비해 크다.
+    //   대신 주문의 pointsUsed를 0으로 둬서 애초에 호출되지 않는 조건으로 맞춘다.
+    // - tradeService/priceRankingRefreshStore(Redis)/userAccessChecker: confirmBuyOfferPurchase
+    //   경로에서 아예 호출되지 않는다. 빈이 없으면 컨텍스트가 안 뜨므로 자리만 채운다.
+    @MockitoBean
+    private TossPaymentClient tossPaymentClient;
+
+    @MockitoBean
+    private PointService pointService;
+
+    @MockitoBean
+    private TradeService tradeService;
+
+    @MockitoBean
+    private PriceRankingRefreshStore priceRankingRefreshStore;
+
+    @MockitoBean
+    private UserAccessChecker userAccessChecker;
+
+    private TransactionTemplate transactionTemplate() {
+        return new TransactionTemplate(transactionManager);
+    }
+
+    // 클래스 트랜잭션을 껐다는 건 이 테스트가 넣은 데이터가 자동으로 롤백되지 않는다는 뜻이고,
+    // AbstractIntegrationTest의 PostgreSQLContainer는 static이라 JVM 안의 모든 테스트 클래스가 같은
+    // DB를 공유한다. 그냥 두면 여기서 만든 카드 3장이 CardRepositoryTest처럼 "카드 전체 건수"를
+    // 절대값으로 단언하는 테스트를 깨뜨린다(실제로 9건이 깨지는 것을 확인했다). 그래서 이 테스트가
+    // 만든 행만 접두사로 골라 직접 지운다 - FK 때문에 notifications → listings → card_variants →
+    // cards → users 순서를 지켜야 한다.
+    @AfterEach
+    void cleanUpOwnData() {
+        transactionTemplate().executeWithoutResult(status -> {
+            entityManager.createNativeQuery("DELETE FROM notifications WHERE user_id IN "
+                    + "(SELECT id FROM users WHERE email LIKE 'bo-notice-%')").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM buy_offers WHERE buyer_id IN "
+                    + "(SELECT id FROM users WHERE email LIKE 'bo-notice-%')").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM buy_offer_orders WHERE buyer_id IN "
+                    + "(SELECT id FROM users WHERE email LIKE 'bo-notice-%')").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM listings WHERE card_id IN "
+                    + "(SELECT id FROM cards WHERE external_id LIKE 'bo-notice-card-%')").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM card_variants WHERE card_id IN "
+                    + "(SELECT id FROM cards WHERE external_id LIKE 'bo-notice-card-%')").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM cards WHERE external_id LIKE 'bo-notice-card-%'")
+                    .executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM users WHERE email LIKE 'bo-notice-%'").executeUpdate();
+        });
+        pushEventRecorder.clear();
+    }
+
+    // 클래스 트랜잭션을 껐으므로 준비 데이터도 각자 자기 트랜잭션에서 커밋해야 한다.
+    private Long persistActiveUser(String email) {
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO users (email, nickname, provider, role, status) "
+                                + "VALUES (:email, :nickname, 'LOCAL', 'USER', 'ACTIVE') RETURNING id")
+                .setParameter("email", email)
+                .setParameter("nickname", email.substring(0, email.indexOf('@')))
+                .getSingleResult()).longValue());
+    }
+
+    private Long persistCard(String externalId, String name) {
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO cards (external_id, name) VALUES (:externalId, :name) RETURNING id")
+                .setParameter("externalId", externalId)
+                .setParameter("name", name)
+                .getSingleResult()).longValue());
+    }
+
+    private Long persistVariant(Long cardId, String variantName) {
+        return transactionTemplate().execute(status -> ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO card_variants (card_id, variant_name, is_primary, synced_at) "
+                                + "VALUES (:cardId, :variantName, true, now()) RETURNING id")
+                .setParameter("cardId", cardId)
+                .setParameter("variantName", variantName)
+                .getSingleResult()).longValue());
+    }
+
+    private void persistActiveListing(Long cardId, Long sellerId, Long variantId, int price) {
+        transactionTemplate().executeWithoutResult(status -> entityManager.createNativeQuery(
+                        "INSERT INTO listings (card_id, seller_id, variant_id, price, grade, status) "
+                                + "VALUES (:cardId, :sellerId, :variantId, :price, 'S', 'ACTIVE')")
+                .setParameter("cardId", cardId)
+                .setParameter("sellerId", sellerId)
+                .setParameter("variantId", variantId)
+                .setParameter("price", price)
+                .executeUpdate());
+    }
+
+    // PriceService.confirmBuyOfferPurchase가 하는 일을 그대로 재현한다 - 업무 트랜잭션 안에서 이벤트를
+    // 발행하고 그 트랜잭션을 커밋한다. 결제/포인트 협력자까지 끌어오면 슬라이스가 통째로 무거워지므로
+    // 발행 지점만 같은 조건으로 맞춘다(발행 자체는 PriceServiceTest t69가 따로 고정한다).
+    private void publishInCommittedTransaction(BuyOfferCreatedEvent event) {
+        transactionTemplate().executeWithoutResult(status -> eventPublisher.publishEvent(event));
+    }
+
+    private List<Notification> notificationsOf(Long userId) {
+        return notificationRepository.findAllByUserIdForTestVerification(userId);
+    }
+
+    @Test
+    void 커밋되면_매물을_가진_판매자들에게_알림이_실제로_저장된다() {
+        Long buyerId = persistActiveUser("bo-notice-buyer1@test.com");
+        Long seller1 = persistActiveUser("bo-notice-seller1a@test.com");
+        Long seller2 = persistActiveUser("bo-notice-seller1b@test.com");
+        Long cardId = persistCard("bo-notice-card-1", "Charizard");
+        Long variantId = persistVariant(cardId, "holo-1");
+        // seller1은 같은 카드에 매물 2건 - 중복 제거가 DB 저장 단계까지 유지되는지 함께 본다.
+        persistActiveListing(cardId, seller1, variantId, 140000);
+        persistActiveListing(cardId, seller1, variantId, 145000);
+        persistActiveListing(cardId, seller2, variantId, 150000);
+
+        publishInCommittedTransaction(
+                new BuyOfferCreatedEvent(1L, cardId, variantId, ListingGrade.S, buyerId, 150000));
+
+        assertThat(notificationsOf(seller1)).hasSize(1);
+        assertThat(notificationsOf(seller2)).hasSize(1);
+
+        Notification saved = notificationsOf(seller1).get(0);
+        assertThat(saved.getType()).isEqualTo(NotificationType.BUY_OFFER_RECEIVED);
+        assertThat(saved.getCardId()).isEqualTo(cardId);
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getMessage()).contains("150,000");
+        // 입찰자 본인은 매물이 없으므로 애초에 대상이 아니다 - 알림이 새어 들어가지 않았는지 확인.
+        assertThat(notificationsOf(buyerId)).isEmpty();
+    }
+
+    @Test
+    void 이벤트를_발행한_트랜잭션이_롤백되면_알림이_생기지_않는다() {
+        Long buyerId = persistActiveUser("bo-notice-buyer2@test.com");
+        Long sellerId = persistActiveUser("bo-notice-seller2@test.com");
+        Long cardId = persistCard("bo-notice-card-2", "Blastoise");
+        Long variantId = persistVariant(cardId, "holo-2");
+        persistActiveListing(cardId, sellerId, variantId, 150000);
+
+        transactionTemplate().executeWithoutResult(status -> {
+            eventPublisher.publishEvent(
+                    new BuyOfferCreatedEvent(2L, cardId, variantId, ListingGrade.S, buyerId, 150000));
+            status.setRollbackOnly();
+        });
+
+        assertThat(notificationsOf(sellerId)).isEmpty();
+    }
+
+    @Test
+    void 알림이_저장되면_SSE_푸시_이벤트가_수신자마다_발행된다() {
+        Long buyerId = persistActiveUser("bo-notice-buyer3@test.com");
+        Long seller1 = persistActiveUser("bo-notice-seller3a@test.com");
+        Long seller2 = persistActiveUser("bo-notice-seller3b@test.com");
+        Long cardId = persistCard("bo-notice-card-3", "Pikachu");
+        Long variantId = persistVariant(cardId, "holo-3");
+        persistActiveListing(cardId, seller1, variantId, 140000);
+        persistActiveListing(cardId, seller2, variantId, 150000);
+        pushEventRecorder.clear();
+
+        publishInCommittedTransaction(
+                new BuyOfferCreatedEvent(3L, cardId, variantId, ListingGrade.S, buyerId, 150000));
+
+        assertThat(pushEventRecorder.received())
+                .hasSize(2)
+                .extracting(NotificationPushEvent::userId)
+                .containsExactlyInAnyOrder(seller1, seller2);
+        // 푸시 payload는 저장된 행 기준이라 id가 채워져 있어야 한다(저장 전 인스턴스를 쓰면 null이 나간다).
+        assertThat(pushEventRecorder.received())
+                .allSatisfy(event -> assertThat(event.response().id()).isNotNull());
+    }
+
+    // 위 세 테스트가 흉내로 대신했던 앞단 - PriceService.confirmBuyOfferPurchase를 실제로 호출한다.
+    // 여기서만 검증되는 것: 업무 서비스가 자기 @Transactional 안에서 BuyOfferCreatedEvent를 발행하고,
+    // 그 트랜잭션이 물리적으로 커밋되면서 AFTER_COMMIT 리스너가 붙는다는 배선 전체. publishEvent를
+    // 테스트가 직접 부르는 방식으로는 "서비스가 이벤트 발행을 빠뜨렸다" 같은 회귀를 잡을 수 없다.
+    //
+    // 포인트 사용액을 0으로 두는 건 pointService(mock)를 타지 않게 하려는 것이고, 결제금액은 일부러
+    // 0보다 크게 둬서 토스 승인 분기까지 실제로 통과시킨다(호출 자체만 스텁).
+    @Test
+    void confirmBuyOfferPurchase가_커밋되면_판매자에게_알림이_저장된다() {
+        Long buyerId = persistActiveUser("bo-notice-buyer4@test.com");
+        Long sellerId = persistActiveUser("bo-notice-seller4@test.com");
+        Long cardId = persistCard("bo-notice-card-4", "Mewtwo");
+        Long variantId = persistVariant(cardId, "holo-4");
+        persistActiveListing(cardId, sellerId, variantId, 160000);
+
+        String orderId = UUID.randomUUID().toString();
+        transactionTemplate().executeWithoutResult(status -> buyOfferOrderRepository.save(BuyOfferOrder.builder()
+                .orderId(orderId)
+                .buyerId(buyerId)
+                .cardId(cardId)
+                .variantId(variantId)
+                .grade(ListingGrade.S)
+                .price(150000)
+                .shippingFee(3000)
+                .pointsUsed(0)
+                .recipientName("받는사람")
+                .recipientPhone("010-0000-0000")
+                .recipientAddress("서울시 어딘가 1-1")
+                .build()));
+
+        priceService.confirmBuyOfferPurchase(buyerId, "test-payment-key", orderId, 153000L);
+
+        List<Notification> notifications = notificationsOf(sellerId);
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getType()).isEqualTo(NotificationType.BUY_OFFER_RECEIVED);
+        assertThat(notifications.get(0).getCardId()).isEqualTo(cardId);
+        // 알림 문구의 금액은 배송비를 뺀 상품가(=판매자 정산 기준가)여야 한다.
+        assertThat(notifications.get(0).getMessage()).contains("150,000");
+        // 입찰자 본인에게는 가지 않는다(매물이 없어 애초에 대상이 아님).
+        assertThat(notificationsOf(buyerId)).isEmpty();
+
+        // 알림만 보고 끝내면 "결제 경로가 실제로 끝까지 갔는지"는 알 수 없으므로 업무 결과도 함께 본다.
+        List<BuyOffer> buyOffers = buyOfferRepository.findAll().stream()
+                .filter(buyOffer -> buyerId.equals(buyOffer.getBuyerId()))
+                .toList();
+        assertThat(buyOffers).hasSize(1);
+        assertThat(buyOffers.get(0).getCardId()).isEqualTo(cardId);
+        assertThat(buyOfferOrderRepository.findByOrderId(orderId))
+                .get()
+                .extracting(BuyOfferOrder::getStatus)
+                .isEqualTo(BuyOfferOrderStatus.CONFIRMED);
+        verify(tossPaymentClient, times(1)).confirmPayment("test-payment-key", orderId, 153000);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeIntegrationTest.java
@@ -1,6 +1,11 @@
 package com.pokade.domain.listing.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -17,6 +22,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -153,6 +159,13 @@ class BuyOfferReceivedNoticeIntegrationTest extends AbstractIntegrationTest {
     @MockitoBean
     private UserAccessChecker userAccessChecker;
 
+    // 예외 격리 테스트에서만 스텁한다(나머지 테스트는 실제 구현이 그대로 돈다) - 알림 저장이 실패하는
+    // 상황을 실제 DB 오류로 만들 방법이 마땅치 않아서다. notifications.user_id는 users를 FK로 참조하는데
+    // 수신자는 findOrderbook이 "ACTIVE인 유저"만 골라 온 판매자라 존재가 보장되고, 문구도 카드명
+    // 상한(cards.name VARCHAR(200))까지 채워도 message VARCHAR(255)를 넘지 않는다.
+    @MockitoSpyBean
+    private NotificationService notificationService;
+
     private TransactionTemplate transactionTemplate() {
         return new TransactionTemplate(transactionManager);
     }
@@ -230,6 +243,26 @@ class BuyOfferReceivedNoticeIntegrationTest extends AbstractIntegrationTest {
 
     private List<Notification> notificationsOf(Long userId) {
         return notificationRepository.findAllByUserIdForTestVerification(userId);
+    }
+
+    // 결제 승인 직전 상태(PENDING)의 주문을 만들어 커밋한다. pointsUsed=0이라 pointService(mock)를
+    // 타지 않고, 결제금액은 price+shippingFee = 153000으로 0보다 커서 토스 승인 분기까지 실제로 지난다.
+    private String persistPendingOrder(Long buyerId, Long cardId, Long variantId) {
+        String orderId = UUID.randomUUID().toString();
+        transactionTemplate().executeWithoutResult(status -> buyOfferOrderRepository.save(BuyOfferOrder.builder()
+                .orderId(orderId)
+                .buyerId(buyerId)
+                .cardId(cardId)
+                .variantId(variantId)
+                .grade(ListingGrade.S)
+                .price(150000)
+                .shippingFee(3000)
+                .pointsUsed(0)
+                .recipientName("받는사람")
+                .recipientPhone("010-0000-0000")
+                .recipientAddress("서울시 어딘가 1-1")
+                .build()));
+        return orderId;
     }
 
     @Test
@@ -314,20 +347,7 @@ class BuyOfferReceivedNoticeIntegrationTest extends AbstractIntegrationTest {
         Long variantId = persistVariant(cardId, "holo-4");
         persistActiveListing(cardId, sellerId, variantId, 160000);
 
-        String orderId = UUID.randomUUID().toString();
-        transactionTemplate().executeWithoutResult(status -> buyOfferOrderRepository.save(BuyOfferOrder.builder()
-                .orderId(orderId)
-                .buyerId(buyerId)
-                .cardId(cardId)
-                .variantId(variantId)
-                .grade(ListingGrade.S)
-                .price(150000)
-                .shippingFee(3000)
-                .pointsUsed(0)
-                .recipientName("받는사람")
-                .recipientPhone("010-0000-0000")
-                .recipientAddress("서울시 어딘가 1-1")
-                .build()));
+        String orderId = persistPendingOrder(buyerId, cardId, variantId);
 
         priceService.confirmBuyOfferPurchase(buyerId, "test-payment-key", orderId, 153000L);
 
@@ -351,5 +371,44 @@ class BuyOfferReceivedNoticeIntegrationTest extends AbstractIntegrationTest {
                 .extracting(BuyOfferOrder::getStatus)
                 .isEqualTo(BuyOfferOrderStatus.CONFIRMED);
         verify(tossPaymentClient, times(1)).confirmPayment("test-payment-key", orderId, 153000);
+    }
+
+    // onBuyOfferCreated의 try/catch가 실제로 근거 있는 주장인지 확인한다. 그 catch 위에는 "알림이
+    // 실패해도 POST /api/buy-offers/confirm-payment가 500이 되지 않는다"는 설명이 길게 붙어 있는데,
+    // 지금까지는 catch를 통째로 지워도 모든 테스트가 초록이었다 - 어느 테스트도 알림 실패를 만들지
+    // 않았기 때문이다.
+    //
+    // 격리가 성립하려면 두 가지가 동시에 맞아야 한다. (1) 리스너에 @Transactional이 없어 catch가
+    // 트랜잭션 경계 바깥에 있을 것, (2) 예외가 AFTER_COMMIT 동기화를 타고 바깥 commit() 호출부까지
+    // 올라가지 않을 것. 둘 중 하나만 깨져도 결제·입찰은 커밋된 채 API만 500을 돌려주게 된다.
+    @Test
+    void 알림_저장이_실패해도_결제_확정은_예외_없이_끝나고_결과가_그대로_남는다() {
+        Long buyerId = persistActiveUser("bo-notice-buyer5@test.com");
+        Long sellerId = persistActiveUser("bo-notice-seller5@test.com");
+        Long cardId = persistCard("bo-notice-card-5", "Snorlax");
+        Long variantId = persistVariant(cardId, "holo-5");
+        persistActiveListing(cardId, sellerId, variantId, 160000);
+        String orderId = persistPendingOrder(buyerId, cardId, variantId);
+
+        doThrow(new IllegalStateException("알림 저장 실패 재현"))
+                .when(notificationService)
+                .createBuyOfferReceivedNotification(anyList(), any(), anyString(), any(), any());
+
+        assertThatCode(() -> priceService.confirmBuyOfferPurchase(buyerId, "test-payment-key", orderId, 153000L))
+                .doesNotThrowAnyException();
+
+        // 스텁이 실제로 불렸는지부터 확인한다 - 이게 없으면 리스너가 수신자를 못 찾아 알림 단계까지
+        // 가지도 못한 경우(sellerIds가 비었거나 카드 조회 실패)에도 아래 단언이 전부 통과해 버린다.
+        verify(notificationService, times(1))
+                .createBuyOfferReceivedNotification(anyList(), any(), anyString(), any(), any());
+        // 알림만 유실되고 결제·입찰은 그대로 유효하다 - catch 위 주석이 로그로 주장하는 내용 그대로다.
+        assertThat(notificationsOf(sellerId)).isEmpty();
+        assertThat(buyOfferRepository.findAll().stream()
+                .filter(buyOffer -> buyerId.equals(buyOffer.getBuyerId()))
+                .toList()).hasSize(1);
+        assertThat(buyOfferOrderRepository.findByOrderId(orderId))
+                .get()
+                .extracting(BuyOfferOrder::getStatus)
+                .isEqualTo(BuyOfferOrderStatus.CONFIRMED);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListenerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/BuyOfferReceivedNoticeListenerTest.java
@@ -1,0 +1,149 @@
+package com.pokade.domain.listing.service;
+
+import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
+import com.pokade.domain.listing.entity.Listing;
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.listing.entity.ListingStatus;
+import com.pokade.domain.listing.repository.ListingRepository;
+import com.pokade.domain.notification.service.NotificationService;
+import com.pokade.global.event.BuyOfferCreatedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class BuyOfferReceivedNoticeListenerTest {
+
+    @Mock
+    private ListingRepository listingRepository;
+
+    @Mock
+    private CardRepository cardRepository;
+
+    @Mock
+    private CardNameKoResolver cardNameKoResolver;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private BuyOfferReceivedNoticeListener listener;
+
+    private static final Long CARD_ID = 55L;
+    private static final Long VARIANT_ID = 7L;
+    private static final Long BUYER_ID = 200L;
+
+    private BuyOfferCreatedEvent event() {
+        return event(ListingGrade.S);
+    }
+
+    private BuyOfferCreatedEvent event(ListingGrade grade) {
+        return new BuyOfferCreatedEvent(1L, CARD_ID, VARIANT_ID, grade, BUYER_ID, 150000);
+    }
+
+    private Listing listing(Long sellerId) {
+        return Listing.builder()
+                .cardId(CARD_ID).sellerId(sellerId).variantId(VARIANT_ID)
+                .price(150000).grade(ListingGrade.S)
+                .build();
+    }
+
+    private Card card() {
+        return Card.builder().id(CARD_ID).name("Charizard ex").imageMedium("medium.png").build();
+    }
+
+    private void givenListings(List<Listing> listings) {
+        given(listingRepository.findOrderbook(eq(CARD_ID), eq(VARIANT_ID), eq(ListingStatus.ACTIVE), any()))
+                .willReturn(listings);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> captureSellerIds() {
+        ArgumentCaptor<List<Long>> captor = ArgumentCaptor.forClass(List.class);
+        then(notificationService).should()
+                .createBuyOfferReceivedNotification(captor.capture(), eq(CARD_ID), any(), eq(150000), any());
+        return captor.getValue();
+    }
+
+    @Test
+    @DisplayName("한 판매자가 같은 카드에 매물을 여러 개 갖고 있어도 알림 대상에는 한 번만 들어간다")
+    void dedupesSellerWithMultipleListings() {
+        givenListings(List.of(listing(10L), listing(10L), listing(11L)));
+        given(cardRepository.findById(CARD_ID)).willReturn(Optional.of(card()));
+        given(cardNameKoResolver.resolve(any(Card.class))).willReturn("리자몽 ex");
+
+        listener.onBuyOfferCreated(event());
+
+        assertThat(captureSellerIds()).containsExactly(10L, 11L);
+    }
+
+    @Test
+    @DisplayName("입찰자 본인이 올린 매물은 알림 대상에서 빠진다")
+    void excludesBidderOwnListing() {
+        givenListings(List.of(listing(BUYER_ID), listing(11L)));
+        given(cardRepository.findById(CARD_ID)).willReturn(Optional.of(card()));
+        given(cardNameKoResolver.resolve(any(Card.class))).willReturn("리자몽 ex");
+
+        listener.onBuyOfferCreated(event());
+
+        assertThat(captureSellerIds()).containsExactly(11L);
+    }
+
+    @Test
+    @DisplayName("알릴 판매자가 하나도 없으면 카드 조회도 알림 생성도 하지 않는다")
+    void withNoSeller_doesNothing() {
+        // 매물이 전부 입찰자 본인 것이면 걸러진 뒤 비게 된다 - 매물 0건과 같은 경로다.
+        givenListings(List.of(listing(BUYER_ID)));
+
+        listener.onBuyOfferCreated(event());
+
+        then(cardRepository).should(never()).findById(any());
+        then(notificationService).should(never())
+                .createBuyOfferReceivedNotification(anyList(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("카드를 찾을 수 없으면 예외 없이 스킵하고 알림을 만들지 않는다")
+    void withMissingCard_skipsQuietly() {
+        givenListings(List.of(listing(10L)));
+        given(cardRepository.findById(CARD_ID)).willReturn(Optional.empty());
+
+        listener.onBuyOfferCreated(event());
+
+        then(notificationService).should(never())
+                .createBuyOfferReceivedNotification(anyList(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("등급 무관 입찰(grade=null)이면 조회에도 null을 그대로 넘겨 전 등급 판매자를 대상으로 삼는다")
+    void withNullGrade_queriesEveryGrade() {
+        given(listingRepository.findOrderbook(eq(CARD_ID), eq(VARIANT_ID), eq(ListingStatus.ACTIVE), isNull()))
+                .willReturn(List.of(listing(10L)));
+        given(cardRepository.findById(CARD_ID)).willReturn(Optional.of(card()));
+        given(cardNameKoResolver.resolve(any(Card.class))).willReturn("리자몽 ex");
+
+        listener.onBuyOfferCreated(event(null));
+
+        then(listingRepository).should()
+                .findOrderbook(eq(CARD_ID), eq(VARIANT_ID), eq(ListingStatus.ACTIVE), isNull());
+        assertThat(captureSellerIds()).containsExactly(10L);
+    }
+}

--- a/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/notification/service/NotificationServiceTest.java
@@ -636,4 +636,75 @@ class NotificationServiceTest {
         assertThat(captureEvent().userId()).isEqualTo(200L);
         then(sseEmitterStore).should(never()).findByUserId(any());
     }
+
+    // ===== 구매입찰 등록 알림(판매자 팬아웃) =====
+    // 수신자 선별(중복 제거/본인 제외/정지 판매자 제외)은 BuyOfferReceivedNoticeListener 책임이라
+    // 여기서는 검증하지 않는다 - 이 메서드는 넘겨받은 목록을 그대로 믿는 계약이다.
+    @Test
+    @DisplayName("입찰 등록 알림: 판매자 수만큼 saveAll로 한 번에 저장하고 각각 푸시 이벤트를 발행한다")
+    void createBuyOfferReceivedNotification_fansOutToEverySeller() {
+        // saveAll이 돌려주는 인스턴스로 이벤트를 만들어야 id가 채워진다 - 여기서는 인자를 그대로 되돌려준다.
+        given(notificationRepository.saveAll(anyList()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        notificationService.createBuyOfferReceivedNotification(
+                List.of(10L, 11L), 55L, "리자몽 ex", 150000, card());
+
+        ArgumentCaptor<List<Notification>> savedCaptor = ArgumentCaptor.forClass(List.class);
+        then(notificationRepository).should().saveAll(savedCaptor.capture());
+        // 저장은 판매자 수와 무관하게 saveAll 1회 - 개별 save로 새지 않았는지 함께 고정한다.
+        then(notificationRepository).should(never()).save(any());
+        assertThat(savedCaptor.getValue())
+                .extracting(Notification::getUserId, Notification::getType, Notification::getCardId)
+                .containsExactly(
+                        tuple(10L, NotificationType.BUY_OFFER_RECEIVED, 55L),
+                        tuple(11L, NotificationType.BUY_OFFER_RECEIVED, 55L));
+
+        ArgumentCaptor<NotificationPushEvent> eventCaptor = ArgumentCaptor.forClass(NotificationPushEvent.class);
+        then(eventPublisher).should(times(2)).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getAllValues()).extracting(NotificationPushEvent::userId)
+                .containsExactly(10L, 11L);
+        // 커밋 전에 직접 쏘지 않고 이벤트만 발행한다(나머지 타입과 동일).
+        then(sseEmitterStore).should(never()).findByUserId(any());
+    }
+
+    @Test
+    @DisplayName("입찰 등록 알림: 판매자가 없으면 저장도 이벤트 발행도 하지 않는다")
+    void createBuyOfferReceivedNotification_withNoSeller_doesNothing() {
+        notificationService.createBuyOfferReceivedNotification(List.of(), 55L, "리자몽 ex", 150000, card());
+
+        then(notificationRepository).should(never()).saveAll(anyList());
+        then(eventPublisher).should(never()).publishEvent(any(NotificationPushEvent.class));
+    }
+
+    @Test
+    @DisplayName("입찰 등록 알림: 문구에 카드명과 천단위 콤마를 넣은 입찰가가 들어간다")
+    void createBuyOfferReceivedNotification_messageContainsCardNameAndPrice() {
+        given(notificationRepository.saveAll(anyList()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        notificationService.createBuyOfferReceivedNotification(
+                List.of(10L), 55L, "리자몽 ex", 150000, card());
+
+        ArgumentCaptor<List<Notification>> savedCaptor = ArgumentCaptor.forClass(List.class);
+        then(notificationRepository).should().saveAll(savedCaptor.capture());
+        assertThat(savedCaptor.getValue().get(0).getMessage())
+                .contains("리자몽 ex")
+                .contains("150,000원")
+                .contains("즉시판매");
+    }
+
+    @Test
+    @DisplayName("입찰 등록 알림: 호출자가 넘긴 카드로 푸시 payload의 썸네일을 채운다")
+    void createBuyOfferReceivedNotification_fillsThumbnailFromGivenCard() {
+        given(notificationRepository.saveAll(anyList()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        notificationService.createBuyOfferReceivedNotification(
+                List.of(10L), 55L, "리자몽 ex", 150000, card());
+
+        // 카드를 넘겨받았으므로 푸시 시점에 다시 조회하지 않는다.
+        then(cardRepository).should(never()).findById(any());
+        assertThat(captureEvent().response().cardImageUrl()).isEqualTo("medium.png");
+    }
 }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -54,6 +54,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.pokade.global.event.BuyOfferCreatedEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -129,6 +132,9 @@ class PriceServiceTest {
 
     @Spy
     private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private PriceService priceService;
@@ -1403,5 +1409,33 @@ class PriceServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.BUY_OFFER_ALREADY_MATCHED);
+    }
+
+    @Test
+    @DisplayName("t69 결제승인 성공 시 저장된 구매입찰 그대로를 담은 BuyOfferCreatedEvent를 발행한다")
+    void t69() {
+        BuyOfferOrder order = pendingBuyOfferOrderOf(2L, 1L, 10L, 250000);
+        given(buyOfferOrderRepository.findByOrderId("bo-order-1")).willReturn(Optional.of(order));
+        // 실제 저장 시 PK가 채워지는 것을 재현한다 - 이벤트가 저장 전 인스턴스가 아니라 save() 결과를
+        // 쓰는지 확인하려면 둘이 구분돼야 한다(저장 전에는 id가 null이다).
+        given(buyOfferRepository.save(any(BuyOffer.class))).willAnswer(invocation -> {
+            BuyOffer saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 99L);
+            return saved;
+        });
+
+        priceService.confirmBuyOfferPurchase(2L, "pay_123", "bo-order-1", 253000);
+
+        ArgumentCaptor<BuyOfferCreatedEvent> captor = ArgumentCaptor.forClass(BuyOfferCreatedEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        BuyOfferCreatedEvent event = captor.getValue();
+        assertThat(event.buyOfferId()).isEqualTo(99L);
+        assertThat(event.cardId()).isEqualTo(1L);
+        assertThat(event.variantId()).isEqualTo(10L);
+        assertThat(event.grade()).isEqualTo(ListingGrade.S);
+        assertThat(event.buyerId()).isEqualTo(2L);
+        // 이벤트의 price는 상품가만이어야 한다 - 배송비(3000)를 더한 결제 금액이 새어 들어가면
+        // 판매자에게 잘못된 값이 알림 문구로 나간다.
+        assertThat(event.price()).isEqualTo(250000);
     }
 }

--- a/Pokade/src/test/resources/application-test.yaml
+++ b/Pokade/src/test/resources/application-test.yaml
@@ -1,4 +1,8 @@
 spring:
+  datasource:
+    hikari:
+      minimum-idle: 2   # 캐시된 테스트 컨텍스트마다 유휴 20개를 잡아 postgres max_connections 고갈(기본값=풀 크기)
+
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## 📌 관련 이슈
- #417

## ✨ 작업 내용
구매입찰이 등록되어도 판매자가 알 방법이 없었습니다. 기존 입찰 알림은 체결 시점(`BUY_OFFER_MATCHED`) 하나뿐이라 체결 이전 단계가 비어 있었습니다.

`confirmBuyOfferPurchase()`에서 `BuyOffer` 저장 후 이벤트를 발행하고, 리스너가 해당 카드·판본의 ACTIVE 매물 판매자에게 알림을 보냅니다. 입찰자 본인이 판매자면 제외하고, 같은 판매자 매물이 여러 개여도 알림은 1건입니다.

왜 이벤트인가 — 결제·포인트 차감과 같은 트랜잭션이라 알림을 직접 호출하면 저장 실패가 결제까지 롤백시킵니다. `AFTER_COMMIT`으로 받고 `NotificationService`에만 `REQUIRES_NEW`를 지정했습니다.

커넥션 풀도 함께 조정했습니다 — 위 구조가 결제 1건당 커넥션을 순간 2개 점유합니다. 풀을 10→20으로 늘렸지만 이건 임계값을 올린 것일 뿐 근본 해결은 아닙니다. 동시 요청이 20건을 넘으면 20에서도 같은 순환 대기가 재현되고, 실패 시 결제·입찰은 이미 반영된 채 알림만 유실됩니다. 

## 📸 테스트 결과
- 신규 `BuyOfferReceivedNoticeIntegrationTest` 5건, `BuyOfferReceivedNoticeListenerTest` 5건, `NotificationServiceTest` 4건, `PriceServiceTest` 1건, `ListingRepositoryTest` 2건
- 전체 1204건 중 8건 실패 — `origin/develop` 대조 결과 전부 기존 결함(무관 도메인)

## 🔍 리뷰 포인트
- `PriceService.java`는 import 1 + 필드 1 + `publishEvent` 1블록만 추가. 기존 로직 미변경
- **CodeRabbit 지적으로 결함 2건을 발견했습니다.** ① 단위 테스트가 전부 통과하는 채로 알림이 DB에 저장되지 않고 있었음 (mock이 트랜잭션 경계를 안 탐 → `REQUIRES_NEW`로 해결). ② `REQUIRES_NEW`가 커넥션을 이중 점유하는 문제 (풀 조정으로 완화, 근본 해결은 별도 이슈)
- `application*.yaml`은 공유 파일이라 사전 공유했습니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?