### PR TITLE
[Fix] 배포 스크립트의 백업 이미지 태깅이 set -e 때문에 매 배포마다 실패하던 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,10 +72,12 @@ jobs:
             IMAGE_BASE="${IMAGE%:latest}"
 
             # 롤백용 백업 2세대 유지: backup-1(직전) -> backup-2(그 이전), 3세대는 자동 dangling 처리되어 prune된다.
+            # script_stop(set -e) 아래에서 "cmd1 && cmd2"는 cmd1만 실패해도(=백업이 아직 없어도) 전체
+            # 스크립트가 죽는다 - 태그가 없는 첫 배포마다 여기서 계속 실패했다. || true로 무해화.
             docker image inspect "$IMAGE_BASE:backup-1" >/dev/null 2>&1 && \
-              docker tag "$IMAGE_BASE:backup-1" "$IMAGE_BASE:backup-2"
+              docker tag "$IMAGE_BASE:backup-1" "$IMAGE_BASE:backup-2" || true
             docker image inspect "$IMAGE" >/dev/null 2>&1 && \
-              docker tag "$IMAGE" "$IMAGE_BASE:backup-1"
+              docker tag "$IMAGE" "$IMAGE_BASE:backup-1" || true
 
             docker pull "$IMAGE"
 


### PR DESCRIPTION
## ✨ 작업 내용

`deploy.yml`에 백업 이미지 태깅(backup-1/backup-2) 로직이 추가된 이후, 배포가
`docker login` 직후 단계에서 계속 실패하고 있었습니다.

- 원인: `script_stop: true`(=`set -e`)가 걸린 상태에서 `docker image inspect ... && docker tag ...`
  형태의 문장은, `inspect`가 실패하면(=아직 `backup-1` 태그가 없으면) 그 실패가 문장 전체의
  종료 코드가 되어 스크립트가 그 자리에서 즉시 중단됩니다
- `backup-1`은 이 로직의 두 번째 줄(`$IMAGE`를 `backup-1`로 태깅)에서만 만들어지는데, 그 줄에
  도달하기도 전에 첫 번째 줄("`backup-1`이 있나?" 체크)에서 매번 죽어서, 이 구조로는
  `backup-1`이 영원히 생성될 수 없는 상태였습니다
- 실제로 운영 EC2에 `pokade-backend:latest` 태그만 있고 `backup-1`/`backup-2`는 존재하지
  않는 것을 확인해, 이 로직이 추가된 뒤로 배포가 한 번도 성공하지 못했음을 확인했습니다
- 각 줄 끝에 `|| true`를 붙여 무해화 — 같은 스크립트에 이미 쓰이던
  `docker rm -f ... 2>/dev/null || true`와 동일한 패턴

## 📸 스크린샷 / 테스트 결과

- YAML 문법 검증(`yaml.safe_load`) 통과
- 실패했던 실제 GitHub Actions 로그(`docker login` 이후 다른 출력 없이 바로 `Process exited with status 1`)와, 원인으로 지목한 `&&` 체인 위치가 정확히 일치하는 것을 로그로 확인
- 운영 EC2에 `backup-1`/`backup-2` 태그가 실제로 없는 것을 `docker images`로 직접 확인해 근거로 삼음

## 🔍 리뷰 포인트

- 지금 이 문제 때문에 **어떤 브랜치가 머지돼도 배포 자체가 실패**하는 상태라, 급하게 별도로 분리해서 올렸습니다 — 우선 리뷰 부탁드립니다
- `deploy.yml`을 최근에 수정하신 분(changmin41)이 계셔서, 백업 2세대 유지 의도 자체는 그대로 살리고 `set -e` 함정만 제거하는 방향으로 최소한으로 고쳤습니다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가? (YAML 문법 검증으로 대체 — 실제 배포 트리거는 CI에서만 가능)
- [x] 불필요한 주석이나 console.log를 제거했는가?
- [ ] 관련 문서를 함께 수정했는가?