### PR TITLE
[Fix] #426 탈퇴 확정 배치 통합 테스트가 컨텍스트 로딩 단계에서 실패한다

### DIFF
--- a/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/user/service/WithdrawalConfirmIntegrationTest.java
@@ -11,6 +11,7 @@ import com.pokade.domain.user.repository.UserRepository;
 import com.pokade.domain.user.support.AnonymizationTokenGenerator;
 import com.pokade.global.security.TokenBlacklistStore;
 import com.pokade.support.AbstractIntegrationTest;
+import com.pokade.support.TestMetricsConfig;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +37,13 @@ import static org.mockito.Mockito.never;
  */
 @DataJpaTest
 @RecordApplicationEvents
-@Import({WithdrawalService.class, WithdrawalConfirmer.class, AnonymizationTokenGenerator.class})
+@Import({
+        WithdrawalService.class,
+        WithdrawalConfirmer.class,
+        AnonymizationTokenGenerator.class,
+        // WithdrawalService가 계측을 위해 MeterRegistry를 받는데 @DataJpaTest 슬라이스에는 그 빈이 없다.
+        TestMetricsConfig.class
+})
 class WithdrawalConfirmIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## 📌 관련 이슈

- #426

## ✨ 작업 내용

`WithdrawalConfirmIntegrationTest` 4건이 전부 실패하고 있었다. 단언이 틀린 것이 아니라 **Spring 컨텍스트 자체가 뜨지 않았다.**

```
Error creating bean with name 'WithdrawalService'
Unsatisfied dependency expressed through constructor parameter 7:
  No qualifying bean of type 'io.micrometer.core.instrument.MeterRegistry'
```

첫 테스트가 컨텍스트 생성에 실패하고 나머지 3건이 캐시된 실패 컨텍스트를 물려받아 함께 죽는 구조였다.

- `@Import`에 `TestMetricsConfig.class`를 추가했다
- **프로덕션 코드는 변경하지 않았다.** 테스트 파일 한 개, `+8/-1`

### 원인

계측을 붙이면서 `WithdrawalService`에 `MeterRegistry` 의존이 추가됐고(`fb7240b feat: 탈퇴 확정 배치 계측 추가`), 그때 이 테스트를 함께 손보지 않았다. `@DataJpaTest` 슬라이스는 `MetricsAutoConfiguration`을 로드하지 않아 `MeterRegistry` 빈이 없다. 다른 의존은 `@MockitoBean`으로 채워져 있는데 이것만 빠져 있었다.

### 이미 있는 공용 설정을 쓴다

처음에는 테스트 클래스 안에 `SimpleMeterRegistry`를 넣는 내부 `@TestConfiguration`을 만들었다. 통과는 했지만, 이슈 To-do의 "공용 설정으로 뺄지 검토" 항목을 확인하는 과정에서 **`support/TestMetricsConfig`가 이미 존재한다**는 것을 발견했다.

`#343`에서 같은 목적으로 만들어졌고 사용법까지 주석에 적혀 있으며, 이미 다른 통합 테스트 5곳이 쓰고 있다. 결과적으로 **이 테스트만 그 규칙에서 빠져 있던 것**이라, 직접 만든 설정을 걷어내고 공용 클래스를 쓰도록 바꿨다.

### 왜 지금까지 드러나지 않았나

CI 워크플로우가 `-x test`로 실행되어 테스트를 돌리지 않는다. 빌드가 초록이어도 테스트 상태는 알 수 없고, 이 실패는 로컬에서 전체 스위트를 돌려야 보인다.

## 📸 스크린샷 / 테스트 결과

| | 변경 전 | 변경 후 |
|---|---|---|
| `WithdrawalConfirmIntegrationTest` | **4건 실패** | **4건 통과** |
| 전체 스위트 | 1191건 중 8건 실패 | 1212건 중 **4건 실패** |

남은 4건은 `TradeRepositoryTest`이며 **담당 도메인이 달라 손대지 않았다**(커밋 이력상 ktk3376·Unordinary). 이 PR 이전부터 실패하던 것으로, `git stash`로 변경을 모두 치운 상태에서도 같은 4건이 같은 이름으로 실패하는 것을 확인했다.

## 🔍 리뷰 포인트

### `MeterRegistry`를 목으로 채우지 않은 이유

`WithdrawalService`는 목으로는 동작하지 않는 방식으로 쓴다.

```java
@PostConstruct
void registerLastSuccessGauge() {
    meterRegistry.gauge(LAST_SUCCESS_METRIC, lastSuccessEpochSecond, AtomicLong::doubleValue);
}

Counter.builder(CONFIRM_METRIC)...register(meterRegistry)   // 목이면 null → 증가 시 NPE
```

`TestMetricsConfig`의 주석에도 같은 내용이 이미 적혀 있다. 계측 값을 단언할 필요는 없고 "빈이 있어 서비스가 뜬다"까지만 필요하므로 인메모리 `SimpleMeterRegistry`로 충분하다.

### 같은 원인의 다른 슬라이스 테스트

`MeterRegistry`를 주입받는 프로덕션 클래스 18개와 그것들을 `@Import`하는 슬라이스 테스트를 전수 확인했다. 나머지는 이미 `TestMetricsConfig`를 함께 `@Import`하고 있어 추가로 손댈 곳은 없었다.

### 남은 근본 문제

CI가 테스트를 건너뛰는 것이 이 문제를 오래 방치한 이유다. `-x test` 제거는 팀 전체에 영향이 가므로 이 PR 범위에 넣지 않았고, 별도 논의가 필요하다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? — 대상 4건 통과, 잔여 4건은 타 도메인 기존 실패
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 테스트 설정 보완이라 문서 변경 없음``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 회원 탈퇴 확인 통합 테스트에서 메트릭 관련 테스트 설정을 추가했습니다.
  * 테스트 환경에서도 실제 서비스 구성 요소가 정상적으로 연결되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->