### PR TITLE
[Feature] #433 시세 랭킹/거래 현황 API 비로그인 공개 전환

### DIFF
--- a/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
+++ b/Pokade/src/main/java/com/pokade/global/config/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/cards", "/api/cards/**").permitAll()
                         .requestMatchers(AUTH_WHITELIST).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/prices/*/summary", "/api/prices/summaries",
-                                "/api/prices/*/trades")
+                                "/api/prices/*/trades", "/api/prices/ranking", "/api/prices/market-overview")
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/listings").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/watchlist/counts").permitAll()


### PR DESCRIPTION
## 📌 관련 이슈
- #433

## ✨ 작업 내용
- GET /api/prices/ranking, GET /api/prices/market-overview를 SecurityConfig의
  permitAll 목록에 추가 — 비회원도 조회 가능하도록 공개 전환
- 기존 GET /api/prices/*/summary, /summaries, /*/trades와 동일한 성격의
  "조회만 가능한 공개 시세 데이터"라 정책상 문제 없음

## 📸 스크린샷 / 테스트 결과
- 로컬에서 Authorization 헤더 없이 두 엔드포인트 호출 → 둘 다 HTTP 200 확인
- PriceControllerTest는 @AutoConfigureMockMvc(addFilters=false)라 영향 없음(회귀 없음)
- ./gradlew compileJava 성공

## 🔍 리뷰 포인트
- permitAll이 GET만 커버해 OPTIONS 프리플라이트 관련 기존 이슈(별도 트랙)는
  이번 PR 범위 밖입니다

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?