### PR TITLE
[Feature] #460 구매입찰 결제 취소(환불) API 추가 

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/price/controller/BuyOfferController.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/controller/BuyOfferController.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -106,6 +107,18 @@ public class BuyOfferController {
             @PathVariable Long buyOfferId
     ) {
         return ApiResponse.ok(priceService.getMyBuyOffer(buyOfferId, buyerId));
+    }
+
+    @Operation(
+            summary = "구매입찰 결제 취소",
+            description = "결제 완료(ACTIVE)된 구매입찰을 취소합니다. 토스 에스크로 결제취소 및/또는 포인트 환불을 처리합니다."
+    )
+    @DeleteMapping("/{buyOfferId}")
+    public ApiResponse<MyBuyOfferResponse> cancel(
+            @AuthenticationPrincipal Long buyerId,
+            @PathVariable Long buyOfferId
+    ) {
+        return ApiResponse.ok("구매입찰이 취소되었습니다.", priceService.cancelBuyOffer(buyOfferId, buyerId));
     }
 
     @Operation(

--- a/Pokade/src/main/java/com/pokade/domain/price/entity/BuyOffer.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/entity/BuyOffer.java
@@ -141,4 +141,14 @@ public class BuyOffer {
         this.recipientPhone = recipientPhone;
         this.recipientAddress = recipientAddress;
     }
+
+    // 취소(환불) - ACTIVE가 아니면(이미 체결/취소) 거부한다. markMatched()/updateRecipient()와 달리
+    // 만료 여부는 확인하지 않는다 - 만료 자체는 자동 환불을 트리거하지 않으므로(별도 배치 없음),
+    // 유일한 환불 경로인 취소를 만료됐다는 이유로 막으면 그 돈을 영영 못 돌려받는다.
+    public void cancel() {
+        if (!"ACTIVE".equals(this.status)) {
+            throw new BusinessException(ErrorCode.BUY_OFFER_ALREADY_MATCHED);
+        }
+        this.status = "CANCELLED";
+    }
 }

--- a/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
+++ b/Pokade/src/main/java/com/pokade/domain/price/service/PriceService.java
@@ -446,6 +446,26 @@ public class PriceService {
         return MyBuyOfferResponse.of(buyOffer, card, cardNameKo);
     }
 
+    // 마이페이지 "입찰" 주문서에서 결제 취소 - TradeService.cancelTrade()와 동일한 순서(상태 전이 먼저,
+    // 그다음 실제 환불)를 따른다. 토스 에스크로 결제가 있었으면 결제취소, 포인트를 미리 썼으면 환불.
+    // 포인트로 전액 충당한 경우 tossPaymentKey가 없어 토스 호출 자체를 건너뛴다.
+    @Transactional
+    public MyBuyOfferResponse cancelBuyOffer(Long buyOfferId, Long buyerId) {
+        BuyOffer buyOffer = getOwnedBuyOffer(buyOfferId, buyerId);
+        buyOffer.cancel();
+
+        if (buyOffer.getTossPaymentKey() != null) {
+            tossPaymentClient.cancelPayment(buyOffer.getTossPaymentKey(), "구매입찰 취소");
+        }
+        if (buyOffer.getPointsUsed() != null && buyOffer.getPointsUsed() > 0) {
+            pointService.refund(buyerId, buyOffer.getPointsUsed(), null);
+        }
+
+        Card card = cardRepository.findById(buyOffer.getCardId()).orElse(null);
+        String cardNameKo = card != null ? cardNameKoResolver.resolve(card) : null;
+        return MyBuyOfferResponse.of(buyOffer, card, cardNameKo);
+    }
+
     private BuyOffer getOwnedBuyOffer(Long buyOfferId, Long buyerId) {
         BuyOffer buyOffer = buyOfferRepository.findById(buyOfferId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.BUY_OFFER_NOT_FOUND));

--- a/Pokade/src/test/java/com/pokade/domain/price/controller/BuyOfferControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/controller/BuyOfferControllerTest.java
@@ -44,6 +44,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -297,6 +298,41 @@ class BuyOfferControllerTest {
                         .with(userId(100L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("BUY_OFFER_ALREADY_MATCHED"));
+    }
+
+    @Test
+    void 구매입찰을_취소하면_200과_취소된_상태를_반환한다() throws Exception {
+        MyBuyOfferResponse response = new MyBuyOfferResponse(
+                5L, 1L, "리자몽", null, "img-1", 10L, 250000, ListingGrade.S, "CANCELLED", 3000, 0,
+                "홍길동", "010-9999-8888", "서울시 서초구", LocalDateTime.now());
+        given(priceService.cancelBuyOffer(5L, 100L)).willReturn(response);
+
+        mockMvc.perform(delete("/api/buy-offers/5")
+                        .with(userId(100L)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("CANCELLED"));
+    }
+
+    @Test
+    void 본인이_아니면_취소시_403을_반환한다() throws Exception {
+        given(priceService.cancelBuyOffer(5L, 200L))
+                .willThrow(new BusinessException(ErrorCode.ACCESS_DENIED));
+
+        mockMvc.perform(delete("/api/buy-offers/5")
+                        .with(userId(200L)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("ACCESS_DENIED"));
+    }
+
+    @Test
+    void 이미_체결된_구매입찰을_취소하면_409를_반환한다() throws Exception {
+        given(priceService.cancelBuyOffer(5L, 100L))
+                .willThrow(new BusinessException(ErrorCode.BUY_OFFER_ALREADY_MATCHED));
+
+        mockMvc.perform(delete("/api/buy-offers/5")
+                        .with(userId(100L)))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value("BUY_OFFER_ALREADY_MATCHED"));
     }

--- a/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/price/service/PriceServiceTest.java
@@ -1438,4 +1438,46 @@ class PriceServiceTest {
         // 판매자에게 잘못된 값이 알림 문구로 나간다.
         assertThat(event.price()).isEqualTo(250000);
     }
+
+    @Test
+    @DisplayName("t70 ACTIVE 상태면 취소 시 토스 결제취소와 포인트 환불을 모두 처리한다")
+    void t70() {
+        BuyOffer buyOffer = activeBuyOfferOf(7L, 1L);
+        given(buyOfferRepository.findById(7L)).willReturn(java.util.Optional.of(buyOffer));
+        given(cardRepository.findById(1L)).willReturn(java.util.Optional.of(Card.builder().id(1L).name("리자몽").build()));
+
+        MyBuyOfferResponse response = priceService.cancelBuyOffer(7L, 1L);
+
+        assertThat(response.status()).isEqualTo("CANCELLED");
+        assertThat(buyOffer.getStatus()).isEqualTo("CANCELLED");
+        verify(tossPaymentClient).cancelPayment("pay_999", "구매입찰 취소");
+        verify(pointService).refund(1L, 1000, null);
+    }
+
+    @Test
+    @DisplayName("t71 본인이 아니면 취소 시 ACCESS_DENIED 예외가 발생한다")
+    void t71() {
+        BuyOffer buyOffer = activeBuyOfferOf(7L, 1L);
+        given(buyOfferRepository.findById(7L)).willReturn(java.util.Optional.of(buyOffer));
+
+        assertThatThrownBy(() -> priceService.cancelBuyOffer(7L, 2L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ACCESS_DENIED);
+        verifyNoInteractions(tossPaymentClient, pointService);
+    }
+
+    @Test
+    @DisplayName("t72 이미 체결된 구매입찰을 취소하면 BUY_OFFER_ALREADY_MATCHED 예외가 발생하고 환불도 일어나지 않는다")
+    void t72() {
+        BuyOffer buyOffer = activeBuyOfferOf(7L, 1L);
+        buyOffer.markMatched();
+        given(buyOfferRepository.findById(7L)).willReturn(java.util.Optional.of(buyOffer));
+
+        assertThatThrownBy(() -> priceService.cancelBuyOffer(7L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.BUY_OFFER_ALREADY_MATCHED);
+        verifyNoInteractions(tossPaymentClient, pointService);
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- #460

## ✨ 작업 내용

- `BuyOffer.cancel()` — ACTIVE가 아니면 거부. `markMatched()`/`updateRecipient()`와 달리 만료 여부는 확인하지 않습니다 — 만료 자체는 자동 환불을 트리거하지 않으므로(별도 배치 없음), 유일한 환불 경로인 취소를 만료로 막으면 그 돈을 영영 못 돌려받습니다
- `PriceService.cancelBuyOffer(buyOfferId, buyerId)` — 본인 확인 → 상태 전이 → 토스 결제취소(있으면) → 포인트 환불(있으면)
- `DELETE /api/buy-offers/{buyOfferId}` 신규

## 📸 스크린샷 / 테스트 결과

- `PriceServiceTest` 3건(정상 취소+환불 검증, 비소유자 403, 이미 체결 409), `BuyOfferControllerTest` 3건 추가
- `./gradlew test --tests "com.pokade.domain.price.*"` 전체 통과

## 🔍 리뷰 포인트

- 만료(`expiresAt`) 여부를 취소 가드에서 의도적으로 체크하지 않은 부분 — 위 설명대로 "환불받을 유일한 경로를 막으면 안 된다"는 판단인데, 다른 의견 있으면 말씀해주세요
- 기존 `BUY_OFFER_ALREADY_MATCHED` 에러코드를 "이미 체결/취소된 입찰"까지 재사용했습니다(`updateRecipient()`가 이미 같은 방식으로 재사용 중이라 일관성 유지)

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?