### PR TITLE
fix: nginx reload를 systemctl 대신 신호 기반으로 변경, ssh-action pty 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,10 +62,6 @@ jobs:
           # GHCR 로그인·이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
           # nginx 설정을 건드리지 않은 채로 배포만 실패한다(기본값 false라 명시 필요).
           script_stop: true
-          # pty 없이 exec만 하면 sudo systemctl reload가 PAM/D-Bus 경로에서 종료
-          # 상태를 잘못 보고해 배포가 매번 실패했다 — pty를 할당해 표준 로그인
-          # 세션과 동일한 경로를 타게 한다.
-          request_pty: true
           script: |
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
@@ -115,7 +111,12 @@ jobs:
 
             echo "upstream pokade_upstream { server 127.0.0.1:${APP_PORT}; }" | sudo tee /etc/nginx/conf.d/pokade_upstream.conf > /dev/null
             sudo nginx -t
-            sudo systemctl reload nginx
+            # systemctl reload는 PAM/D-Bus를 거쳐 pty가 없으면 종료 상태를 잘못
+            # 보고하고, pty를 켜면 그 pty를 docker login --password-stdin과 같은
+            # stdin 소비 명령이 같이 써서 세션이 조기 종료되는 문제가 있었다.
+            # 신호 기반 reload는 systemd/D-Bus/PAM을 아예 안 거치므로 pty 자체가
+            # 필요 없다 — docs/troubleshooting/decisions/ssh-action-systemctl-reload-exit-status.md
+            sudo nginx -s reload
 
             if [ -n "$CURRENT_SLOT" ]; then
               docker rm -f "pokade-app-$CURRENT_SLOT" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- 오늘(8/26) 배포가 두 번 실패 — `request_pty: true` 적용 이후 `docker login` 직후 세션이 간헐적으로 조기 종료돼 스크립트 나머지(pull/blue-green/healthcheck/reload)가 전혀 실행되지 않는 증상 확인
- pty가 필요했던 이유(`systemctl reload`의 PAM/D-Bus 경로 종료상태 오보고)를 근본적으로 제거하기 위해 `sudo nginx -s reload`(신호 기반)로 교체, `request_pty: true` 제거
- EC2 sudoers(`/etc/sudoers.d/pokade-deploy`)도 `nginx -s reload` 허용으로 사전 변경 완료 (머지 전 필수 선행 조건)

## Test plan
- [ ] 머지 후 배포 워크플로우가 nginx reload 단계까지 정상 통과하는지 확인
- [ ] `/actuator/health` UP 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 배포 과정에서 웹 서버 설정을 보다 안정적으로 다시 적용하도록 개선했습니다.
  - 불필요한 중간 처리 단계를 줄여 배포 후 서비스 반영이 더욱 원활해졌습니다.
  - 배포 중 웹 서비스의 설정 반영 과정이 간소화되어 운영 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->