### PR TITLE
debug: ssh-action에 임시 debug 로그 추가 - 세션 조기 종료 원인 파악용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,10 @@ jobs:
           # GHCR 로그인·이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
           # nginx 설정을 건드리지 않은 채로 배포만 실패한다(기본값 false라 명시 필요).
           script_stop: true
+          # 임시 디버깅용 - docker login 직후 SSH 세션이 원인 불명으로 조기 종료되는
+          # 문제의 실제 원인(타임아웃/keepalive/네트워크 리셋 등)을 SSH 클라이언트
+          # 레벨 로그로 확인하기 위함. 원인 파악되면 제거할 것.
+          debug: true
           script: |
             echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest


### PR DESCRIPTION
## Summary
- `docker login` 직후 SSH 세션이 원인 불명으로 조기 종료되는 문제가 반복됨 (PR #453로 pty 제거해도 재발)
- EC2 `auth.log` 확인 결과 세션이 열린 지 1.9초 만에 `Connection closed by <GH runner IP>` — 정상적인 SSH 프로토콜 disconnect 메시지(`Received disconnect`) 없이 끊김. 네트워크 레벨 문제로 추정
- `appleboy/ssh-action`의 `debug: true`를 임시로 켜서 SSH 클라이언트 레벨 로그(타임아웃/keepalive/네트워크 에러 등)로 실제 원인을 확인하려 함
- **임시 디버깅용 변경입니다. 원인 파악되면 제거할 예정.**

## Test plan
- [ ] 머지 후 배포 워크플로우 실행 → 실패 시 debug 로그에서 SSH 세션 종료 원인 확인
- [ ] 원인 파악 후 debug: true 제거하는 후속 PR