### PR TITLE
fix: 배포 스크립트에서 매번 하던 GHCR 재로그인 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,15 +59,20 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_KEY }}
           envs: OPENAI_API_KEY
-          # GHCR 로그인·이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
+          # 이미지 pull·헬스체크가 실패하면 즉시 중단 — 기존 컨테이너와
           # nginx 설정을 건드리지 않은 채로 배포만 실패한다(기본값 false라 명시 필요).
           script_stop: true
-          # 임시 디버깅용 - docker login 직후 SSH 세션이 원인 불명으로 조기 종료되는
-          # 문제의 실제 원인(타임아웃/keepalive/네트워크 리셋 등)을 SSH 클라이언트
-          # 레벨 로그로 확인하기 위함. 원인 파악되면 제거할 것.
+          # 임시 디버깅용 - 배포 스크립트 시작 직후 SSH 세션이 원인 불명으로
+          # 조기 종료되는 문제의 실제 원인(타임아웃/keepalive/네트워크 리셋 등)을
+          # SSH 클라이언트 레벨 로그로 확인하기 위함. 원인 파악되면 제거할 것.
           debug: true
           script: |
-            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            # GHCR 로그인은 매 배포마다 하지 않는다 — docker login은 자격증명을
+            # ~/.docker/config.json에 영구 저장하므로 EC2가 한 번만 로그인해두면
+            # 이후 pull엔 재로그인이 불필요하다. 매번 반복하면 SSH exec로 매번
+            # 전송되는 스크립트에 시크릿 처리 줄이 하나 더 늘어날 뿐이라 제거함.
+            # GHCR_PAT가 회전되면 EC2에서 수동으로 한 번만 다시 로그인해야 한다:
+            #   echo "$GHCR_PAT" | docker login ghcr.io -u <user> --password-stdin
             IMAGE=ghcr.io/${{ github.repository_owner }}/pokade-backend:latest
             IMAGE_BASE="${IMAGE%:latest}"
 


### PR DESCRIPTION
## Summary
- 배포 스크립트가 SSH 세션 시작 직후(첫 줄) 원인 불명으로 조기 종료되는 문제가 계속 재발 중 (pty 제거 후에도 재현)
- `docker login`은 자격증명을 EC2의 `~/.docker/config.json`에 영구 저장하므로, 한 번만 로그인해두면 이후 `docker pull`엔 재로그인이 불필요함 — 실제로 EC2에서 수동 `docker pull` 테스트 시 이미 이 방식으로 정상 동작 확인함
- 매 배포마다 반복할 이유가 없고, SSH exec로 매번 전송되는 스크립트에서 시크릿을 다루는 가장 앞쪽 줄이라 원인 후보를 줄이는 차원에서도 제거
- EC2는 이미 로그인된 상태라 이번 PR만으로 추가 조치 불필요. GHCR_PAT가 회전되면 EC2에서 수동으로 한 번만 재로그인 필요 (스크립트 주석에 명령어 남김)

## Test plan
- [ ] 머지 후 배포 워크플로우 실행 → 세션 조기 종료 재현 여부 확인