### PR TITLE
[Feature] #411 판매 매물 정산계좌/반송주소 수정 및 참고 시세 수정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/controller/ListingController.java
@@ -93,14 +93,17 @@ public class ListingController {
         return ApiResponse.ok(listingService.getMyListing(sellerId, id));
     }
 
-    @Operation(summary = "매물 가격 수정", description = "판매자 본인의 매물 가격을 수정합니다. 판매 중(ACTIVE) 상태가 아니면 실패합니다.")
+    @Operation(
+            summary = "매물 가격/정산계좌/반송주소 수정",
+            description = "판매자 본인의 매물 가격, 정산계좌, 반송주소를 수정합니다. 판매 중(ACTIVE) 상태가 아니면 실패합니다."
+    )
     @PutMapping("/{id}")
     public ApiResponse<ListingResponse> updateListing(
             @AuthenticationPrincipal Long sellerId,
             @Parameter(description = "매물 ID") @PathVariable Long id,
             @Valid @RequestBody ListingUpdateRequest request
     ) {
-        return ApiResponse.ok("매물 가격이 수정되었습니다.", listingService.updatePrice(sellerId, id, request));
+        return ApiResponse.ok("매물 정보가 수정되었습니다.", listingService.updatePrice(sellerId, id, request));
     }
 
     @Operation(summary = "매물 삭제", description = "판매자 본인의 매물을 삭제(취소)합니다.")

--- a/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/dto/ListingUpdateRequest.java
@@ -3,9 +3,19 @@ package com.pokade.domain.listing.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
+// 정산계좌/반송주소 6개 필드는 전부 선택 - 생략(null)하면 기존 값을 그대로 둔다(부분 수정).
+// "내 매물 관리"(/listings/me)의 가격만 바꾸는 빠른 수정과 "주문서" 화면의 전체 수정이 같은
+// API를 쓰는데, 전자는 이 필드들을 아예 안 보내므로 필수로 만들면 그 플로우가 깨진다.
 public record ListingUpdateRequest(
         @NotNull(message = "price는 필수입니다.")
         @Positive(message = "price는 0보다 커야 합니다.")
-        Integer price
+        Integer price,
+
+        String settlementBankName,
+        String settlementAccountNumber,
+        String settlementAccountHolder,
+        String returnRecipientName,
+        String returnRecipientPhone,
+        String returnAddress
 ) {
 }

--- a/Pokade/src/main/java/com/pokade/domain/listing/entity/Listing.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/entity/Listing.java
@@ -115,6 +115,28 @@ public class Listing {
         this.price = newPrice;
     }
 
+    // 가격 수정과 동일하게 ACTIVE 상태에서만 허용 - 거래가 이미 시작된 뒤 정산계좌를 바꾸면
+    // 사기(엉뚱한 계좌로 정산금 가로채기) 위험이 있어 계속 막는다.
+    // 각 필드는 null이면 건드리지 않고 기존 값을 유지한다(부분 수정) - "내 매물 관리"의 가격만
+    // 바꾸는 빠른 수정이 이 필드들을 아예 안 보내는데, 그 요청이 기존 정산계좌/반송주소를
+    // null로 지워버리면 안 되기 때문이다.
+    public void updateSettlementAndReturnInfo(
+            String settlementBankName,
+            String settlementAccountNumber,
+            String settlementAccountHolder,
+            String returnRecipientName,
+            String returnRecipientPhone,
+            String returnAddress
+    ) {
+        requireActive();
+        if (settlementBankName != null) this.settlementBankName = settlementBankName;
+        if (settlementAccountNumber != null) this.settlementAccountNumber = settlementAccountNumber;
+        if (settlementAccountHolder != null) this.settlementAccountHolder = settlementAccountHolder;
+        if (returnRecipientName != null) this.returnRecipientName = returnRecipientName;
+        if (returnRecipientPhone != null) this.returnRecipientPhone = returnRecipientPhone;
+        if (returnAddress != null) this.returnAddress = returnAddress;
+    }
+
     public void cancel() {
         requireActive();
         this.status = ListingStatus.CANCELLED;

--- a/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
+++ b/Pokade/src/main/java/com/pokade/domain/listing/service/ListingService.java
@@ -132,6 +132,14 @@ public class ListingService {
         Listing listing = getOwnedListing(sellerId, listingId);
 
         listing.changePrice(request.price());
+        listing.updateSettlementAndReturnInfo(
+                request.settlementBankName(),
+                request.settlementAccountNumber(),
+                request.settlementAccountHolder(),
+                request.returnRecipientName(),
+                request.returnRecipientPhone(),
+                request.returnAddress()
+        );
 
         return ListingResponse.of(listing);
     }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -92,6 +92,8 @@ public class PriceService {
     private static final String RAW_PRICE_TYPE = "raw";
     private static final String RAW_GRADE = "";
     private static final String RAW_COMPANY = "";
+    // PSA10/PSA9/PSA8 등 공인 감정 등급의 card_prices 조회 키.
+    private static final String GRADED_PRICE_TYPE = "graded";
     // 구매입찰 결제 시 상품가에 더하는 고정 배송비(KRW) - TradeService.ready()의 즉시구매용 배송비와
     // 동일한 값/성격이며, 두 도메인이 각자 자기 상수로 갖는다(공유 상수 모듈은 아직 없음).
     private static final int SHIPPING_FEE = 3000;
@@ -180,12 +182,19 @@ public class PriceService {
                                 PriceTradeStatsRepository.CardPriceView::getCardId,
                                 PriceTradeStatsRepository.CardPriceView::getPrice));
 
-        // buyPrice/recentTradePrice가 둘 다 없는 카드용 fallback - Scrydex 동기화 비등급(raw) 시세.
-        // 우리 플랫폼 거래 이력이 없는 대다수 카드(직접 거래된 적 없는 카드)도 "가격 정보 없음" 대신 참고 시세를 보여주기 위함.
+        // buyPrice/recentTradePrice가 둘 다 없는 카드용 fallback. PSA10/PSA9/PSA8처럼 공인 인증
+        // 등급을 요청했으면 그 등급 자체의 감정 시세(card_prices의 graded 행, getGradeChart와 동일한
+        // toGradeKey 매핑)를 쓰고, 그 외(자체 AI등급 S/A/B, 등급 미지정)에는 기존처럼 Scrydex 동기화
+        // 비등급(raw) 시세를 쓴다. 우리 플랫폼 거래 이력이 없는 대다수 카드(직접 거래된 적 없는 카드)도
+        // "가격 정보 없음" 대신 참고 시세를 보여주기 위함.
+        GradeKey certifiedGradeKey = isCertifiedGrade(grade) ? toGradeKey(grade) : null;
+        String marketPriceType = certifiedGradeKey != null ? GRADED_PRICE_TYPE : RAW_PRICE_TYPE;
+        String marketGrade = certifiedGradeKey != null ? certifiedGradeKey.grade() : RAW_GRADE;
+        String marketCompany = certifiedGradeKey != null ? certifiedGradeKey.company() : RAW_COMPANY;
         Map<Long, CardPriceRepository.VariantMarketPriceView> marketPriceByVariant = variantIds.isEmpty()
                 ? Map.of()
                 : cardPriceRepository
-                        .findMarketPricesByVariantIds(variantIds, RAW_PRICE_TYPE, RAW_GRADE, RAW_COMPANY).stream()
+                        .findMarketPricesByVariantIds(variantIds, marketPriceType, marketGrade, marketCompany).stream()
                         .collect(Collectors.toMap(
                                 CardPriceRepository.VariantMarketPriceView::getVariantId,
                                 view -> view));
@@ -556,6 +565,10 @@ public class PriceService {
                 .orElseGet(() -> new PriceStatsResponse(BigDecimal.ZERO, null, 0L));
     }
 
+    private boolean isCertifiedGrade(ListingGrade grade) {
+        return grade == ListingGrade.PSA10 || grade == ListingGrade.PSA9 || grade == ListingGrade.PSA8;
+    }
+
     private GradeKey toGradeKey(ListingGrade grade) {
         return switch (grade) {
             case PSA10 -> new GradeKey("10", "PSA");
@@ -593,7 +606,7 @@ public class PriceService {
 
         GradeKey gradeKey = toGradeKey(grade);
         CardPrice cardPrice = cardPriceRepository
-                .findByVariantIdAndPriceTypeAndGradeAndCompany(resolvedVariantId, "graded", gradeKey.grade(), gradeKey.company())
+                .findByVariantIdAndPriceTypeAndGradeAndCompany(resolvedVariantId, GRADED_PRICE_TYPE, gradeKey.grade(), gradeKey.company())
                 .orElse(null);
 
         if (cardPrice == null || cardPrice.getMarket() == null) {

--- a/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/controller/ListingControllerTest.java
@@ -298,10 +298,10 @@ class ListingControllerTest {
 
     @Test
     void 매물_수정에_성공하면_200과_수정된_매물을_반환한다() throws Exception {
-        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
         ListingResponse response = new ListingResponse(
                 1L, 1L, 100L, null, 20000, ListingGrade.A, ListingStatus.ACTIVE,
-                null, null, null, null, null, null, LocalDateTime.now());
+                "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1", LocalDateTime.now());
 
         given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
                 .willReturn(response);
@@ -311,12 +311,14 @@ class ListingControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.price").value(20000));
+                .andExpect(jsonPath("$.data.price").value(20000))
+                .andExpect(jsonPath("$.data.settlementBankName").value("국민은행"))
+                .andExpect(jsonPath("$.data.returnAddress").value("서울시 강남구 테헤란로 1"));
     }
 
     @Test
     void 수정시_가격이_없으면_400을_반환한다() throws Exception {
-        ListingUpdateRequest invalidRequest = new ListingUpdateRequest(null);
+        ListingUpdateRequest invalidRequest = new ListingUpdateRequest(null, null, null, null, null, null, null);
 
         mockMvc.perform(put("/api/listings/1")
                         .with(userId(100L))
@@ -327,8 +329,29 @@ class ListingControllerTest {
     }
 
     @Test
+    void 정산계좌_정보없이_가격만_보내도_200을_반환한다() throws Exception {
+        // "내 매물 관리"(/listings/me)의 빠른 가격 수정처럼 정산계좌/반송주소를 아예 안 보내는 요청도
+        // 허용돼야 한다(부분 수정 - 서비스가 기존 값을 그대로 유지).
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, null, null, null, null, null, null);
+        ListingResponse response = new ListingResponse(
+                1L, 1L, 100L, null, 20000, ListingGrade.A, ListingStatus.ACTIVE,
+                "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1", LocalDateTime.now());
+
+        given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/api/listings/1")
+                        .with(userId(100L))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.price").value(20000))
+                .andExpect(jsonPath("$.data.settlementBankName").value("국민은행"));
+    }
+
+    @Test
     void ACTIVE_상태가_아니면_수정시_400을_반환한다() throws Exception {
-        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
 
         given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.INVALID_LISTING_STATUS));
@@ -343,7 +366,7 @@ class ListingControllerTest {
 
     @Test
     void 본인_매물이_아니면_수정시_403을_반환한다() throws Exception {
-        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
 
         given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.ACCESS_DENIED));
@@ -358,7 +381,7 @@ class ListingControllerTest {
 
     @Test
     void 존재하지_않는_매물_수정시_404를_반환한다() throws Exception {
-        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
 
         given(listingService.updatePrice(anyLong(), anyLong(), any(ListingUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.LISTING_NOT_FOUND));

--- a/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/listing/service/ListingServiceTest.java
@@ -105,7 +105,8 @@ class ListingServiceTest {
 
     @Test
     void 가격_수정시_판매자_계정이_비활성이면_ACCOUNT_NOT_ACTIVE_예외가_발생한다() {
-        ListingUpdateRequest request = new ListingUpdateRequest(20000);
+        ListingUpdateRequest request = new ListingUpdateRequest(
+                20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
         willThrow(new BusinessException(ErrorCode.ACCOUNT_NOT_ACTIVE))
                 .given(userAccessChecker).assertWritable(100L);
 
@@ -125,9 +126,55 @@ class ListingServiceTest {
                 .build();
         given(listingRepository.findById(1L)).willReturn(Optional.of(listing));
 
-        ListingResponse response = listingService.updatePrice(100L, 1L, new ListingUpdateRequest(20000));
+        ListingUpdateRequest request = new ListingUpdateRequest(
+                20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
+        ListingResponse response = listingService.updatePrice(100L, 1L, request);
 
         assertThat(response.price()).isEqualTo(20000);
+        assertThat(response.settlementBankName()).isEqualTo("국민은행");
+        assertThat(response.returnAddress()).isEqualTo("서울시 강남구 테헤란로 1");
+    }
+
+    @Test
+    void 정산계좌_정보없이_가격만_수정하면_기존_정산계좌_정보가_유지된다() {
+        // "내 매물 관리"(/listings/me)의 빠른 가격 수정처럼 정산계좌/반송주소를 아예 안 보내는 요청도
+        // 기존 값을 지우지 않고 그대로 둬야 한다.
+        Listing listing = Listing.builder()
+                .cardId(1L)
+                .sellerId(100L)
+                .price(10000)
+                .settlementBankName("국민은행")
+                .settlementAccountNumber("110-1234-5678")
+                .settlementAccountHolder("김철수")
+                .returnRecipientName("김철수")
+                .returnRecipientPhone("010-1234-5678")
+                .returnAddress("서울시 강남구 테헤란로 1")
+                .build();
+        given(listingRepository.findById(1L)).willReturn(Optional.of(listing));
+
+        ListingUpdateRequest request = new ListingUpdateRequest(20000, null, null, null, null, null, null);
+        ListingResponse response = listingService.updatePrice(100L, 1L, request);
+
+        assertThat(response.price()).isEqualTo(20000);
+        assertThat(response.settlementBankName()).isEqualTo("국민은행");
+        assertThat(response.returnAddress()).isEqualTo("서울시 강남구 테헤란로 1");
+    }
+
+    @Test
+    void ACTIVE_상태가_아니면_정산계좌_수정시_INVALID_LISTING_STATUS_예외가_발생한다() {
+        Listing listing = Listing.builder()
+                .cardId(1L)
+                .sellerId(100L)
+                .price(10000)
+                .build();
+        listing.cancel();
+        given(listingRepository.findById(1L)).willReturn(Optional.of(listing));
+        ListingUpdateRequest request = new ListingUpdateRequest(
+                20000, "국민은행", "110-1234-5678", "김철수", "김철수", "010-1234-5678", "서울시 강남구 테헤란로 1");
+
+        assertThatThrownBy(() -> listingService.updatePrice(100L, 1L, request))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_LISTING_STATUS);
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -404,6 +404,25 @@ class PriceServiceTest {
                 new CardPriceSummaryResponse(1L, 3000000, null, null, "KRW", new BigDecimal("25.60"), "USD"));
     }
 
+    @Test
+    @DisplayName("t32b PSA10처럼 공인 감정 등급을 요청하면 raw 대신 그 등급의 감정 시세(graded)를 fallback으로 반환한다")
+    void t32b() {
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(List.of(1L)))
+                .willReturn(List.of(primaryVariantIdView(1L, 10L)));
+        given(listingRepository.findLowestActivePricesByVariantIds(List.of(10L), ListingStatus.ACTIVE, ListingGrade.PSA10))
+                .willReturn(List.of());
+        given(buyOfferRepository.findHighestActivePricesByVariantIds(List.of(10L)))
+                .willReturn(List.of());
+        given(cardPriceRepository.findMarketPricesByVariantIds(List.of(10L), "graded", "10", "PSA"))
+                .willReturn(List.of(variantMarketPriceView(10L, new BigDecimal("51.20"), "USD")));
+
+        List<CardPriceSummaryResponse> result = priceService.getSummaries(List.of(1L), ListingGrade.PSA10, false);
+
+        assertThat(result).containsExactly(
+                new CardPriceSummaryResponse(1L, null, null, null, "KRW", new BigDecimal("51.20"), "USD"));
+        verify(cardPriceRepository, never()).findMarketPricesByVariantIds(any(), eq("raw"), any(), any());
+    }
+
     private CardPriceRepository.VariantMarketPriceView variantMarketPriceView(Long variantId, BigDecimal market, String currency) {
         return new CardPriceRepository.VariantMarketPriceView() {
             @Override


### PR DESCRIPTION
## 📌 관련 이슈
- #411

## ✨ 작업 내용
- 판매 매물 수정 시 가격뿐 아니라 정산계좌(은행명/계좌번호/예금주)·반송주소도 함께 수정 가능하도록 확장
- PSA10/PSA9/PSA8처럼 공인 감정 등급을 요청했는데 buyPrice/recentTradePrice가 둘 다 없을 때,
  항상 raw(비등급) 시세로 fallback하던 것을 그 등급 자체의 감정 시세(card_prices의 graded 행)로 반환하도록 수정

## 📸 스크린샷 / 테스트 결과
- `PriceServiceTest` 전체 통과 (신규 회귀 테스트 t32b 포함)
- `domain.price.*` 테스트 전체 통과 (develop 머지 후 재확인)

## 🔍 리뷰 포인트
- `isCertifiedGrade`/`toGradeKey`로 PSA 계열만 graded fallback을 타고, 자체 AI 등급(S/A/B)·등급 미지정은 기존 raw fallback을 그대로 쓰는지
- 매물 수정 API의 정산계좌/반송주소 필드가 부분 수정(가격만 변경 등)과도 호환되는지

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 매물 수정 시 가격과 함께 정산계좌 및 반송주소 정보를 수정할 수 있습니다.
  * 필요한 항목만 선택적으로 수정할 수 있으며, 생략한 정보는 기존 값이 유지됩니다.
  * 공인 감정 등급의 시세 조회 시 등급별 graded 시세를 우선 사용합니다.

* **버그 수정**
  * 가격만 수정할 때 정산계좌와 반송주소가 의도치 않게 변경되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->