### PR TITLE
[Feature] #466 관리자 거래 관리 API에 닉네임 및 상세 조회 추가

### DIFF
--- a/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminTradeController.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/controller/AdminTradeController.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.admin.controller;
 
+import com.pokade.domain.admin.dto.response.AdminTradeResponse;
+import com.pokade.domain.admin.service.AdminTradeService;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.service.TradeService;
 import com.pokade.global.response.ApiResponse;
@@ -22,14 +24,21 @@ import java.util.List;
 public class AdminTradeController {
 
     private final TradeService tradeService;
+    private final AdminTradeService adminTradeService;
 
     @Operation(
             summary = "검수/배송 대기 거래 목록 조회",
             description = "발송됨(SHIPPED_TO_PLATFORM, 검수 대기)·검수됨(INSPECTED, 배송 대기) 거래를 접수순으로 조회합니다."
     )
     @GetMapping
-    public ApiResponse<List<TradeResponse>> getPendingTrades() {
-        return ApiResponse.ok(tradeService.getPendingTrades());
+    public ApiResponse<List<AdminTradeResponse>> getPendingTrades() {
+        return ApiResponse.ok(adminTradeService.getPendingTrades());
+    }
+
+    @Operation(summary = "거래 상세 조회", description = "거래 번호로 거래 상세(현재 진행 상황)를 조회합니다.")
+    @GetMapping("/{id}")
+    public ApiResponse<AdminTradeResponse> getTrade(@Parameter(description = "거래 ID") @PathVariable Long id) {
+        return ApiResponse.ok(adminTradeService.getTrade(id));
     }
 
     @Operation(summary = "검수 완료 처리", description = "발송된 거래를 검수 완료 처리합니다 (SHIPPED_TO_PLATFORM → INSPECTED).")

--- a/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminTradeResponse.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/dto/response/AdminTradeResponse.java
@@ -1,0 +1,65 @@
+package com.pokade.domain.admin.dto.response;
+
+import com.pokade.domain.listing.entity.ListingGrade;
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.domain.trade.entity.TradeStatus;
+
+import java.time.LocalDateTime;
+
+// 관리자 거래 관리 화면 전용 - TradeResponse에 판매자/구매자 닉네임을 더한 것.
+// 일반 사용자용 MyTradeResponse.counterpartyId는 상대방 닉네임을 의도적으로 안 내려주는 기존 결정이 있어,
+// TradeResponse 자체를 바꾸지 않고 이 관리자 전용 DTO를 새로 둔다(AdminTradeController에서만 쓴다).
+public record AdminTradeResponse(
+        Long id,
+        Long listingId,
+        Long buyerId,
+        String buyerNickname,
+        Long sellerId,
+        String sellerNickname,
+        Long cardId,
+        String cardName,
+        String cardNameKo,
+        String cardImageUrl,
+        ListingGrade grade,
+        Integer price,
+        TradeStatus status,
+        LocalDateTime shippedAt,
+        LocalDateTime inspectedAt,
+        LocalDateTime deliveredAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime settledAt,
+        String recipientName,
+        String recipientPhone,
+        String recipientAddress,
+        LocalDateTime createdAt,
+        Integer pointsUsed
+) {
+
+    public static AdminTradeResponse of(TradeResponse trade, String buyerNickname, String sellerNickname) {
+        return new AdminTradeResponse(
+                trade.id(),
+                trade.listingId(),
+                trade.buyerId(),
+                buyerNickname,
+                trade.sellerId(),
+                sellerNickname,
+                trade.cardId(),
+                trade.cardName(),
+                trade.cardNameKo(),
+                trade.cardImageUrl(),
+                trade.grade(),
+                trade.price(),
+                trade.status(),
+                trade.shippedAt(),
+                trade.inspectedAt(),
+                trade.deliveredAt(),
+                trade.confirmedAt(),
+                trade.settledAt(),
+                trade.recipientName(),
+                trade.recipientPhone(),
+                trade.recipientAddress(),
+                trade.createdAt(),
+                trade.pointsUsed()
+        );
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/admin/service/AdminTradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/admin/service/AdminTradeService.java
@@ -1,0 +1,54 @@
+package com.pokade.domain.admin.service;
+
+import com.pokade.domain.admin.dto.response.AdminTradeResponse;
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+// 관리자 거래 관리 화면 전용 - TradeService의 조회 결과에 판매자/구매자 닉네임을 붙인다.
+// 실제 거래 조회/상태 전이 로직은 그대로 TradeService에 위임하고, 여기서는 닉네임 배치 조회만 담당한다.
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminTradeService {
+
+    private final TradeService tradeService;
+    private final UserRepository userRepository;
+
+    // 검수/배송 대기 목록 - buyer/seller id를 한 번에 모아 배치 조회한다(목록 크기만큼 쿼리가 나가지 않도록).
+    public List<AdminTradeResponse> getPendingTrades() {
+        List<TradeResponse> trades = tradeService.getPendingTrades();
+        Map<Long, String> nicknameByUserId = nicknameByUserId(trades);
+        return trades.stream()
+                .map(trade -> AdminTradeResponse.of(
+                        trade,
+                        nicknameByUserId.get(trade.buyerId()),
+                        nicknameByUserId.get(trade.sellerId())))
+                .toList();
+    }
+
+    public AdminTradeResponse getTrade(Long tradeId) {
+        TradeResponse trade = tradeService.getTradeForAdmin(tradeId);
+        Map<Long, String> nicknameByUserId = nicknameByUserId(List.of(trade));
+        return AdminTradeResponse.of(
+                trade, nicknameByUserId.get(trade.buyerId()), nicknameByUserId.get(trade.sellerId()));
+    }
+
+    private Map<Long, String> nicknameByUserId(List<TradeResponse> trades) {
+        List<Long> userIds = trades.stream()
+                .flatMap(t -> Stream.of(t.buyerId(), t.sellerId()))
+                .distinct()
+                .toList();
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getNickname));
+    }
+}

--- a/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
+++ b/Pokade/src/main/java/com/pokade/domain/trade/service/TradeService.java
@@ -316,6 +316,14 @@ public class TradeService {
         return toResponse(trade);
     }
 
+    // 관리자 페이지에서 호출 — getTrade()와 달리 참여자(구매자/판매자) 확인을 하지 않는다.
+    // 인가(관리자 권한 확인)는 markInspected()/markDelivered()와 동일하게 호출하는 쪽(관리자 도메인)의 책임.
+    public TradeResponse getTradeForAdmin(Long tradeId) {
+        Trade trade = tradeRepository.findById(tradeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TRADE_NOT_FOUND));
+        return toResponse(trade);
+    }
+
     public Page<MyTradeResponse> getMyTrades(Long userId, MyTradeSearchCondition condition, Pageable pageable) {
         Page<Trade> trades = tradeRepository.findMyTrades(
                 userId,

--- a/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/controller/AdminTradeControllerTest.java
@@ -1,5 +1,7 @@
 package com.pokade.domain.admin.controller;
 
+import com.pokade.domain.admin.dto.response.AdminTradeResponse;
+import com.pokade.domain.admin.service.AdminTradeService;
 import com.pokade.domain.trade.dto.TradeResponse;
 import com.pokade.domain.trade.entity.TradeStatus;
 import com.pokade.domain.trade.service.TradeService;
@@ -48,6 +50,9 @@ class AdminTradeControllerTest {
     private TradeService tradeService;
 
     @MockitoBean
+    private AdminTradeService adminTradeService;
+
+    @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
     @MockitoBean
@@ -86,21 +91,54 @@ class AdminTradeControllerTest {
                 LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now(), null);
     }
 
+    private AdminTradeResponse adminTradeResponseOf(Long id, TradeStatus status) {
+        return AdminTradeResponse.of(tradeResponseOf(id, status), "구매자닉네임", "판매자닉네임");
+    }
+
     @Test
     void 검수_배송_대기_목록_조회에_성공하면_200을_반환한다() throws Exception {
-        given(tradeService.getPendingTrades())
-                .willReturn(List.of(tradeResponseOf(1L, TradeStatus.SHIPPED_TO_PLATFORM)));
+        given(adminTradeService.getPendingTrades())
+                .willReturn(List.of(adminTradeResponseOf(1L, TradeStatus.SHIPPED_TO_PLATFORM)));
 
         mockMvc.perform(get("/api/admin/trades").with(admin()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(1))
-                .andExpect(jsonPath("$.data[0].status").value("SHIPPED_TO_PLATFORM"));
+                .andExpect(jsonPath("$.data[0].status").value("SHIPPED_TO_PLATFORM"))
+                .andExpect(jsonPath("$.data[0].buyerNickname").value("구매자닉네임"))
+                .andExpect(jsonPath("$.data[0].sellerNickname").value("판매자닉네임"));
     }
 
     @Test
     void 관리자가_아니면_대기_목록_조회시_403을_반환한다() throws Exception {
         mockMvc.perform(get("/api/admin/trades").with(user()))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 거래_상세_조회에_성공하면_200과_닉네임을_반환한다() throws Exception {
+        given(adminTradeService.getTrade(1L))
+                .willReturn(adminTradeResponseOf(1L, TradeStatus.SHIPPED_TO_PLATFORM));
+
+        mockMvc.perform(get("/api/admin/trades/{id}", 1L).with(admin()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.buyerNickname").value("구매자닉네임"))
+                .andExpect(jsonPath("$.data.sellerNickname").value("판매자닉네임"));
+    }
+
+    @Test
+    void 관리자가_아니면_거래_상세_조회시_403을_반환한다() throws Exception {
+        mockMvc.perform(get("/api/admin/trades/{id}", 1L).with(user()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void 존재하지_않는_거래를_상세조회하면_404를_반환한다() throws Exception {
+        willThrow(new BusinessException(ErrorCode.TRADE_NOT_FOUND))
+                .given(adminTradeService).getTrade(999L);
+
+        mockMvc.perform(get("/api/admin/trades/{id}", 999L).with(admin()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TRADE_NOT_FOUND"));
     }
 
     @Test

--- a/Pokade/src/test/java/com/pokade/domain/admin/service/AdminTradeServiceTest.java
+++ b/Pokade/src/test/java/com/pokade/domain/admin/service/AdminTradeServiceTest.java
@@ -1,0 +1,74 @@
+package com.pokade.domain.admin.service;
+
+import com.pokade.domain.admin.dto.response.AdminTradeResponse;
+import com.pokade.domain.trade.dto.TradeResponse;
+import com.pokade.domain.trade.entity.TradeStatus;
+import com.pokade.domain.trade.service.TradeService;
+import com.pokade.domain.user.entity.User;
+import com.pokade.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AdminTradeServiceTest {
+
+    @Mock
+    private TradeService tradeService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminTradeService adminTradeService;
+
+    private User userOf(Long id, String nickname) {
+        return User.builder().id(id).nickname(nickname).build();
+    }
+
+    private TradeResponse tradeResponseOf(Long id, Long buyerId, Long sellerId) {
+        return new TradeResponse(
+                id, 10L, buyerId, sellerId, 1L, "리자몽 ex", "리자몽", null, null, 10000,
+                TradeStatus.SHIPPED_TO_PLATFORM,
+                LocalDateTime.now(), null, null, null, null, null, null, null, LocalDateTime.now(), null);
+    }
+
+    @Test
+    void 검수_배송_대기_목록_조회시_구매자_판매자_닉네임을_배치_조회해서_채운다() {
+        TradeResponse trade1 = tradeResponseOf(1L, 100L, 200L);
+        TradeResponse trade2 = tradeResponseOf(2L, 100L, 300L);
+        given(tradeService.getPendingTrades()).willReturn(List.of(trade1, trade2));
+        given(userRepository.findAllById(List.of(100L, 200L, 300L))).willReturn(List.of(
+                userOf(100L, "구매자"), userOf(200L, "판매자1"), userOf(300L, "판매자2")));
+
+        List<AdminTradeResponse> result = adminTradeService.getPendingTrades();
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).buyerNickname()).isEqualTo("구매자");
+        assertThat(result.get(0).sellerNickname()).isEqualTo("판매자1");
+        assertThat(result.get(1).buyerNickname()).isEqualTo("구매자");
+        assertThat(result.get(1).sellerNickname()).isEqualTo("판매자2");
+    }
+
+    @Test
+    void 거래_상세_조회시_구매자_판매자_닉네임을_함께_반환한다() {
+        TradeResponse trade = tradeResponseOf(1L, 100L, 200L);
+        given(tradeService.getTradeForAdmin(1L)).willReturn(trade);
+        given(userRepository.findAllById(List.of(100L, 200L))).willReturn(List.of(
+                userOf(100L, "구매자"), userOf(200L, "판매자")));
+
+        AdminTradeResponse result = adminTradeService.getTrade(1L);
+
+        assertThat(result.buyerNickname()).isEqualTo("구매자");
+        assertThat(result.sellerNickname()).isEqualTo("판매자");
+        assertThat(result.cardNameKo()).isEqualTo("리자몽");
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #466

## ✨ 작업 내용

관리자 거래 관리(검수 대기) 화면에서 판매자/구매자가 `#1`, `#3`처럼 ID로만 보이고,
거래 번호를 클릭해도 상세(진행 상황)를 볼 방법이 없던 문제를 해결했습니다.

- `AdminTradeResponse` — 기존 `TradeResponse`에 `buyerNickname`/`sellerNickname`을 더한 관리자 전용 DTO. 일반 사용자용 `MyTradeResponse.counterpartyId`는 닉네임을 의도적으로 안 내려주는 기존 결정이 있어서, `TradeResponse` 자체는 그대로 두고 이 DTO를 새로 만들었습니다
- `TradeService.getTradeForAdmin(tradeId)` — 기존 `getTrade()`는 참여자(구매자/판매자)만 조회 가능해 관리자가 못 씁니다. `markInspected()`/`markDelivered()`와 동일하게 인가(관리자 권한 확인)는 호출하는 쪽(관리자 도메인) 책임으로 뒀습니다
- `AdminTradeService` 신규 — 목록/상세 조회 시 buyer/seller id를 모아 `UserRepository`로 배치 조회해 닉네임을 붙입니다(N+1 방지)
- `GET /api/admin/trades/{id}` 신규 — 상세 모달용
- 카드 한글명(`cardNameKo`)·등급(`grade`)은 이미 `TradeResponse`에 있어 이번 작업에서 추가할 필요가 없었습니다(#450에서 이미 반영, develop에 병합됨)

## 📸 스크린샷 / 테스트 결과

- `AdminTradeServiceTest`(닉네임 배치 조회 검증) 2건, `AdminTradeControllerTest`(상세 조회 200/403/404) 3건 추가
- `./gradlew test --tests "com.pokade.domain.admin.*"`, `--tests "com.pokade.domain.trade.*"` 전체 통과(기존 known-fail 6건 제외)
- 로컬 서버에 검수 대기 더미 거래를 넣고 실제 API 호출로 확인: `buyerNickname`/`sellerNickname`/`cardNameKo`/`grade` 전부 정상 반환

## 🔍 리뷰 포인트

- `domain.trade`는 원 담당자 도메인이지만 이번 수정은 팀 확인 하에 진행했습니다
- `TradeResponse`를 직접 확장하지 않고 `AdminTradeResponse`를 별도로 둔 이유(닉네임 노출 범위를 관리자로 한정)가 맞는 방향인지 확인 부탁드립니다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 준수했는가?
- [x] 로컬에서 빌드 및 테스트가 성공했는가?
- [x] 불필요한 주석이나 console.log를 제거했는가?