### PR TITLE
[Fix] EC2 로컬 이미지 정리 시간 필터 제거 및 백업 이미지 2세대 보관

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,9 +117,12 @@ jobs:
 
             echo "$TARGET" > ~/pokade-active-slot
 
-            # 48시간 지난 미사용 이미지 정리 - EC2 로컬 디스크가 무한정 쌓이는 걸 방지.
+            # 미사용(dangling) 이미지 정리 - EC2 로컬 디스크가 무한정 쌓이는 걸 방지.
             # GHCR 쪽 정리(cleanup-old-images job)는 레지스트리만 청소하고 로컬 pull 이미지는
             # 안 지워서, 배포를 반복할수록 디스크가 가득 차 배포가 실패하는 문제가 있었다.
-            docker image prune -af --filter "until=48h" || true
+            # until=48h 필터를 쓰면 배포 주기(하루 여러 번)가 48시간보다 짧아 이미지가
+            # 지워지기 전에 계속 쌓였다. -a는 태그 없는(dangling) 이미지만 지우고 현재
+            # 실행 중인 이미지는 건드리지 않으므로 시간 제한 없이 매 배포마다 정리한다.
+            docker image prune -af || true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,14 @@ jobs:
           script: |
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
+            IMAGE_BASE="${IMAGE%:latest}"
+
+            # 롤백용 백업 2세대 유지: backup-1(직전) -> backup-2(그 이전), 3세대는 자동 dangling 처리되어 prune된다.
+            docker image inspect "$IMAGE_BASE:backup-1" >/dev/null 2>&1 && \
+              docker tag "$IMAGE_BASE:backup-1" "$IMAGE_BASE:backup-2"
+            docker image inspect "$IMAGE" >/dev/null 2>&1 && \
+              docker tag "$IMAGE" "$IMAGE_BASE:backup-1"
+
             docker pull "$IMAGE"
 
             CURRENT_SLOT=$(cat ~/pokade-active-slot 2>/dev/null || echo "")
@@ -123,6 +131,7 @@ jobs:
             # until=48h 필터를 쓰면 배포 주기(하루 여러 번)가 48시간보다 짧아 이미지가
             # 지워지기 전에 계속 쌓였다. -a는 태그 없는(dangling) 이미지만 지우고 현재
             # 실행 중인 이미지는 건드리지 않으므로 시간 제한 없이 매 배포마다 정리한다.
+            # backup-1/backup-2는 태그가 있어 dangling이 아니므로 이 prune에 영향받지 않는다.
             docker image prune -af || true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## 📌 관련 이슈
- 없음 (운영 중 EC2 디스크 100% 참 재발을 SSH로 직접 확인하고 수정)

## ✨ 작업 내용
`docker image prune --filter "until=48h"`가 하루 여러 번인 배포 주기보다 느슨해서, 방금 dangling된 이미지가 48시간을 못 채우고 계속 쌓이기만 했다. EC2 루트 디스크(19GB)가 다시 100%(여유 106MB)까지 차서 `docker pull`이 `no space left on device`로 실패했다.

- 시간 필터 제거, `docker image prune -af`로 매 배포마다 무조건 정리 — 컨테이너가 참조 중인 이미지(=현재 활성 이미지)는 `-a`를 줘도 지워지지 않으므로 안전
- 다만 `:latest` 단일 태그만 쓰다 보니 이전 이미지를 지우면 롤백 대상 자체가 사라지는 부작용이 생겨서, `docker pull` 직전에 현재 `:latest`를 `:backup-1`로, 기존 `:backup-1`은 `:backup-2`로 태그 회전시키는 로직 추가. 3세대 전 이미지는 자동으로 dangling 처리되어 다음 prune에서 정리됨
- 결과적으로 EC2 로컬에는 `latest`(현재) + `backup-1`(직전) + `backup-2`(그 이전) 최대 3개 이미지만 유지됨

## 📸 스크린샷 / 테스트 결과
SSH로 직접 확인한 조치 전/후 디스크 상태:

```
# 조치 전
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        19G   19G  106M 100% /
# dangling 이미지 33개, 10.15GB

# docker image prune -af 실행 후
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        19G  8.7G  9.6G  48% /
```

GitHub Actions 워크플로 문법 자체는 기존 blue-green 배포 스크립트 구조를 그대로 따르는 셸 스크립트 추가/수정이라 실제 검증은 develop 머지 후 첫 배포에서 확인 예정.

## 🔍 리뷰 포인트
- 시간 필터를 없앤 근거: `-a`는 태그 없는(dangling) 이미지만 지우고, 현재 컨테이너가 참조 중인 이미지는 태그 유무와 무관하게 안 지워진다. 따라서 시간 제한 없이 매 배포마다 정리해도 활성 이미지가 잘못 지워질 위험이 없다.
- 백업 2세대만 유지하기로 한 이유: 로컬 디스크 용량(19GB) 대비 이미지 1개가 약 771MB라 3개(현재+백업 2개) 정도면 여유가 충분하고, 그 이상 늘리는 건 지금 문제(디스크 부족) 재발 방지 취지에 안 맞음.
- 자동 롤백 스크립트는 이번 범위에 포함하지 않음 — 헬스체크 통과 후에만 드러나는 버그에 대한 수동 롤백 절차는 별도 운영 문서(레포 밖 개인 트러블슈팅 노트)에 정리해뒀고, 필요성이 확인되면 후속으로 스크립트화할 예정.

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? — 워크플로 셸 스크립트 변경으로 Gradle 빌드 영향 없음, EC2 SSH로 `docker image prune -af` 직접 실행해 디스크 회복 확인
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가? — 개인 트러블슈팅 노트에는 반영(레포 밖, push 제외 대상이라 이 PR에는 포함되지 않음)