### PR TITLE
[Fix] #450 거래 카드 한글명·등급 표시 및 어드민 대시보드 재시작 초기화 버그 수정

### DIFF
--- a/Pokade/docker-compose.observability.prod.yml
+++ b/Pokade/docker-compose.observability.prod.yml
@@ -21,10 +21,8 @@ services:
     image: prom/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
     container_name: pokade-prometheus
     restart: unless-stopped
-    # 기본 보존 기간(15d)으로는 어드민 대시보드의 "총 방문자 수" 등 누적 카드가 배포(BE 재시작)를 겪을
-    # 때마다 sum(increase(...[90d])) 구간 밖으로 과거 데이터가 밀려 사실상 줄어드는 문제가 생긴다
-    # (AdminMetricsService.TOTAL_WINDOW 참고, 90d로 맞춰뒀으니 여기도 같이 바꿀 것). 나머지 플래그는
-    # 이미지 기본 CMD를 그대로 유지 - command를 지정하면 기본값이 전부 사라지므로 명시해야 한다.
+    # AdminMetricsService.TOTAL_WINDOW(90d)와 맞춰야 하는 값 - 같이 바꿀 것.
+    # command를 지정하면 이미지 기본 CMD가 전부 사라지므로 나머지 플래그도 함께 명시했다.
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'

--- a/Pokade/docker-compose.observability.prod.yml
+++ b/Pokade/docker-compose.observability.prod.yml
@@ -21,6 +21,16 @@ services:
     image: prom/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
     container_name: pokade-prometheus
     restart: unless-stopped
+    # 기본 보존 기간(15d)으로는 어드민 대시보드의 "총 방문자 수" 등 누적 카드가 배포(BE 재시작)를 겪을
+    # 때마다 sum(increase(...[90d])) 구간 밖으로 과거 데이터가 밀려 사실상 줄어드는 문제가 생긴다
+    # (AdminMetricsService.TOTAL_WINDOW 참고, 90d로 맞춰뒀으니 여기도 같이 바꿀 것). 나머지 플래그는
+    # 이미지 기본 CMD를 그대로 유지 - command를 지정하면 기본값이 전부 사라지므로 명시해야 한다.
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=90d'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
     volumes:
       - ./observability/prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus-data:/prometheus

--- a/Pokade/docker-compose.observability.yml
+++ b/Pokade/docker-compose.observability.yml
@@ -11,10 +11,8 @@ services:
     image: prom/prometheus:latest
     container_name: pokade-prometheus
     restart: unless-stopped
-    # 기본 보존 기간(15d)으로는 어드민 대시보드의 "총 방문자 수" 등 누적 카드가 재시작을 겪을 때마다
-    # sum(increase(...[90d])) 구간 밖으로 과거 데이터가 밀려 사실상 줄어드는 문제가 생긴다
-    # (AdminMetricsService.TOTAL_WINDOW 참고, 90d로 맞춰뒀으니 여기도 같이 바꿀 것). 나머지 플래그는
-    # 이미지 기본 CMD를 그대로 유지 - command를 지정하면 기본값이 전부 사라지므로 명시해야 한다.
+    # AdminMetricsService.TOTAL_WINDOW(90d)와 맞춰야 하는 값 - 같이 바꿀 것.
+    # command를 지정하면 이미지 기본 CMD가 전부 사라지므로 나머지 플래그도 함께 명시했다.
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'

--- a/Pokade/docker-compose.observability.yml
+++ b/Pokade/docker-compose.observability.yml
@@ -11,6 +11,16 @@ services:
     image: prom/prometheus:latest
     container_name: pokade-prometheus
     restart: unless-stopped
+    # 기본 보존 기간(15d)으로는 어드민 대시보드의 "총 방문자 수" 등 누적 카드가 재시작을 겪을 때마다
+    # sum(increase(...[90d])) 구간 밖으로 과거 데이터가 밀려 사실상 줄어드는 문제가 생긴다
+    # (AdminMetricsService.TOTAL_WINDOW 참고, 90d로 맞춰뒀으니 여기도 같이 바꿀 것). 나머지 플래그는
+    # 이미지 기본 CMD를 그대로 유지 - command를 지정하면 기본값이 전부 사라지므로 명시해야 한다.
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=90d'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
@@ -23,19 +23,31 @@ public class AdminMetricsService {
     static final String AI_GRADE_URI = "/api/ai/grade";
     static final String TRADE_CONFIRM_URI = "/api/trades/{id}/confirm";
 
+    // 블루-그린 배포 때마다(=BE 프로세스 재시작 때마다) 카운터 원값이 0으로 리셋되는 문제(사용자 리포트) -
+    // Micrometer 카운터 자체는 JVM 인메모리라 재시작을 못 버티지만, Prometheus가 스크랩해 쌓아둔 시계열은
+    // 재시작과 무관하게 남아있다. increase(...)는 구간 안의 카운터 리셋을 자동으로 감지해 보정하므로,
+    // 원시값을 그대로 읽는 대신 TOTAL_WINDOW 구간의 increase 합을 "누적 총합"으로 취급하면 재시작에도
+    // 끊기지 않는다. 또한 sum()으로 묶어야 blue/green 두 슬롯(app-a/app-b)이 서로 다른 instance 라벨의
+    // 별도 시계열로 잡히는 것도 하나로 합쳐진다(PrometheusApiClient.firstResult()의 "항상 sum(...)으로
+    // 하나로 합쳐서 쿼리한다"는 전제와도 일치 - 이 세 카드만 그 전제를 어기고 원시값을 쓰고 있었다).
+    // TOTAL_WINDOW는 Prometheus 보존 기간(docker-compose.observability*.yml의
+    // --storage.tsdb.retention.time)과 맞춰뒀다 - 그보다 길게 잡아도 의미가 없다(그 이전 데이터가 이미
+    // 삭제됨). 보존 기간을 늘리면 이 상수도 함께 늘려야 한다.
+    private static final String TOTAL_WINDOW = "90d";
+
     // 새 지표는 (필요 시 계측 후) 이 리스트에 한 줄만 추가하면 되고, 이미 자동 계측되는 지표는 uri 필터링만으로 추가 가능하다.
     private static final List<CardDefinition> CARDS = List.of(
-            // 카운터 원값 자체가 "누적" - 마지막 BE 재시작 이후로 쌓인 합계다(재시작 시 0으로 리셋됨).
-            new CardDefinition("totalVisits", "총 방문자 수", "site_visits_total", "명",
+            new CardDefinition("totalVisits", "총 방문자 수",
+                    "sum(increase(site_visits_total[" + TOTAL_WINDOW + "]))", "명",
                     "오늘 증가", "increase(site_visits_total[24h])"),
             new CardDefinition("aiGradeTotal", "AI 등급진단 총 사용 수",
-                    "sum(http_server_requests_seconds_count{uri=\"" + AI_GRADE_URI
-                            + "\",method=\"POST\",status=\"200\"})", "회",
+                    "sum(increase(http_server_requests_seconds_count{uri=\"" + AI_GRADE_URI
+                            + "\",method=\"POST\",status=\"200\"}[" + TOTAL_WINDOW + "]))", "회",
                     "오늘 증가", "sum(increase(http_server_requests_seconds_count{uri=\"" + AI_GRADE_URI
                             + "\",method=\"POST\",status=\"200\"}[24h]))"),
             new CardDefinition("tradesConfirmedTotal", "거래 확정 총 건수",
-                    "sum(http_server_requests_seconds_count{uri=\"" + TRADE_CONFIRM_URI
-                            + "\",method=\"PATCH\",status=\"200\"})", "건",
+                    "sum(increase(http_server_requests_seconds_count{uri=\"" + TRADE_CONFIRM_URI
+                            + "\",method=\"PATCH\",status=\"200\"}[" + TOTAL_WINDOW + "]))", "건",
                     "오늘 증가", "sum(increase(http_server_requests_seconds_count{uri=\"" + TRADE_CONFIRM_URI
                             + "\",method=\"PATCH\",status=\"200\"}[24h]))"),
             new CardDefinition("httpErrorRate24h", "HTTP 5xx 에러율(24h)",

--- a/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
@@ -31,7 +31,7 @@ public class AdminMetricsService {
     private static final List<CardDefinition> CARDS = List.of(
             new CardDefinition("totalVisits", "총 방문자 수",
                     "sum(increase(site_visits_total[" + TOTAL_WINDOW + "]))", "명",
-                    "오늘 증가", "increase(site_visits_total[24h])"),
+                    "오늘 증가", "sum(increase(site_visits_total[24h]))"),
             new CardDefinition("aiGradeTotal", "AI 등급진단 총 사용 수",
                     "sum(increase(http_server_requests_seconds_count{uri=\"" + AI_GRADE_URI
                             + "\",method=\"POST\",status=\"200\"}[" + TOTAL_WINDOW + "]))", "회",
@@ -52,7 +52,7 @@ public class AdminMetricsService {
 
     // group이 같으면 스케일이 맞아 한 차트에 겹쳐 그릴 수 있다(FE가 구분); %1$s는 period.step으로 채워져 increase() 구간을 조회 단위에 맞춘다.
     private static final List<SeriesDefinition> SERIES = List.of(
-            new SeriesDefinition("visits", "방문 수", "increase(site_visits_total[%1$s])", "회", "activity"),
+            new SeriesDefinition("visits", "방문 수", "sum(increase(site_visits_total[%1$s]))", "회", "activity"),
             new SeriesDefinition("aiGrade", "AI 진단 사용 수",
                     "sum(increase(http_server_requests_seconds_count{uri=\"" + AI_GRADE_URI
                             + "\",method=\"POST\",status=\"200\"}[%1$s]))", "회", "activity"),

--- a/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/metrics/service/AdminMetricsService.java
@@ -23,16 +23,8 @@ public class AdminMetricsService {
     static final String AI_GRADE_URI = "/api/ai/grade";
     static final String TRADE_CONFIRM_URI = "/api/trades/{id}/confirm";
 
-    // 블루-그린 배포 때마다(=BE 프로세스 재시작 때마다) 카운터 원값이 0으로 리셋되는 문제(사용자 리포트) -
-    // Micrometer 카운터 자체는 JVM 인메모리라 재시작을 못 버티지만, Prometheus가 스크랩해 쌓아둔 시계열은
-    // 재시작과 무관하게 남아있다. increase(...)는 구간 안의 카운터 리셋을 자동으로 감지해 보정하므로,
-    // 원시값을 그대로 읽는 대신 TOTAL_WINDOW 구간의 increase 합을 "누적 총합"으로 취급하면 재시작에도
-    // 끊기지 않는다. 또한 sum()으로 묶어야 blue/green 두 슬롯(app-a/app-b)이 서로 다른 instance 라벨의
-    // 별도 시계열로 잡히는 것도 하나로 합쳐진다(PrometheusApiClient.firstResult()의 "항상 sum(...)으로
-    // 하나로 합쳐서 쿼리한다"는 전제와도 일치 - 이 세 카드만 그 전제를 어기고 원시값을 쓰고 있었다).
-    // TOTAL_WINDOW는 Prometheus 보존 기간(docker-compose.observability*.yml의
-    // --storage.tsdb.retention.time)과 맞춰뒀다 - 그보다 길게 잡아도 의미가 없다(그 이전 데이터가 이미
-    // 삭제됨). 보존 기간을 늘리면 이 상수도 함께 늘려야 한다.
+    // increase()는 카운터 리셋(BE 재시작)을 자동 보정해줘서 원시값과 달리 재시작에도 안 끊긴다.
+    // Prometheus 보존 기간(docker-compose.observability*.yml)과 맞춰뒀으니 같이 바꿀 것.
     private static final String TOTAL_WINDOW = "90d";
 
     // 새 지표는 (필요 시 계측 후) 이 리스트에 한 줄만 추가하면 되고, 이미 자동 계측되는 지표는 uri 필터링만으로 추가 가능하다.

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/MyTradeResponse.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.trade.dto;
 
 import com.pokade.domain.card.entity.Card;
+import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
 
@@ -11,7 +12,11 @@ public record MyTradeResponse(
         Long listingId,
         Long cardId,
         String cardName,
+        // 한글 매핑이 없으면 null(어설픈 오번역보다 안전하다는 팀 컨벤션, domain.ai/domain.portfolio와 동일).
+        // 표시할 땐 cardNameKo ?? cardName.
+        String cardNameKo,
         String cardImageUrl,
+        ListingGrade grade,
         Integer price,
         TradeStatus status,
         TradeRole role,
@@ -20,14 +25,16 @@ public record MyTradeResponse(
         LocalDateTime completedAt
 ) {
 
-    public static MyTradeResponse of(Trade trade, Long userId, Card card) {
+    public static MyTradeResponse of(Trade trade, Long userId, Card card, String cardNameKo) {
         boolean isBuyer = trade.getBuyerId().equals(userId);
         return new MyTradeResponse(
                 trade.getId(),
                 trade.getListing().getId(),
                 trade.getListing().getCardId(),
                 card == null ? null : card.getName(),
+                card == null ? null : cardNameKo,
                 card == null ? null : card.getImageSmall(),
+                trade.getListing().getGrade(),
                 trade.getPrice(),
                 trade.getStatus(),
                 isBuyer ? TradeRole.BUY : TradeRole.SELL,

--- a/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/dto/TradeResponse.java
@@ -1,5 +1,6 @@
 package com.pokade.domain.trade.dto;
 
+import com.pokade.domain.listing.entity.ListingGrade;
 import com.pokade.domain.trade.entity.Trade;
 import com.pokade.domain.trade.entity.TradeStatus;
 
@@ -12,7 +13,11 @@ public record TradeResponse(
         Long sellerId,
         Long cardId,
         String cardName,
+        // 한글 매핑이 없으면 null(어설픈 오번역보다 안전하다는 팀 컨벤션, domain.ai/domain.portfolio와 동일).
+        // 표시할 땐 cardNameKo ?? cardName.
+        String cardNameKo,
         String cardImageUrl,
+        ListingGrade grade,
         Integer price,
         TradeStatus status,
         LocalDateTime shippedAt,
@@ -27,7 +32,8 @@ public record TradeResponse(
         Integer pointsUsed
 ) {
 
-    public static TradeResponse of(Trade trade, String cardName, String cardImageUrl, Integer pointsUsed) {
+    public static TradeResponse of(
+            Trade trade, String cardName, String cardNameKo, String cardImageUrl, Integer pointsUsed) {
         return new TradeResponse(
                 trade.getId(),
                 trade.getListing().getId(),
@@ -35,7 +41,9 @@ public record TradeResponse(
                 trade.getListing().getSellerId(),
                 trade.getListing().getCardId(),
                 cardName,
+                cardNameKo,
                 cardImageUrl,
+                trade.getListing().getGrade(),
                 trade.getPrice(),
                 trade.getStatus(),
                 trade.getShippedAt(),

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -2,6 +2,7 @@ package com.pokade.domain.trade.service;
 
 import com.pokade.domain.card.entity.Card;
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.repository.ListingRepository;
 import com.pokade.domain.point.client.TossPaymentClient;
@@ -55,6 +56,7 @@ public class TradeService {
     private final TradeRepository tradeRepository;
     private final PaymentRepository paymentRepository;
     private final CardRepository cardRepository;
+    private final CardNameKoResolver cardNameKoResolver;
     private final UserAccessChecker userAccessChecker;
     private final UserRepository userRepository;
     private final TradeOrderRepository tradeOrderRepository;
@@ -72,6 +74,7 @@ public class TradeService {
         return TradeResponse.of(
                 trade,
                 card != null ? card.getName() : null,
+                card != null ? cardNameKoResolver.resolve(card) : null,
                 card != null ? card.getImageSmall() : null,
                 pointsUsed);
     }
@@ -331,8 +334,11 @@ public class TradeService {
         Map<Long, Card> cards = cardRepository.findAllById(cardIds).stream()
                 .collect(Collectors.toMap(Card::getId, Function.identity()));
 
-        return trades.map(trade ->
-                MyTradeResponse.of(trade, userId, cards.get(trade.getListing().getCardId())));
+        return trades.map(trade -> {
+            Card card = cards.get(trade.getListing().getCardId());
+            String cardNameKo = card != null ? cardNameKoResolver.resolve(card) : null;
+            return MyTradeResponse.of(trade, userId, card, cardNameKo);
+        });
     }
 
     @Transactional

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
@@ -82,7 +82,7 @@ class AdminTradeControllerTest {
 
     private TradeResponse tradeResponseOf(Long id, TradeStatus status) {
         return new TradeResponse(
-                id, 10L, 200L, 100L, 1L, "리자몽 ex", null, 10000, status,
+                id, 10L, 200L, 100L, 1L, "리자몽 ex", null, null, null, 10000, status,
                 LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now(), null);
     }
 

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1139,7 +1139,7 @@ class PriceServiceTest {
         given(buyOfferRepository.findById(7L)).willReturn(java.util.Optional.of(buyOffer));
         given(listingRepository.save(any(Listing.class))).willAnswer(invocation -> invocation.getArgument(0));
         TradeResponse expected = new TradeResponse(
-                100L, null, 2L, 1L, 1L, "리자몽", null, 250000, TradeStatus.PENDING,
+                100L, null, 2L, 1L, 1L, "리자몽", null, null, null, 250000, TradeStatus.PENDING,
                 null, null, null, null, null,
                 "김철수", "010-1234-5678", "서울시 강남구", java.time.LocalDateTime.now(), null);
         given(tradeService.createMatchedTrade(

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/MyTradeControllerTest.java
@@ -78,7 +78,7 @@ class MyTradeControllerTest {
 
     private MyTradeResponse sampleResponse() {
         return new MyTradeResponse(
-                10L, 20L, 30L, "리자몽", "https://img/small.png",
+                10L, 20L, 30L, "리자몽", null, "https://img/small.png", null,
                 50000, TradeStatus.COMPLETED, TradeRole.BUY, 99L,
                 LocalDateTime.of(2026, 5, 10, 12, 0),
                 LocalDateTime.of(2026, 5, 12, 9, 0));

--- a/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/controller/TradeControllerTest.java
@@ -146,7 +146,7 @@ class TradeControllerTest {
     void 결제승인에_성공하면_200과_생성된_거래를_반환한다() throws Exception {
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest("pay_123", "order-1", 10000L);
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, "pay_123", "order-1", 10000L))
@@ -181,7 +181,7 @@ class TradeControllerTest {
         // paymentKey 없이도 요청 자체는 컨트롤러를 통과하는지만 확인한다.
         TradePaymentConfirmRequest request = new TradePaymentConfirmRequest(null, "order-1", 0L);
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.confirmPurchase(200L, null, "order-1", 0L)).willReturn(response);
@@ -212,7 +212,7 @@ class TradeControllerTest {
     @Test
     void 본인_거래를_조회하면_200과_거래정보를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.PENDING,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.PENDING,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.getTrade(200L, 1L)).willReturn(response);
@@ -254,7 +254,7 @@ class TradeControllerTest {
         LocalDateTime deliveredAt = LocalDateTime.now().minusDays(1);
         LocalDateTime confirmedAt = LocalDateTime.now();
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.COMPLETED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.COMPLETED,
                 shippedAt, inspectedAt, deliveredAt, confirmedAt, confirmedAt, null, null, null, confirmedAt, null);
 
         given(tradeService.confirmTrade(200L, 1L)).willReturn(response);
@@ -304,7 +304,7 @@ class TradeControllerTest {
     @Test
     void 구매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.CANCELLED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.CANCELLED,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(200L, 1L)).willReturn(response);
@@ -318,7 +318,7 @@ class TradeControllerTest {
     @Test
     void 판매자가_취소하면_200과_CANCELLED_상태를_반환한다() throws Exception {
         TradeResponse response = new TradeResponse(
-                1L, 1L, 200L, 100L, 1L, "테스트카드", null, 10000, TradeStatus.CANCELLED,
+                1L, 1L, 200L, 100L, 1L, "테스트카드", null, null, null, 10000, TradeStatus.CANCELLED,
                 null, null, null, null, null, null, null, null, LocalDateTime.now(), null);
 
         given(tradeService.cancelTrade(100L, 1L)).willReturn(response);

--- a/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/trade/service/TradeServiceTest.java
@@ -1,6 +1,7 @@
 package com.pokade.domain.trade.service;
 
 import com.pokade.domain.card.repository.CardRepository;
+import com.pokade.domain.card.support.CardNameKoResolver;
 import com.pokade.domain.listing.entity.Listing;
 import com.pokade.domain.listing.entity.ListingStatus;
 import com.pokade.domain.listing.repository.ListingRepository;
@@ -63,6 +64,9 @@ class TradeServiceTest {
 
     @Mock
     private CardRepository cardRepository;
+
+    @Mock
+    private CardNameKoResolver cardNameKoResolver;
 
     @Mock
     private UserAccessChecker userAccessChecker;


### PR DESCRIPTION
## 📌 관련 이슈
- #450

## ✨ 작업 내용

**1. 거래 내역/상세에 카드 한글명·등급 표시 (#450)**
- `TradeResponse`/`MyTradeResponse`에 `cardNameKo`(도감/AI진단에서 쓰던 `CardNameKoResolver` 재사용), `grade`(`listing.getGrade()`, 신규 쿼리 없음) 추가
- 마이페이지 거래 내역·거래 상세 화면에서 카드 이름이 영문으로만 보이고 등급이 아예 안 보이던 문제 해결

**2. 어드민 대시보드 누적 카드가 BE 재시작마다 초기화되는 문제 수정**
- "총 방문자 수"/"AI 등급진단 총 사용 수"/"거래 확정 총 건수" 카드가 Micrometer 카운터 원시값을 그대로 읽고 있어서, 블루-그린 배포로 BE가 재시작될 때마다(=매 배포마다) 0에 가깝게 리셋된 것처럼 보이던 문제
- `sum(increase(지표[90d]))`로 변경 — Prometheus의 `increase()`가 구간 안 카운터 리셋을 자동 보정해줘서 재시작을 겪어도 끊기지 않는 누적치가 됨. `sum()`은 블루/그린 두 슬롯이 서로 다른 시계열로 잡히는 문제도 함께 해결
- 90일 구간이 의미 있으려면 Prometheus 보존 기간도 그만큼 필요해서, observability compose 파일 두 개(`local`/`prod`) 모두 `--storage.tsdb.retention.time=90d` 명시(기본 15d)
- **운영 Prometheus에는 이미 적용 완료**(컨테이너 재기동, 기존 이력 볼륨 그대로 유지되는 것 확인)

## 📸 스크린샷 / 테스트 결과

- `./gradlew test` 전체 통과(신규/기존 케이스 포함), 기존에 문서화된 known-fail(Testcontainers 미사용 2건, `TradeRepositoryTest` 4건)만 남아있고 이번 변경과 무관함을 확인
- 로컬 서버 재기동 후 curl로 실제 확인: 거래 응답에 `cardNameKo`/`grade` 정상 반영
- 운영 Prometheus에 `sum(increase(site_visits_total[90d]))` 직접 쿼리해서 컨테이너 재기동 전후로 과거 데이터가 그대로 이어지는 것 확인

## 🔍 리뷰 포인트

- `domain.trade`는 원 담당자 도메인이지만 이번 수정은 팀 확인 하에 진행했습니다
- `AdminMetricsService.TOTAL_WINDOW`(90d)와 Prometheus `--storage.tsdb.retention.time`(90d)이 서로 맞물려 있는 값이라, 나중에 보존 기간을 바꾸면 이 상수도 같이 바꿔야 합니다(코드 주석에 남겨둠)
- 운영 Prometheus 재기동은 이번 PR과 별도로 이미 수동 적용해뒀습니다 — 머지 후 별도 인프라 작업 불필요

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?