### PR TITLE
[Fix] #445  AI 진단·포트폴리오 응답에 카드 한글명(cardNameKo) 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/dto/GradeResponse.java
@@ -36,6 +36,9 @@ public record GradeResponse(
         // FR-AI-04(도감 등록) 진입 가능 여부를 FE가 판단하는 기준이기도 하다.
         Long cardId,
         String cardName,
+        // 카드 이름에서 종 이름 부분만 한글로 치환한 값 - domain.card.support.CardNameKoResolver가
+        // 매핑을 못 찾으면(트레이너/에너지 카드 등) null. FE는 cardNameKo ?? cardName으로 표시한다.
+        String cardNameKo,
         String cardImageSmall,
         // 카드 인식 신뢰도(%) — 등급 산출 신뢰도(confidence)와는 별개 지표.
         BigDecimal cardConfidence,
@@ -50,12 +53,12 @@ public record GradeResponse(
     private static final String LEGAL_NOTICE =
             "본 결과는 AI 기반 참고용 예비진단이며, 정식 카드 감정을 대체하지 않습니다.";
 
-    public static GradeResponse from(GradeResult result, Card card,
+    public static GradeResponse from(GradeResult result, Card card, String cardNameKo,
                                       Map<String, String> imageUrls, Integer remainingPoints) {
-        return from(result, card, imageUrls, remainingPoints, false);
+        return from(result, card, cardNameKo, imageUrls, remainingPoints, false);
     }
 
-    public static GradeResponse from(GradeResult result, Card card, Map<String, String> imageUrls,
+    public static GradeResponse from(GradeResult result, Card card, String cardNameKo, Map<String, String> imageUrls,
                                       Integer remainingPoints, boolean cached) {
         return new GradeResponse(
                 result.getId(),
@@ -73,6 +76,7 @@ public record GradeResponse(
                 result.getCreatedAt(),
                 card != null ? card.getId() : null,
                 card != null ? card.getName() : null,
+                card != null ? cardNameKo : null,
                 card != null ? card.getImageSmall() : null,
                 result.getVisionConfidence(),
                 imageUrls,

--- a/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/ai/service/AiGradeService.java
@@ -9,6 +9,7 @@ import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.point.service.PointService;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
@@ -111,6 +112,7 @@ public class AiGradeService {
     private final GradeResultRepository gradeResultRepository;
     private final GradeResultImageRepository gradeResultImageRepository;
     private final CardRepository cardRepository;
+    private final CardNameKoResolver cardNameKoResolver;
     private final PointService pointService;
     private final PlatformTransactionManager transactionManager;
 
@@ -136,6 +138,7 @@ public class AiGradeService {
                           GradeResultRepository gradeResultRepository,
                           GradeResultImageRepository gradeResultImageRepository,
                           CardRepository cardRepository,
+                          CardNameKoResolver cardNameKoResolver,
                           PointService pointService,
                           PlatformTransactionManager transactionManager,
                           MeterRegistry meterRegistry) {
@@ -145,6 +148,7 @@ public class AiGradeService {
         this.gradeResultRepository = gradeResultRepository;
         this.gradeResultImageRepository = gradeResultImageRepository;
         this.cardRepository = cardRepository;
+        this.cardNameKoResolver = cardNameKoResolver;
         this.pointService = pointService;
         this.transactionManager = transactionManager;
 
@@ -270,7 +274,8 @@ public class AiGradeService {
 
         // ── presigned URL 생성 후 응답 ───────────────────────────────────────
         Map<String, String> imageUrls = toPresignedUrls(imageKeys);
-        return GradeResponse.from(gradeResult, resolveCard(gradeResult), imageUrls, remainingPoints);
+        Card recognizedCard = resolveCard(gradeResult);
+        return GradeResponse.from(gradeResult, recognizedCard, resolveCardNameKo(recognizedCard), imageUrls, remainingPoints);
     }
 
     // 업로드 순서가 항상 FRONT/BACK/CORNER_TL/TR/BL/BR로 고정이라 바이트를 이 순서대로 이어붙여 해시를
@@ -305,7 +310,8 @@ public class AiGradeService {
                         img -> img.getPhotoType().name(),
                         img -> s3FileStorage.generatePresignedUrl(img.getImageUrl()),
                         (existing, replacement) -> existing));
-        return GradeResponse.from(cached, resolveCard(cached), imageUrls, null, true);
+        Card recognizedCard = resolveCard(cached);
+        return GradeResponse.from(cached, recognizedCard, resolveCardNameKo(recognizedCard), imageUrls, null, true);
     }
 
     private void recordResultMetric(VisionResult visionResult, boolean isFree) {
@@ -333,7 +339,8 @@ public class AiGradeService {
                         img -> s3FileStorage.generatePresignedUrl(img.getImageUrl()),
                         (existing, replacement) -> existing));
 
-        return GradeResponse.from(gradeResult, resolveCard(gradeResult), imageUrls, null);
+        Card recognizedCard = resolveCard(gradeResult);
+        return GradeResponse.from(gradeResult, recognizedCard, resolveCardNameKo(recognizedCard), imageUrls, null);
     }
 
     // vision_card_id(externalId)가 자체 DB에 없거나(신규 세트 동기화 지연 등) 아예 인식 실패면 null —
@@ -342,6 +349,12 @@ public class AiGradeService {
         return gradeResult.getVisionCardId() != null
                 ? cardRepository.findByExternalId(gradeResult.getVisionCardId()).orElse(null)
                 : null;
+    }
+
+    // 카드가 인식되지 않았으면(null) 한글명도 없다 - resolve() 자체는 null 카드를 허용하지 않으므로
+    // 호출 전에 여기서 가드한다.
+    private String resolveCardNameKo(Card card) {
+        return card != null ? cardNameKoResolver.resolve(card) : null;
     }
 
     public Page<GradeResponse> getGradeHistory(Long userId, Pageable pageable) {
@@ -360,9 +373,10 @@ public class AiGradeService {
                         .collect(Collectors.toMap(Card::getExternalId, c -> c));
 
         // 이미지 URL·remainingPoints는 목록에서 제공하지 않음
-        return results.map(r -> GradeResponse.from(r,
-                r.getVisionCardId() != null ? cardByExternalId.get(r.getVisionCardId()) : null,
-                null, null));
+        return results.map(r -> {
+            Card recognizedCard = r.getVisionCardId() != null ? cardByExternalId.get(r.getVisionCardId()) : null;
+            return GradeResponse.from(r, recognizedCard, resolveCardNameKo(recognizedCard), null, null);
+        });
     }
 
     private void validateImageFormats(GradeRequest request) {

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/dto/PortfolioItemResponse.java
@@ -12,6 +12,9 @@ public record PortfolioItemResponse(
         Long id,
         Long cardId,
         String cardName,
+        // 카드 이름에서 종 이름 부분만 한글로 치환한 값 - domain.card.support.CardNameKoResolver가
+        // 매핑을 못 찾으면(트레이너/에너지 카드 등) null. FE는 cardNameKo ?? cardName으로 표시한다.
+        String cardNameKo,
         String cardImageSmall,
         Long variantId,
         String variantName,
@@ -29,12 +32,14 @@ public record PortfolioItemResponse(
             Card card,
             CardVariant variant,
             CardPriceRepository.VariantMarketPriceView priceView,
-            String thumbnailUrl
+            String thumbnailUrl,
+            String cardNameKo
     ) {
         return new PortfolioItemResponse(
                 item.getId(),
                 item.getCardId(),
                 card != null ? card.getName() : null,
+                card != null ? cardNameKo : null,
                 thumbnailUrl != null ? thumbnailUrl : (card != null ? card.getImageSmall() : null),
                 item.getVariantId(),
                 variant != null ? variant.getVariantName() : null,

--- a/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
+++ b/Pokade/src/main/java/com/pokade/domain/portfolio/service/PortfolioService.java
@@ -13,6 +13,7 @@ import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
 import com.pokade.domain.card.repository.ExpansionRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
@@ -69,6 +70,7 @@ public class PortfolioService {
 
     private final PortfolioItemRepository portfolioItemRepository;
     private final CardRepository cardRepository;
+    private final CardNameKoResolver cardNameKoResolver;
     private final CardVariantRepository cardVariantRepository;
     private final CardPriceRepository cardPriceRepository;
     private final ExpansionRepository expansionRepository;
@@ -571,7 +573,8 @@ public class PortfolioService {
                     ? priceMap.get(resolvedVariantId)
                     : null;
 
-            return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item));
+            String cardNameKo = card != null ? cardNameKoResolver.resolve(card) : null;
+            return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item), cardNameKo);
         }).toList();
     }
 
@@ -591,6 +594,7 @@ public class PortfolioService {
             price = prices.isEmpty() ? null : prices.get(0);
         }
 
-        return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item));
+        String cardNameKo = card != null ? cardNameKoResolver.resolve(card) : null;
+        return PortfolioItemResponse.of(item, card, variant, price, resolveThumbnailUrl(item), cardNameKo);
     }
 }

--- a/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/ai/service/AiGradeServiceTest.java
@@ -35,6 +35,7 @@ import com.pokade.domain.ai.entity.GradeStatus;
 import com.pokade.domain.ai.repository.GradeResultImageRepository;
 import com.pokade.domain.ai.repository.GradeResultRepository;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.global.exception.BusinessException;
 import com.pokade.global.exception.ErrorCode;
 import org.springframework.ai.chat.client.ChatClient;
@@ -59,6 +60,9 @@ class AiGradeServiceTest {
 
     @Mock
     private CardRepository cardRepository;
+
+    @Mock
+    private CardNameKoResolver cardNameKoResolver;
 
     @Mock
     private PlatformTransactionManager transactionManager;
@@ -92,6 +96,36 @@ class AiGradeServiceTest {
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent().get(0).grade()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("진단 이력에 인식된 카드가 있으면 CardNameKoResolver로 구한 한글명을 함께 내려준다")
+    void getGradeHistory_includesCardNameKo() {
+        Long userId = 1L;
+        Pageable pageable = PageRequest.of(0, 20);
+        GradeResult gradeResult = GradeResult.builder()
+                .userId(userId)
+                .status(GradeStatus.SUCCESS)
+                .grade("S")
+                .isFree(true)
+                .pointUsed(0)
+                .retryAllowed(false)
+                .visionCardId("base1-4")
+                .build();
+        Page<GradeResult> page = new PageImpl<>(List.of(gradeResult), pageable, 1);
+        com.pokade.domain.card.entity.Card card = com.pokade.domain.card.entity.Card.builder()
+                .externalId("base1-4")
+                .name("Charizard")
+                .build();
+
+        given(gradeResultRepository.findByUserId(userId, pageable)).willReturn(page);
+        given(cardRepository.findByExternalIdIn(List.of("base1-4"))).willReturn(List.of(card));
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽");
+
+        Page<GradeResponse> result = aiGradeService.getGradeHistory(userId, pageable);
+
+        assertThat(result.getContent().get(0).cardName()).isEqualTo("Charizard");
+        assertThat(result.getContent().get(0).cardNameKo()).isEqualTo("리자몽");
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/portfolio/service/PortfolioServiceTest.java
@@ -10,6 +10,7 @@ import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardPriceRepository;
 import com.pokade.domain.card.repository.CardRepository;
 import com.pokade.domain.card.repository.CardVariantRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsItemResponse;
 import com.pokade.domain.portfolio.dto.PortfolioAnalyticsResponse;
 import com.pokade.domain.portfolio.dto.PortfolioItemAddRequest;
@@ -52,6 +53,7 @@ class PortfolioServiceTest {
 
     @Mock PortfolioItemRepository portfolioItemRepository;
     @Mock CardRepository cardRepository;
+    @Mock CardNameKoResolver cardNameKoResolver;
     @Mock CardVariantRepository cardVariantRepository;
     @Mock CardPriceRepository cardPriceRepository;
     @Mock GradeResultRepository gradeResultRepository;
@@ -173,6 +175,22 @@ class PortfolioServiceTest {
         List<PortfolioItemResponse> result = portfolioService.getMyPortfolio(1L);
 
         assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("조회: CardNameKoResolver로 구한 한글명을 cardNameKo로 함께 내려준다")
+    void getMyPortfolio_includesCardNameKo() {
+        PortfolioItem item = stubItem(1L, 10L, null);
+        Card card = stubCard(10L);
+        given(portfolioItemRepository.findByUserIdOrderByIdDesc(1L)).willReturn(List.of(item));
+        given(cardRepository.findAllById(any())).willReturn(List.of(card));
+        given(cardVariantRepository.findPrimaryVariantIdsByCardIds(anyList())).willReturn(List.of());
+        given(cardNameKoResolver.resolve(card)).willReturn("리자몽 한글명");
+
+        List<PortfolioItemResponse> result = portfolioService.getMyPortfolio(1L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).cardNameKo()).isEqualTo("리자몽 한글명");
     }
 
     // ===== updateItem =====


### PR DESCRIPTION
## 📌 관련 이슈
- #445

## ✨ 작업 내용

- AI 등급 진단(`GET /api/ai/grade/{id}`, `/history`)과 포트폴리오(`GET /api/portfolio`) 응답에 `cardNameKo` 필드 추가 — 지금까지는 카드 이름이 Scrydex 원본 영문(`cardName`)만 내려가서 FE에서 한글로 표시할 방법이 없었음
- 다른 도메인(chat/price/watchlist/listing)에서 이미 쓰던 `CardNameKoResolver`를 `AiGradeService`/`PortfolioService`에 주입해서 재사용 — 신규 매핑 로직 없음
- 한글 매핑을 못 찾으면(트레이너/에너지 카드 등) `null` — FE는 `cardNameKo ?? cardName`으로 표시
- domain.ai/domain.portfolio는 원래 다른 담당자 도메인이지만, 이번 수정은 팀 확인 하에 진행

## 📸 스크린샷 / 테스트 결과

- `AiGradeServiceTest`/`PortfolioServiceTest`에 회귀 테스트 추가, 전체 통과
- 전체 회귀(`./gradlew test`) 1233개 중 27개 실패 — 전부 기존에 문서화된 환경 이슈(Testcontainers 미사용 테스트, TradeRepositoryTest 등)이고 이번 변경과 무관함을 확인
- 로컬 서버 재기동 후 curl로 직접 확인: 포트폴리오에 base1-4(Charizard) 추가 시 `"cardNameKo":"리자몽"` 정상 응답

## 🔍 리뷰 포인트

- `AiGradeService`는 수동 생성자(Micrometer Counter 초기화 때문에 `@RequiredArgsConstructor` 미사용)라 `CardNameKoResolver` 주입 위치를 직접 확인해주세요
- `GradeResponse.from(...)`/`PortfolioItemResponse.of(...)` 팩토리 시그니처가 바뀌어서 다른 호출부가 있다면 컴파일 에러로 바로 드러납니다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?