### PR TITLE
[Feature] #441 1:1 문의 수정·삭제 API 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/controller/InquiryController.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.inquiry.controller;
 
 import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.request.InquiryUpdateRequest;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.service.InquiryService;
 import com.pokade.global.response.ApiResponse;
@@ -8,8 +9,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,5 +40,19 @@ public class InquiryController {
     @GetMapping("/me")
     public ApiResponse<List<InquiryResponse>> getMyInquiries(@AuthenticationPrincipal Long userId) {
         return ApiResponse.ok(inquiryService.getMyInquiries(userId));
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<InquiryResponse> updateInquiry(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long id,
+            @Valid @RequestBody InquiryUpdateRequest request) {
+        return ApiResponse.ok("문의가 수정되었습니다.", inquiryService.updateInquiry(userId, id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteInquiry(@AuthenticationPrincipal Long userId, @PathVariable Long id) {
+        inquiryService.deleteInquiry(userId, id);
+        return ApiResponse.ok("문의가 삭제되었습니다.");
     }
 }

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryUpdateRequest.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/dto/request/InquiryUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.pokade.domain.inquiry.dto.request;
+
+import com.pokade.domain.inquiry.entity.InquiryCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record InquiryUpdateRequest(
+        @NotNull(message = "문의 유형은 필수입니다.")
+        InquiryCategory category,
+        @NotBlank(message = "제목은 필수입니다.")
+        @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다.")
+        String title,
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/entity/Inquiry.java
@@ -67,6 +67,14 @@ public class Inquiry {
         this.status = status;
     }
 
+    // UNHANDLED 상태에서만 호출 가능하도록 서비스 계층에서 먼저 검증한다(답변 이후에는 이력 보존을
+    // 위해 수정을 막는다 - 엔티티 자체는 그 정책을 모르고 값 변경만 담당).
+    public void update(InquiryCategory category, String title, String content) {
+        this.category = category;
+        this.title = title;
+        this.content = content;
+    }
+
     public void answer(String answerContent) {
         this.answerContent = answerContent;
         this.answeredAt = LocalDateTime.now();

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryNotificationCleanupRepository.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/repository/InquiryNotificationCleanupRepository.java
@@ -1,0 +1,21 @@
+package com.pokade.domain.inquiry.repository;
+
+import com.pokade.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+// domain.notification의 Notification 엔티티를 domain.inquiry가 직접 건드릴 일이 있어 추가한
+// 전용 리포지토리 - JpaRepository가 아니라 Spring Data의 맨몸 Repository<T, ID>를 상속해,
+// 실수로 다른 도메인 소유 테이블에 save()/delete()를 호출할 수 없게 원천 차단한다
+// (PriceTradeStatsRepository와 동일한 패턴 - "Package convention" 참고).
+// 문의를 삭제할 때(InquiryService.deleteInquiry), 문의 등록 시 관리자에게 보낸
+// INQUIRY_RECEIVED 알림이 notifications.inquiry_id로 그 문의를 참조하고 있어 FK 제약에
+// 걸린다 - 이 알림도 함께 정리해야 한다.
+public interface InquiryNotificationCleanupRepository extends Repository<Notification, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Notification n WHERE n.inquiryId = :inquiryId")
+    void deleteByInquiryId(@Param("inquiryId") Long inquiryId);
+}

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
@@ -1,9 +1,11 @@
 package com.pokade.domain.inquiry.service;
 
 import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.request.InquiryUpdateRequest;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryImage;
+import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.domain.notification.service.NotificationService;
@@ -96,6 +98,48 @@ public class InquiryService {
             }
             throw e;
         }
+    }
+
+    @Transactional
+    public InquiryResponse updateInquiry(Long userId, Long inquiryId, InquiryUpdateRequest request) {
+        Inquiry inquiry = getOwnedUnhandledInquiry(userId, inquiryId);
+        inquiry.update(request.category(), request.title(), request.content());
+
+        List<String> imageUrls = inquiryImageRepository.findByInquiryIdOrderByIdAsc(inquiryId).stream()
+                .map(image -> s3FileStorage.generatePresignedUrl(image.getImageUrl()))
+                .toList();
+        return InquiryResponse.of(inquiry, imageUrls);
+    }
+
+    @Transactional
+    public void deleteInquiry(Long userId, Long inquiryId) {
+        Inquiry inquiry = getOwnedUnhandledInquiry(userId, inquiryId);
+
+        List<InquiryImage> images = inquiryImageRepository.findByInquiryIdOrderByIdAsc(inquiryId);
+        inquiryImageRepository.deleteAll(images);
+        for (InquiryImage image : images) {
+            try {
+                s3FileStorage.delete(image.getImageUrl());
+            } catch (RuntimeException e) {
+                log.error("문의 삭제 중 첨부 이미지 S3 객체 삭제 실패 - inquiryId={}, key={} (고아 객체 잔존)",
+                        inquiryId, image.getImageUrl(), e);
+            }
+        }
+        inquiryRepository.delete(inquiry);
+    }
+
+    // 수정·삭제 공통 검증 - 본인 소유 + 아직 답변되지 않은(UNHANDLED) 문의만 허용한다.
+    // 답변 이후에는 관리자 쪽 처리 이력을 보존하기 위해 막는다.
+    private Inquiry getOwnedUnhandledInquiry(Long userId, Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INQUIRY_NOT_FOUND));
+        if (!inquiry.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+        if (inquiry.getStatus() != InquiryStatus.UNHANDLED) {
+            throw new BusinessException(ErrorCode.INQUIRY_ALREADY_HANDLED);
+        }
+        return inquiry;
     }
 
     public List<InquiryResponse> getMyInquiries(Long userId) {

--- a/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
+++ b/Pokade/src/main/java/com/pokade/domain/inquiry/service/InquiryService.java
@@ -7,6 +7,7 @@ import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryImage;
 import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
+import com.pokade.domain.inquiry.repository.InquiryNotificationCleanupRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.user.entity.User;
@@ -43,6 +44,7 @@ public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
     private final InquiryImageRepository inquiryImageRepository;
+    private final InquiryNotificationCleanupRepository inquiryNotificationCleanupRepository;
     private final S3FileStorage s3FileStorage;
     // #392: 문의 등록 시 관리자 전원에게 알림을 보내기 위한 의존성 - createInquiry()에서만 쓴다.
     private final UserRepository userRepository;
@@ -125,6 +127,9 @@ public class InquiryService {
                         inquiryId, image.getImageUrl(), e);
             }
         }
+        // 문의 등록 시 관리자에게 보낸 INQUIRY_RECEIVED 알림이 notifications.inquiry_id로 이 문의를
+        // 참조하고 있어, 먼저 정리하지 않으면 FK 제약 위반으로 문의 삭제 자체가 실패한다.
+        inquiryNotificationCleanupRepository.deleteByInquiryId(inquiryId);
         inquiryRepository.delete(inquiry);
     }
 

--- a/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
+++ b/Pokade/src/main/java/com/pokade/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
     INQUIRY_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "첨부 이미지는 최대 3장까지 가능합니다."),
+    INQUIRY_ALREADY_HANDLED(HttpStatus.CONFLICT, "이미 답변된 문의는 수정하거나 삭제할 수 없습니다."),
 
     DUPLICATE_LISTING(HttpStatus.CONFLICT, "이미 등록된 매물입니다."),
     TRADE_CONFLICT(HttpStatus.CONFLICT, "이미 처리 중인 거래입니다."),

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/controller/InquiryControllerTest.java
@@ -29,12 +29,19 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.pokade.global.exception.BusinessException;
+import com.pokade.global.exception.ErrorCode;
+import org.springframework.http.MediaType;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -105,5 +112,60 @@ class InquiryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(1))
                 .andExpect(jsonPath("$.data[0].title").value("제목"));
+    }
+
+    @Test
+    void 본인_문의_수정에_성공하면_200과_수정된_내용을_반환한다() throws Exception {
+        InquiryResponse response = new InquiryResponse(1L, 100L, InquiryCategory.PAYMENT, InquiryStatus.UNHANDLED, "새 제목", "새 내용", List.of(), LocalDateTime.now(), null, null);
+        given(inquiryService.updateInquiry(eq(100L), eq(1L), any())).willReturn(response);
+
+        mockMvc.perform(patch("/api/inquiries/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"PAYMENT\",\"title\":\"새 제목\",\"content\":\"새 내용\"}")
+                        .with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("새 제목"));
+    }
+
+    @Test
+    void 이미_답변된_문의를_수정하면_409를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.INQUIRY_ALREADY_HANDLED))
+                .given(inquiryService).updateInquiry(eq(100L), eq(1L), any());
+
+        mockMvc.perform(patch("/api/inquiries/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"PAYMENT\",\"title\":\"새 제목\",\"content\":\"새 내용\"}")
+                        .with(userId(100L)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("INQUIRY_ALREADY_HANDLED"));
+    }
+
+    @Test
+    void 로그인하지_않으면_문의_수정시_401을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/inquiries/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"PAYMENT\",\"title\":\"새 제목\",\"content\":\"새 내용\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 본인_문의_삭제에_성공하면_200을_반환한다() throws Exception {
+        mockMvc.perform(delete("/api/inquiries/1").with(userId(100L)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 다른_사람의_문의를_삭제하면_403을_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.ACCESS_DENIED))
+                .given(inquiryService).deleteInquiry(eq(100L), eq(1L));
+
+        mockMvc.perform(delete("/api/inquiries/1").with(userId(100L)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 로그인하지_않으면_문의_삭제시_401을_반환한다() throws Exception {
+        mockMvc.perform(delete("/api/inquiries/1"))
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.inquiry.service;
 
 import com.pokade.domain.inquiry.dto.request.InquiryCreateRequest;
+import com.pokade.domain.inquiry.dto.request.InquiryUpdateRequest;
 import com.pokade.domain.inquiry.dto.response.InquiryResponse;
 import com.pokade.domain.inquiry.entity.Inquiry;
 import com.pokade.domain.inquiry.entity.InquiryCategory;
@@ -27,6 +28,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -204,6 +206,87 @@ class InquiryServiceTest {
 
         then(inquiryRepository).should(never()).save(any());
         then(notificationService).should(never()).createInquiryReceivedNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("본인 소유 + UNHANDLED 문의는 수정할 수 있다")
+    void updateInquiry_ownerAndUnhandled_succeeds() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("원래 제목").content("원래 내용").category(InquiryCategory.ETC).build();
+        given(inquiryRepository.findById(5L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(5L)).willReturn(List.of());
+        InquiryUpdateRequest request = new InquiryUpdateRequest(InquiryCategory.PAYMENT, "새 제목", "새 내용");
+
+        InquiryResponse response = inquiryService.updateInquiry(1L, 5L, request);
+
+        assertThat(inquiry.getTitle()).isEqualTo("새 제목");
+        assertThat(inquiry.getContent()).isEqualTo("새 내용");
+        assertThat(inquiry.getCategory()).isEqualTo(InquiryCategory.PAYMENT);
+        assertThat(response.title()).isEqualTo("새 제목");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문의를 수정하려 하면 INQUIRY_NOT_FOUND")
+    void updateInquiry_notFound() {
+        given(inquiryRepository.findById(5L)).willReturn(Optional.empty());
+        InquiryUpdateRequest request = new InquiryUpdateRequest(InquiryCategory.PAYMENT, "새 제목", "새 내용");
+
+        assertThatThrownBy(() -> inquiryService.updateInquiry(1L, 5L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("본인 소유가 아닌 문의를 수정하려 하면 ACCESS_DENIED")
+    void updateInquiry_notOwner_accessDenied() {
+        Inquiry inquiry = Inquiry.builder().userId(2L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        given(inquiryRepository.findById(5L)).willReturn(Optional.of(inquiry));
+        InquiryUpdateRequest request = new InquiryUpdateRequest(InquiryCategory.PAYMENT, "새 제목", "새 내용");
+
+        assertThatThrownBy(() -> inquiryService.updateInquiry(1L, 5L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("이미 답변된 문의를 수정하려 하면 INQUIRY_ALREADY_HANDLED")
+    void updateInquiry_alreadyHandled_rejected() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        inquiry.answer("답변 내용");
+        given(inquiryRepository.findById(5L)).willReturn(Optional.of(inquiry));
+        InquiryUpdateRequest request = new InquiryUpdateRequest(InquiryCategory.PAYMENT, "새 제목", "새 내용");
+
+        assertThatThrownBy(() -> inquiryService.updateInquiry(1L, 5L, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_ALREADY_HANDLED);
+    }
+
+    @Test
+    @DisplayName("본인 소유 + UNHANDLED 문의는 삭제할 수 있고, 첨부 이미지도 함께 정리된다")
+    void deleteInquiry_ownerAndUnhandled_succeeds() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        InquiryImage image = InquiryImage.builder().inquiryId(5L).imageUrl("inquiries/a.png").build();
+        given(inquiryRepository.findById(5L)).willReturn(Optional.of(inquiry));
+        given(inquiryImageRepository.findByInquiryIdOrderByIdAsc(5L)).willReturn(List.of(image));
+
+        inquiryService.deleteInquiry(1L, 5L);
+
+        then(inquiryImageRepository).should().deleteAll(List.of(image));
+        then(s3FileStorage).should().delete("inquiries/a.png");
+        then(inquiryRepository).should().delete(inquiry);
+    }
+
+    @Test
+    @DisplayName("이미 답변된 문의를 삭제하려 하면 INQUIRY_ALREADY_HANDLED, 아무것도 지워지지 않는다")
+    void deleteInquiry_alreadyHandled_rejected() {
+        Inquiry inquiry = Inquiry.builder().userId(1L).title("제목").content("내용").category(InquiryCategory.ETC).build();
+        inquiry.answer("답변 내용");
+        given(inquiryRepository.findById(5L)).willReturn(Optional.of(inquiry));
+
+        assertThatThrownBy(() -> inquiryService.deleteInquiry(1L, 5L))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.INQUIRY_ALREADY_HANDLED);
+
+        then(inquiryRepository).should(never()).delete(any());
     }
 
     private User adminWithId(Long id) {

--- a/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/inquiry/service/InquiryServiceTest.java
@@ -8,6 +8,7 @@ import com.pokade.domain.inquiry.entity.InquiryCategory;
 import com.pokade.domain.inquiry.entity.InquiryImage;
 import com.pokade.domain.inquiry.entity.InquiryStatus;
 import com.pokade.domain.inquiry.repository.InquiryImageRepository;
+import com.pokade.domain.inquiry.repository.InquiryNotificationCleanupRepository;
 import com.pokade.domain.inquiry.repository.InquiryRepository;
 import com.pokade.domain.notification.service.NotificationService;
 import com.pokade.domain.user.entity.User;
@@ -46,6 +47,8 @@ class InquiryServiceTest {
     private InquiryRepository inquiryRepository;
     @Mock
     private InquiryImageRepository inquiryImageRepository;
+    @Mock
+    private InquiryNotificationCleanupRepository inquiryNotificationCleanupRepository;
     @Mock
     private S3FileStorage s3FileStorage;
     @Mock
@@ -272,6 +275,9 @@ class InquiryServiceTest {
 
         then(inquiryImageRepository).should().deleteAll(List.of(image));
         then(s3FileStorage).should().delete("inquiries/a.png");
+        // 문의 등록 시 관리자에게 보낸 INQUIRY_RECEIVED 알림이 notifications.inquiry_id로 이 문의를
+        // 참조하고 있어, 먼저 지우지 않으면 FK 위반으로 삭제 자체가 실패한다(실제로 로컬에서 재현됨).
+        then(inquiryNotificationCleanupRepository).should().deleteByInquiryId(5L);
         then(inquiryRepository).should().delete(inquiry);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- #441 

## ✨ 작업 내용
- PATCH/DELETE /api/inquiries/{id} 추가 — 본인 소유 + 답변 전(UNHANDLED) 문의만
  수정·삭제 가능
- 문의 삭제 시 등록 당시 관리자에게 보낸 INQUIRY_RECEIVED 알림이
  notifications.inquiry_id로 그 문의를 참조하고 있어 FK 위반이 발생하던 버그 수정
  — domain.inquiry 안에 Notification 전용 bare Repository를 추가해 삭제 전 관련
  알림도 함께 정리

## 📸 스크린샷 / 테스트 결과
- 신규 유닛/컨트롤러 테스트 전부 통과 (수정/삭제 성공, 권한 없음, 이미 답변된 문의
  수정·삭제 시도 시 409 등)
- 로컬 서버로 생성→수정→삭제, 답변 후 수정·삭제 차단(409), 삭제 시 FK 위반 재현 후
  수정까지 curl로 실측 확인
- develop 머지 후 전체 컴파일 + 문의 테스트 재확인, 회귀 없음

## 🔍 리뷰 포인트
- 답변 이후 수정·삭제를 막는 정책(INQUIRY_ALREADY_HANDLED)이 적절한지
- 첨부 이미지는 이번 범위에서 수정 대상이 아님(등록 시점 그대로 유지) — 필요하면
  후속 이슈로 분리

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?