### PR TITLE
[Feature] #429 AI 진단 도감 등록 시 카드 직접 지정 및 표지 사진 설정

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/controller/PortfolioController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.portfolio.controller;
 
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
+import com.pokade.domain.portfolio.dto.PortfolioFromGradeRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
 import com.pokade.domain.portfolio.dto.PortfolioItemPnlResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemResponse;
@@ -19,7 +20,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -76,12 +79,27 @@ public class PortfolioController {
     }
 
     // FR-AI-04: AI 등급 진단 결과를 바탕으로 도감에 카드 즉시 등록.
+    // request 바디는 선택 — AI가 카드를 인식 못했거나 잘못 인식했을 때 사용자가 고른 카드로 덮어쓴다.
     @PostMapping("/from-grade/{resultId}")
     public ApiResponse<PortfolioItemResponse> addFromGradeResult(
             @AuthenticationPrincipal Long userId,
-            @PathVariable Long resultId
+            @PathVariable Long resultId,
+            @RequestBody(required = false) PortfolioFromGradeRequest request
     ) {
-        return ApiResponse.ok("도감에 등록되었습니다.", portfolioService.addFromGradeResult(userId, resultId));
+        Long overrideCardId = request != null ? request.cardId() : null;
+        Long overrideVariantId = request != null ? request.variantId() : null;
+        return ApiResponse.ok("도감에 등록되었습니다.",
+                portfolioService.addFromGradeResult(userId, resultId, overrideCardId, overrideVariantId));
+    }
+
+    // 도감 항목 표지 사진 교체 — AI 진단 등록 여부와 무관하게 항상 가능.
+    @PostMapping("/{id}/thumbnail")
+    public ApiResponse<PortfolioItemResponse> setThumbnail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @RequestPart MultipartFile image
+    ) {
+        return ApiResponse.ok("표지 사진이 변경되었습니다.", portfolioService.setThumbnail(userId, id, image));
     }
 
     @PutMapping("/{id}")

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioFromGradeRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioFromGradeRequest.java
@@ -1,0 +1,10 @@
+package com.pokade.domain.portfolio.dto;
+
+// AI 진단 결과 등록(FR-AI-04) 시 카드를 직접 지정하기 위한 선택적 바디.
+// AI가 카드를 인식하지 못했거나(cardId/visionCardId 둘 다 null), 잘못 인식한 경우
+// 사용자가 직접 고른 카드로 덮어쓰기 위해 사용한다. 둘 다 null이면 기존 AI 인식 결과를 그대로 쓴다.
+public record PortfolioFromGradeRequest(
+        Long cardId,
+        Long variantId
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
@@ -28,13 +28,14 @@ public record PortfolioItemResponse(
             PortfolioItem item,
             Card card,
             CardVariant variant,
-            CardPriceRepository.VariantMarketPriceView priceView
+            CardPriceRepository.VariantMarketPriceView priceView,
+            String thumbnailUrl
     ) {
         return new PortfolioItemResponse(
                 item.getId(),
                 item.getCardId(),
                 card != null ? card.getName() : null,
-                card != null ? card.getImageSmall() : null,
+                thumbnailUrl != null ? thumbnailUrl : (card != null ? card.getImageSmall() : null),
                 item.getVariantId(),
                 variant != null ? variant.getVariantName() : null,
                 item.getQuantity(),

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/entity/PortfolioItem.java
@@ -50,10 +50,14 @@ public class PortfolioItem {
     @Column(name = "grade_result_id", unique = true)
     private Long gradeResultId;
 
+    // 커스텀 표지 이미지의 S3 key. NULL이면 카드 기본 이미지를 그대로 쓴다.
+    @Column(name = "thumbnail_key")
+    private String thumbnailKey;
+
     @Builder
     public PortfolioItem(Long userId, Long cardId, Long variantId, Integer quantity,
                          Integer acquiredPrice, LocalDateTime acquiredAt, Long tradeId,
-                         Long gradeResultId) {
+                         Long gradeResultId, String thumbnailKey) {
         this.userId = userId;
         this.cardId = cardId;
         this.variantId = variantId;
@@ -62,6 +66,12 @@ public class PortfolioItem {
         this.acquiredAt = acquiredAt;
         this.tradeId = tradeId;
         this.gradeResultId = gradeResultId;
+        this.thumbnailKey = thumbnailKey;
+    }
+
+    // 도감에서 사용자가 표지 사진을 직접 바꿀 때 사용 — AI 진단 등록 여부와 무관하게 언제든 교체 가능.
+    public void changeThumbnail(String newKey) {
+        this.thumbnailKey = newKey;
     }
 
     public void update(Integer quantity, Integer acquiredPrice, LocalDateTime acquiredAt) {

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -1,7 +1,10 @@
 package com.pokade.domain.portfolio.service;
 
 import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.ai.entity.GradeResultImage;
 import com.pokade.domain.ai.entity.GradeStatus;
+import com.pokade.domain.ai.entity.PhotoType;
+import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.entity.CardVariant;
@@ -22,10 +25,12 @@ import com.pokade.domain.portfolio.entity.PortfolioItem;
 import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import com.pokade.global.port.UserAccessChecker;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -51,6 +56,10 @@ public class PortfolioService {
     private static final String UNCLASSIFIED = "미분류";
     private static final String KRW = "KRW";
 
+    private static final long THUMBNAIL_MAX_SIZE_BYTES = 5 * 1024 * 1024;
+    private static final Set<String> THUMBNAIL_ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/jpg", "image/png");
+    private static final String THUMBNAIL_FOLDER = "portfolio";
+
     // card_prices는 카드에 따라 USD/JPY로 저장돼 있어 KRW 금액과 그대로 합산할 수 없다.
     // 실시간 환율 API가 없어 프론트(lib/currency.ts)와 동일한 고정 근사치를 사용한다.
     private static final Map<String, BigDecimal> FX_TO_KRW = Map.of(
@@ -64,6 +73,8 @@ public class PortfolioService {
     private final CardPriceRepository cardPriceRepository;
     private final ExpansionRepository expansionRepository;
     private final GradeResultRepository gradeResultRepository;
+    private final GradeResultImageRepository gradeResultImageRepository;
+    private final S3FileStorage s3FileStorage;
     private final UserAccessChecker userAccessChecker;
 
     @Transactional
@@ -386,8 +397,10 @@ public class PortfolioService {
 
     // FR-AI-04: AI 등급 진단 결과를 바탕으로 도감에 카드를 등록한다.
     // 도감 등록은 유저 선택(자동 아님) — 컨트롤러가 이 메서드를 명시적 요청에서만 호출한다.
+    // override(cardId/variantId)는 AI가 카드를 인식하지 못했거나(cardId/visionCardId 둘 다 null)
+    // 잘못 인식한 경우, 사용자가 직접 고른 카드로 등록할 수 있게 한다 — null이면 기존 AI 인식 결과를 그대로 쓴다.
     @Transactional
-    public PortfolioItemResponse addFromGradeResult(Long userId, Long resultId) {
+    public PortfolioItemResponse addFromGradeResult(Long userId, Long resultId, Long overrideCardId, Long overrideVariantId) {
         userAccessChecker.assertWritable(userId);
 
         GradeResult gradeResult = gradeResultRepository.findById(resultId)
@@ -405,24 +418,41 @@ public class PortfolioService {
             throw new BusinessException(ErrorCode.GRADE_RESULT_ALREADY_REGISTERED);
         }
 
-        // cardId/variantId는 카드 자동식별 연동 전까지 채워지지 않을 수 있어(현재 Vision은
-        // vision_card_id(externalId)만 반환), 저장된 값이 없으면 그 자리에서 externalId로 해석한다.
-        Long cardId = gradeResult.getCardId();
+        Long cardId;
         Card card;
-        if (cardId != null) {
+        if (overrideCardId != null) {
+            cardId = overrideCardId;
             card = cardRepository.findById(cardId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
-        } else if (gradeResult.getVisionCardId() != null) {
-            card = cardRepository.findByExternalId(gradeResult.getVisionCardId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
-            cardId = card.getId();
         } else {
-            throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+            // cardId/variantId는 카드 자동식별 연동 전까지 채워지지 않을 수 있어(현재 Vision은
+            // vision_card_id(externalId)만 반환), 저장된 값이 없으면 그 자리에서 externalId로 해석한다.
+            cardId = gradeResult.getCardId();
+            if (cardId != null) {
+                card = cardRepository.findById(cardId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+            } else if (gradeResult.getVisionCardId() != null) {
+                card = cardRepository.findByExternalId(gradeResult.getVisionCardId())
+                        .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+                cardId = card.getId();
+            } else {
+                throw new BusinessException(ErrorCode.CARD_NOT_FOUND);
+            }
         }
 
-        Long variantId = gradeResult.getVariantId() != null
-                ? gradeResult.getVariantId()
-                : cardVariantRepository.findPrimaryVariantId(cardId).orElse(null);
+        Long variantId;
+        if (overrideVariantId != null) {
+            cardVariantRepository.findById(overrideVariantId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CARD_NOT_FOUND));
+            variantId = overrideVariantId;
+        } else if (overrideCardId != null) {
+            // 카드를 직접 지정한 경우 원래 진단의 variantId는 다른 카드 기준이라 재사용하지 않는다.
+            variantId = cardVariantRepository.findPrimaryVariantId(cardId).orElse(null);
+        } else {
+            variantId = gradeResult.getVariantId() != null
+                    ? gradeResult.getVariantId()
+                    : cardVariantRepository.findPrimaryVariantId(cardId).orElse(null);
+        }
 
         PortfolioItem item = PortfolioItem.builder()
                 .userId(userId)
@@ -431,10 +461,53 @@ public class PortfolioService {
                 .quantity(1)
                 .acquiredAt(LocalDateTime.now())
                 .gradeResultId(resultId)
+                // 카드 인식 성공/실패·정정 여부와 무관하게, 사용자가 실제로 찍은 그 카드 사진을 표지로 쓴다.
+                .thumbnailKey(resolveFrontImageKey(resultId))
                 .build();
 
         portfolioItemRepository.save(item);
         return enrichSingle(item, card);
+    }
+
+    // 도감 항목의 표지 사진을 사용자가 직접 업로드한 이미지로 교체한다 - AI 진단으로 등록됐는지와 무관하게 항상 가능.
+    // ponytail: 이전 커스텀 표지 S3 객체는 정리하지 않는다(고아 객체 누적) - 필요해지면
+    // ProfileImageService의 AFTER_COMMIT 정리 이벤트 패턴을 그대로 재사용해 업그레이드.
+    @Transactional
+    public PortfolioItemResponse setThumbnail(Long userId, Long itemId, MultipartFile file) {
+        userAccessChecker.assertWritable(userId);
+        validateThumbnail(file);
+
+        PortfolioItem item = portfolioItemRepository.findByIdAndUserId(itemId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND));
+
+        item.changeThumbnail(s3FileStorage.upload(file, THUMBNAIL_FOLDER));
+
+        Card card = cardRepository.findById(item.getCardId()).orElse(null);
+        return enrichSingle(item, card);
+    }
+
+    private void validateThumbnail(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (file.getSize() > THUMBNAIL_MAX_SIZE_BYTES) {
+            throw new BusinessException(ErrorCode.FILE_TOO_LARGE);
+        }
+        if (!THUMBNAIL_ALLOWED_CONTENT_TYPES.contains(file.getContentType())) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+        }
+    }
+
+    private String resolveFrontImageKey(Long gradeResultId) {
+        return gradeResultImageRepository.findByGradeResultId(gradeResultId).stream()
+                .filter(img -> img.getPhotoType() == PhotoType.FRONT)
+                .map(GradeResultImage::getImageUrl)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String resolveThumbnailUrl(PortfolioItem item) {
+        return item.getThumbnailKey() != null ? s3FileStorage.generatePresignedUrl(item.getThumbnailKey()) : null;
     }
 
     // ─── 내부 enrichment 헬퍼 ────────────────────────────────────────────────
@@ -498,7 +571,7 @@ public class PortfolioService {
                     ? priceMap.get(resolvedVariantId)
                     : null;
 
-            return PortfolioItemResponse.of(item, card, variant, price);
+            return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item));
         }).toList();
     }
 
@@ -518,6 +591,6 @@ public class PortfolioService {
             price = prices.isEmpty() ? null : prices.get(0);
         }
 
-        return PortfolioItemResponse.of(item, card, variant, price);
+        return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item));
     }
 }

--- a/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/GlobalExceptionHandler.java
@@ -67,11 +67,12 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(ErrorCode.FILE_TOO_LARGE, ErrorCode.FILE_TOO_LARGE.getMessage()));
     }
 
-    // 멀티파트 오류 - 사진 누락 등 (400)
+    // 멀티파트 오류 - 필수 파일 누락 등 (400). AI 진단/프로필 이미지/도감 표지/문의 첨부 등
+    // 여러 멀티파트 엔드포인트가 공유하는 핸들러라 특정 도메인 문구를 넣지 않는다.
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<ErrorResponse> handleMultipart(MultipartException e) {
         return ResponseEntity.status(ErrorCode.INVALID_INPUT.getStatus())
-                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "사진 6장(앞면, 뒷면, 모서리 4장)이 모두 필요합니다."));
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, "필수 파일이 누락되었거나 요청 형식이 올바르지 않습니다."));
     }
 
     // AI 서비스 오류 (503)

--- a/Pokade/src/main/resources/db/migration/V25__add_thumbnail_key_to_portfolio_items.sql
+++ b/Pokade/src/main/resources/db/migration/V25__add_thumbnail_key_to_portfolio_items.sql
@@ -1,0 +1,2 @@
+-- 도감 항목의 커스텀 표지 이미지(S3 key). NULL이면 카드 기본 이미지를 그대로 쓴다.
+ALTER TABLE portfolio_items ADD COLUMN thumbnail_key VARCHAR(255);

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -1,7 +1,10 @@
 package com.pokade.domain.portfolio.service;
 
 import com.pokade.domain.ai.entity.GradeResult;
+import com.pokade.domain.ai.entity.GradeResultImage;
 import com.pokade.domain.ai.entity.GradeStatus;
+import com.pokade.domain.ai.entity.PhotoType;
+import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardPriceRepository;
@@ -18,6 +21,7 @@ import com.pokade.domain.portfolio.entity.PortfolioItem;
 import com.pokade.domain.portfolio.repository.PortfolioItemRepository;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
+import com.pokade.global.infra.storage.S3FileStorage;
 import com.pokade.global.port.UserAccessChecker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,7 +29,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -49,6 +55,8 @@ class PortfolioServiceTest {
     @Mock CardVariantRepository cardVariantRepository;
     @Mock CardPriceRepository cardPriceRepository;
     @Mock GradeResultRepository gradeResultRepository;
+    @Mock GradeResultImageRepository gradeResultImageRepository;
+    @Mock S3FileStorage s3FileStorage;
     @Mock UserAccessChecker userAccessChecker;
 
     @InjectMocks PortfolioService portfolioService;
@@ -613,7 +621,7 @@ class PortfolioServiceTest {
     void addFromGradeResult_notFound() {
         given(gradeResultRepository.findById(1L)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_NOT_FOUND);
     }
@@ -624,7 +632,7 @@ class PortfolioServiceTest {
         GradeResult gradeResult = stubGradeResult(99L, GradeStatus.SUCCESS, "S", "base1-4");
         given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
 
-        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
     }
@@ -635,7 +643,7 @@ class PortfolioServiceTest {
         GradeResult gradeResult = stubGradeResult(1L, GradeStatus.QUALITY_FAIL, null, null);
         given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
 
-        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_NOT_REGISTRABLE);
     }
@@ -647,7 +655,7 @@ class PortfolioServiceTest {
         given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
         given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(true);
 
-        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.GRADE_RESULT_ALREADY_REGISTERED);
         then(portfolioItemRepository).should(never()).save(any());
@@ -661,7 +669,7 @@ class PortfolioServiceTest {
         given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
         given(cardRepository.findByExternalId("base1-4")).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L))
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, null, null))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
     }
@@ -677,10 +685,115 @@ class PortfolioServiceTest {
         given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
         given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
 
-        PortfolioItemResponse response = portfolioService.addFromGradeResult(1L, 1L);
+        PortfolioItemResponse response = portfolioService.addFromGradeResult(1L, 1L, null, null);
 
         assertThat(response.cardId()).isEqualTo(10L);
         assertThat(response.quantity()).isEqualTo(1);
         then(portfolioItemRepository).should().save(any(PortfolioItem.class));
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 카드를 인식하지 못했어도 cardId를 직접 지정하면 그 카드로 등록한다")
+    void addFromGradeResult_overrideCardId_whenUnrecognized() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "A", null);
+        Card overrideCard = stubCard(20L);
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
+        given(cardRepository.findById(20L)).willReturn(Optional.of(overrideCard));
+        given(cardVariantRepository.findPrimaryVariantId(20L)).willReturn(Optional.empty());
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+
+        PortfolioItemResponse response = portfolioService.addFromGradeResult(1L, 1L, 20L, null);
+
+        assertThat(response.cardId()).isEqualTo(20L);
+        then(cardRepository).should(never()).findByExternalId(any());
+        then(portfolioItemRepository).should().save(any(PortfolioItem.class));
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 지정한 cardId가 존재하지 않으면 CARD_NOT_FOUND")
+    void addFromGradeResult_overrideCardId_notFound() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "A", null);
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
+        given(cardRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.addFromGradeResult(1L, 1L, 999L, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CARD_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("도감 등록(AI 진단): 진단에 쓴 앞면 사진을 표지로 저장하고, 조회 시 presigned URL로 내려준다")
+    void addFromGradeResult_usesFrontImageAsThumbnail() {
+        GradeResult gradeResult = stubGradeResult(1L, GradeStatus.SUCCESS, "S", "base1-4");
+        Card card = stubCard(10L);
+        GradeResultImage front = GradeResultImage.builder()
+                .gradeResultId(1L).photoType(PhotoType.FRONT).imageUrl("ai-grade/front-key.png").build();
+        GradeResultImage back = GradeResultImage.builder()
+                .gradeResultId(1L).photoType(PhotoType.BACK).imageUrl("ai-grade/back-key.png").build();
+        given(gradeResultRepository.findById(1L)).willReturn(Optional.of(gradeResult));
+        given(portfolioItemRepository.existsByGradeResultId(1L)).willReturn(false);
+        given(cardRepository.findByExternalId("base1-4")).willReturn(Optional.of(card));
+        given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
+        given(gradeResultImageRepository.findByGradeResultId(1L)).willReturn(List.of(back, front));
+        given(s3FileStorage.generatePresignedUrl("ai-grade/front-key.png")).willReturn("https://s3.example/front-presigned");
+        given(portfolioItemRepository.save(any(PortfolioItem.class))).willAnswer(inv -> inv.getArgument(0));
+
+        PortfolioItemResponse response = portfolioService.addFromGradeResult(1L, 1L, null, null);
+
+        assertThat(response.cardImageSmall()).isEqualTo("https://s3.example/front-presigned");
+    }
+
+    // ===== setThumbnail =====
+
+    @Test
+    @DisplayName("표지 사진 변경: 정상 업로드 시 S3 key를 저장하고 presigned URL을 반환한다")
+    void setThumbnail_success() {
+        PortfolioItem item = PortfolioItem.builder().userId(1L).cardId(10L).quantity(1).build();
+        Card card = stubCard(10L);
+        MultipartFile image = new MockMultipartFile("image", "a.png", "image/png", new byte[10]);
+        given(portfolioItemRepository.findByIdAndUserId(5L, 1L)).willReturn(Optional.of(item));
+        given(s3FileStorage.upload(image, "portfolio")).willReturn("portfolio/new-key.png");
+        given(s3FileStorage.generatePresignedUrl("portfolio/new-key.png")).willReturn("https://s3.example/new-presigned");
+        given(cardRepository.findById(10L)).willReturn(Optional.of(card));
+        given(cardVariantRepository.findPrimaryVariantId(10L)).willReturn(Optional.empty());
+
+        PortfolioItemResponse response = portfolioService.setThumbnail(1L, 5L, image);
+
+        assertThat(item.getThumbnailKey()).isEqualTo("portfolio/new-key.png");
+        assertThat(response.cardImageSmall()).isEqualTo("https://s3.example/new-presigned");
+    }
+
+    @Test
+    @DisplayName("표지 사진 변경: 본인 소유가 아니거나 없는 항목이면 PORTFOLIO_ITEM_NOT_FOUND")
+    void setThumbnail_notFound() {
+        MultipartFile image = new MockMultipartFile("image", "a.png", "image/png", new byte[10]);
+        given(portfolioItemRepository.findByIdAndUserId(5L, 1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> portfolioService.setThumbnail(1L, 5L, image))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.PORTFOLIO_ITEM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("표지 사진 변경: 이미지가 아닌 파일이면 UNSUPPORTED_IMAGE_TYPE")
+    void setThumbnail_unsupportedType() {
+        MultipartFile pdf = new MockMultipartFile("image", "a.pdf", "application/pdf", new byte[10]);
+
+        assertThatThrownBy(() -> portfolioService.setThumbnail(1L, 5L, pdf))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.UNSUPPORTED_IMAGE_TYPE);
+        then(portfolioItemRepository).should(never()).findByIdAndUserId(any(), any());
+    }
+
+    @Test
+    @DisplayName("표지 사진 변경: 5MB를 초과하면 FILE_TOO_LARGE")
+    void setThumbnail_tooLarge() {
+        MultipartFile large = new MockMultipartFile("image", "a.png", "image/png", new byte[(int) (5 * 1024 * 1024 + 1)]);
+
+        assertThatThrownBy(() -> portfolioService.setThumbnail(1L, 5L, large))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.FILE_TOO_LARGE);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

- #429

## ✨ 작업 내용
- `portfolio_items`에 커스텀 표지 이미지 S3 key(`thumbnail_key`) 컬럼 추가(`V25` 마이그레이션)
- `POST /api/portfolio/from-grade/{resultId}`가 선택적 요청 바디로 `cardId`/`variantId`를 받아, AI가 카드를 인식 못했거나 잘못 인식했을 때 사용자가 직접 고른 카드로 등록 가능하도록 확장
- AI 진단으로 도감에 등록할 때, 진단에 사용한 앞면(FRONT) 사진을 자동으로 표지에 채움(`GradeResultImageRepository`에서 조회)
- `POST /api/portfolio/{id}/thumbnail` 신규 — 사용자가 임의 도감 항목의 표지를 직접 업로드/교체(jpg/png, 5MB 이하, 프로필 이미지 업로드와 동일한 검증 규칙 재사용)
- (부수 수정) `GlobalExceptionHandler`의 `MultipartException` 처리 메시지가 AI 진단 전용 문구("사진 6장...")로 하드코딩돼 있던 것을, 프로필 이미지·문의 첨부·이번 표지 업로드까지 공유하는 핸들러이므로 도메인 중립 문구로 수정

## 📸 스크린샷 / 테스트 결과
- `PortfolioServiceTest` 전체 통과(신규 override/표지 테스트 6건 포함)
- 로컬 `bootRun` + 프론트 연동으로 AI 진단 → 카드 미인식/오인식 → 직접 카드 지정 → 도감 등록 → 표지가 실제 촬영 사진으로 채워지는 것까지 실제 확인

## 🔍 리뷰 포인트
- 이전 커스텀 표지 S3 객체 정리(cleanup)는 이번 PR에 포함하지 않음 — 표지를 여러 번 바꾸면 옛 S3 객체가 고아로 남는데, 프로필 이미지가 쓰는 `AFTER_COMMIT` 정리 이벤트 패턴을 그대로 재사용해 나중에 업그레이드 가능하도록 코드에 `ponytail:` 주석으로 남겨둠
- override `variantId`가 실제로 그 카드에 속하는지는 검증하지 않음(기존 `addItem`과 동일한 수준) — 프론트가 항상 선택된 카드의 variants 목록에서만 고르게 하므로 실사용상 문제 없음
- 이 PR과 함께 프론트(Team05_FE) 쪽 PR도 같이 나갑니다 — 프론트는 이미 이 override 바디를 보내도록 구현돼 있어서, 이 PR이 배포되지 않으면 프론트의 "카드 수정" 기능이 실제로는 적용되지 않고 무시됩니다.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?
